### PR TITLE
feat: 마크다운 상대경로 .md 링크를 블로그 URL로 자동 변환

### DIFF
--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -188,7 +188,7 @@ export default async function PostPage({ params }: PostPageProps) {
             </header>
 
             {/* Content */}
-            <MarkdownRenderer content={mainContent} />
+            <MarkdownRenderer content={mainContent} basePath={slug} />
 
             {/* Footer */}
             <footer className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800">

--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -11,9 +11,33 @@ import { Mermaid } from "./Mermaid";
 
 interface MarkdownRendererProps {
   content: string;
+  basePath?: string;
 }
 
-export function MarkdownRenderer({ content }: MarkdownRendererProps) {
+/**
+ * 마크다운의 상대경로 .md 링크를 블로그 URL로 변환
+ * 예: ../other.md → /posts/category/other
+ *     ./sub/post.md#section → /posts/category/sub/post#section
+ */
+function resolveMarkdownLink(href: string, basePath: string): string {
+  const hashIdx = href.indexOf("#");
+  const fragment = hashIdx !== -1 ? href.slice(hashIdx) : "";
+  const linkPath = hashIdx !== -1 ? href.slice(0, hashIdx) : href;
+
+  const pathWithoutExt = linkPath.replace(/\.mdx?$/, "");
+  const baseSegments = basePath.split("/").slice(0, -1);
+  const resolved = [...baseSegments];
+
+  for (const seg of pathWithoutExt.split("/")) {
+    if (seg === ".") continue;
+    else if (seg === "..") resolved.pop();
+    else resolved.push(seg);
+  }
+
+  return `/posts/${resolved.join("/")}${fragment}`;
+}
+
+export function MarkdownRenderer({ content, basePath }: MarkdownRendererProps) {
   const components: Partial<Components> = {
     h1: ({ children, ...props }) => (
       <h1
@@ -58,17 +82,29 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
         {children}
       </li>
     ),
-    a: ({ children, href, ...props }) => (
-      <a
-        href={href}
-        className="text-blue-600 dark:text-blue-400 hover:underline"
-        target={href?.startsWith("http") ? "_blank" : undefined}
-        rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
-        {...props}
-      >
-        {children}
-      </a>
-    ),
+    a: ({ children, href, ...props }) => {
+      const isExternal = href?.startsWith("http");
+      const isAnchor = href?.startsWith("#");
+      const isRelativeMd =
+        !isExternal && !isAnchor && /\.mdx?($|#)/.test(href ?? "");
+
+      const resolvedHref =
+        isRelativeMd && basePath
+          ? resolveMarkdownLink(href!, basePath)
+          : href;
+
+      return (
+        <a
+          href={resolvedHref}
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noopener noreferrer" : undefined}
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    },
     blockquote: ({ children, ...props }) => (
       <blockquote
         className="my-4 pl-4 border-l-4 border-blue-500 bg-gray-50 dark:bg-gray-900 py-2 italic"


### PR DESCRIPTION
## Summary
- 마크다운 포스트 내 상대경로 `.md` 링크를 블로그 URL(`/posts/...`)로 자동 변환
- `MarkdownRenderer`에 `basePath` prop 추가 — 현재 포스트 경로 기준으로 상대경로 해석
- 외부 링크(`http://...`)와 앵커(`#section`)는 기존 동작 유지

**변환 예시** (현재 포스트: `AI/RAG/embedding`):
| 마크다운 링크 | 변환 결과 |
|---|---|
| `./other.md` | `/posts/AI/RAG/other` |
| `../intro.md` | `/posts/AI/intro` |
| `../NLP/tokenizer.md#section` | `/posts/AI/NLP/tokenizer#section` |

## Test plan
- [ ] 상대경로 `.md` 링크가 있는 포스트에서 링크 클릭 시 올바른 블로그 페이지로 이동하는지 확인
- [ ] `../` 상위 경로 이동이 정확히 처리되는지 확인
- [ ] 앵커 포함 링크(`post.md#section`) 변환 확인
- [ ] 외부 링크, `#anchor` 링크가 영향받지 않는지 확인
- [ ] `pnpm type-check` 및 `pnpm lint` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)