### PR TITLE
docs: AGENTS.md 내 잘못된 @/lib/db-queries 참조 수정

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -61,8 +61,7 @@ export async function generateStaticParams() { ... }
 
 ### Internal
 - `@/components/` — UI components (Header, PostCard, CategoryList, etc.)
-- `@/lib/db-queries` — legacy query wrapper (still used in `page.tsx`)
-- `@/db/queries` — preferred Drizzle query class
+- `@/db/queries` — Drizzle query class via `getDbQueries()` factory
 
 ### External
 - `next/font/google` — Inter font loading

--- a/app/api/AGENTS.md
+++ b/app/api/AGENTS.md
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
 ## Dependencies
 
 ### Internal
-- `@/lib/db-queries` — database query functions
+- `@/db/queries` — database query functions via `getDbQueries()`
 - `@/lib/sync-github` — sync orchestration
 
 <!-- MANUAL: -->

--- a/app/api/search/AGENTS.md
+++ b/app/api/search/AGENTS.md
@@ -10,7 +10,7 @@ GET API endpoint for full-text post search. Accepts a query string and returns m
 
 | File | Description |
 |------|-------------|
-| `route.ts` | `GET /api/search?q=<query>&limit=<n>` — delegates to `searchPosts()` in `lib/db-queries` |
+| `route.ts` | `GET /api/search?q=<query>&limit=<n>` — delegates to `searchPosts()` via `getDbQueries()` |
 
 ## For AI Agents
 
@@ -34,6 +34,6 @@ Response 500:
 ## Dependencies
 
 ### Internal
-- `@/lib/db-queries` → `searchPosts(query, limit)`
+- `@/db/queries` → `getDbQueries()` → `searchPosts(query, limit)`
 
 <!-- MANUAL: -->

--- a/app/categories/AGENTS.md
+++ b/app/categories/AGENTS.md
@@ -23,7 +23,7 @@ Static listing page for all post categories. Displays every category as a card g
 ## Dependencies
 
 ### Internal
-- `@/lib/db-queries` → `getCategories()`
+- `@/db/queries` → `getDbQueries()` → `getCategories()`
 - `@/components/CategoryList`
 
 <!-- MANUAL: -->

--- a/app/category/[...path]/AGENTS.md
+++ b/app/category/[...path]/AGENTS.md
@@ -35,7 +35,7 @@ params.path (string[])
 ## Dependencies
 
 ### Internal
-- `@/lib/db-queries` → `getFolderContents()`, `getAllFolderPaths()`, `getCategoryIcon()`
+- `@/db/queries` → `getDbQueries()` → `getFolderContents()`, `getAllFolderPaths()`, `getCategoryIcon()`
 - `@/components/PostCard`
 - `@/components/MarkdownRenderer` (for README rendering)
 

--- a/app/posts/[...slug]/AGENTS.md
+++ b/app/posts/[...slug]/AGENTS.md
@@ -41,7 +41,7 @@ params.slug (string[])
 ## Dependencies
 
 ### Internal
-- `@/lib/db-queries` → `getPost()`, `getCategoryIcon()`, `getAllPostPaths()`
+- `@/db/queries` → `getDbQueries()` → `getPost()`, `getCategoryIcon()`, `getAllPostPaths()`
 - `@/lib/markdown` → `extractTitle()`, `extractDescription()`, `getReadingTime()`, `generateTableOfContents()`, `parseFrontMatter()`
 - `@/components/MarkdownRenderer`
 - `@/components/TableOfContents`

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -4,7 +4,7 @@
 # db
 
 ## Purpose
-Database layer using Drizzle ORM with MySQL. Contains the schema definition, TypeScript types, query class, constants, and the database connection singleton. This is the authoritative data access layer — prefer it over `lib/db-queries.ts` for all new code.
+Database layer using Drizzle ORM with MySQL. Contains the schema definition, TypeScript types, query class, constants, and the database connection singleton. This is the authoritative data access layer for all data access.
 
 ## Key Files
 
@@ -48,7 +48,7 @@ Database layer using Drizzle ORM with MySQL. Contains the schema definition, Typ
 
 ### Common Patterns
 ```ts
-// Instantiate queries (done in lib/db-queries.ts and API routes)
+// Instantiate queries (done via getDbQueries() in API routes)
 import { db } from "@/db";
 import { DbQueries } from "@/db/queries";
 const q = new DbQueries(db);
@@ -66,7 +66,7 @@ const { folders, posts, readme } = await q.getFolderContents("ai/basics");
 ## Dependencies
 
 ### Internal
-- Used by `lib/sync-github.ts`, `lib/db-queries.ts`, and all API routes
+- Used by `lib/sync-github.ts` and all API routes via `getDbQueries()`
 
 ### External
 - `drizzle-orm` — ORM and query builder


### PR DESCRIPTION
lib/db-queries.ts는 존재하지 않음 — 모든 참조를 실제 경로인
@/db/queries (getDbQueries() 팩토리 함수)로 수정