### PR TITLE
feat: Lighthouse CI 추가 - SEO 정량 측정 자동화

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,27 @@
+name: Lighthouse CI
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 매주 월요일 오전 9시 (KST = UTC+9) 자동 실행
+    - cron: "0 0 * * 1"
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          urls: |
+            https://fosworld.co.kr
+            https://fosworld.co.kr/categories
+            https://fosworld.co.kr/posts/AI/RAG/embedding.md
+          configPath: ./.lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,22 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 2,
+      "settings": {
+        "preset": "desktop",
+        "throttlingMethod": "provided"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:seo": ["error", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 0.85 }],
+        "categories:best-practices": ["warn", { "minScore": 0.85 }],
+        "categories:performance": ["warn", { "minScore": 0.5 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **매주 월요일** 자동으로 프로덕션 SEO/성능 점수 측정
- **수동 트리거** (`workflow_dispatch`) 지원 — 배포 직후 즉시 측정 가능
- 결과 링크가 Actions 로그에 자동 출력됨

## 측정 대상 URL

- `https://fosworld.co.kr` (홈)
- `https://fosworld.co.kr/categories` (카테고리 목록)
- `https://fosworld.co.kr/posts/AI/RAG/embedding.md` (샘플 포스트)

## 임계값

| 카테고리 | 기준 | 미달 시 |
|---------|------|---------|
| SEO | 90+ | ❌ 빌드 실패 |
| 접근성 | 85+ | ⚠️ 경고 |
| Best Practices | 85+ | ⚠️ 경고 |
| 성능 | 50+ | ⚠️ 경고 |

## 사용법

```bash
# 수동 실행 (배포 후 즉시 측정)
gh workflow run lighthouse.yml
```

또는 GitHub Actions 탭 → Lighthouse CI → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)