### PR TITLE
feat: 마크다운 상대경로 링크 변환 + GitHub 커밋 기준 작성일/수정일 표시

### DIFF
--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -17,7 +17,7 @@ import { Comments } from "@/components/Comments";
 import { PostViewCount } from "@/components/PostViewCount";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Clock, Folder, Github } from "lucide-react";
+import { ArrowLeft, Calendar, Clock, Folder, Github, Pencil } from "lucide-react";
 import { Metadata } from "next";
 
 const siteUrl =
@@ -171,6 +171,32 @@ export default async function PostPage({ params }: PostPageProps) {
                   <Clock className="w-4 h-4" />
                   <span>약 {readingTime}분</span>
                 </div>
+                {post.createdAt && (
+                  <div className="flex items-center gap-2">
+                    <Calendar className="w-4 h-4" />
+                    <span>
+                      {post.createdAt.toLocaleDateString("ko-KR", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                    </span>
+                  </div>
+                )}
+                {post.updatedAt &&
+                  post.createdAt?.getTime() !== post.updatedAt.getTime() && (
+                    <div className="flex items-center gap-2">
+                      <Pencil className="w-4 h-4" />
+                      <span>
+                        {post.updatedAt.toLocaleDateString("ko-KR", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })}
+                        {"  수정"}
+                      </span>
+                    </div>
+                  )}
                 <PostViewCount
                   pagePath={post.path}
                   className="text-gray-600 dark:text-gray-400"

--- a/db/types.ts
+++ b/db/types.ts
@@ -9,6 +9,8 @@ export interface PostData {
   folders?: string[];
   content?: string | null;
   description?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
 }
 
 export interface FolderItemData {

--- a/lib/sync-github.ts
+++ b/lib/sync-github.ts
@@ -105,6 +105,45 @@ async function getLastSyncedCommitSha(): Promise<string | null> {
   return result[0]?.commitSha ?? null;
 }
 
+/**
+ * GitHub 커밋 히스토리에서 파일의 최초 작성일(createdAt)과 최신 수정일(updatedAt)을 가져옴
+ * per_page=100으로 최대 100개 커밋 조회 (배열 앞 = 최신, 뒤 = 오래된 순)
+ */
+async function getFileCommitDates(
+  filePath: string
+): Promise<{ createdAt: Date; updatedAt: Date } | null> {
+  try {
+    const response = await octokit.repos.listCommits({
+      owner: OWNER,
+      repo: REPO,
+      path: filePath,
+      per_page: 100,
+    });
+
+    const commits = response.data;
+    if (commits.length === 0) return null;
+
+    const latestCommit = commits[0];
+    const firstCommit = commits[commits.length - 1];
+
+    const updatedAt = new Date(
+      latestCommit.commit.committer?.date ??
+        latestCommit.commit.author?.date ??
+        new Date()
+    );
+    const createdAt = new Date(
+      firstCommit.commit.committer?.date ??
+        firstCommit.commit.author?.date ??
+        updatedAt
+    );
+
+    return { createdAt, updatedAt };
+  } catch (error) {
+    console.warn(`커밋 날짜 조회 실패 (${filePath}):`, error);
+    return null;
+  }
+}
+
 async function getFileContent(
   path: string
 ): Promise<{ content: string; sha: string } | null> {
@@ -158,7 +197,10 @@ function isMdFile(filename: string) {
 
 async function upsertPost(filePath: string): Promise<"added" | "updated" | "skipped"> {
   const database = getDb();
-  const fileData = await getFileContent(filePath);
+  const [fileData, commitDates] = await Promise.all([
+    getFileContent(filePath),
+    getFileCommitDates(filePath),
+  ]);
   if (!fileData) return "skipped";
 
   const { category, foldersList, subcategory, title } = parsePath(filePath);
@@ -182,7 +224,7 @@ async function upsertPost(filePath: string): Promise<"added" | "updated" | "skip
         subcategory,
         folders: foldersList,
         isActive: true,
-        updatedAt: new Date(),
+        updatedAt: commitDates?.updatedAt ?? new Date(),
       })
       .where(eq(posts.id, existing[0].id));
     return "updated";
@@ -197,6 +239,10 @@ async function upsertPost(filePath: string): Promise<"added" | "updated" | "skip
       content: fileData.content,
       description,
       sha: fileData.sha,
+      ...(commitDates && {
+        createdAt: commitDates.createdAt,
+        updatedAt: commitDates.updatedAt,
+      }),
     });
     return "added";
   }
@@ -307,7 +353,10 @@ async function performFullSync(): Promise<{
 
     if (existing && existing.sha === file.sha) continue;
 
-    const fileData = await getFileContent(file.path);
+    const [fileData, commitDates] = await Promise.all([
+      getFileContent(file.path),
+      getFileCommitDates(file.path),
+    ]);
     if (!fileData) continue;
 
     const { title } = parsePath(file.path);
@@ -325,7 +374,7 @@ async function performFullSync(): Promise<{
           subcategory: file.subcategory,
           folders: file.folders,
           isActive: true,
-          updatedAt: new Date(),
+          updatedAt: commitDates?.updatedAt ?? new Date(),
         })
         .where(eq(posts.id, existing.id));
       updated++;
@@ -341,6 +390,10 @@ async function performFullSync(): Promise<{
         content: fileData.content,
         description,
         sha: fileData.sha,
+        ...(commitDates && {
+          createdAt: commitDates.createdAt,
+          updatedAt: commitDates.updatedAt,
+        }),
       });
       added++;
       console.log(`추가: ${file.path}`);


### PR DESCRIPTION
## Summary
- 마크다운 포스트 내 상대경로 `.md` 링크를 블로그 URL(`/posts/...`)로 자동 변환
- sync 시 GitHub 커밋 히스토리 기반으로 작성일(첫 커밋) / 수정일(최신 커밋) 저장
- 포스트 헤더에 작성일 / 수정일 UI 표시 (작성일=수정일이면 수정일 숨김)

## Details

**상대경로 링크 변환** (`MarkdownRenderer`):
| 마크다운 링크 | 변환 결과 |
|---|---|
| `./other.md` | `/posts/AI/RAG/other` |
| `../intro.md` | `/posts/AI/intro` |
| `../NLP/tokenizer.md#section` | `/posts/AI/NLP/tokenizer#section` |

**GitHub 커밋 날짜** (`sync-github.ts`):
- `getFileCommitDates()` 추가 — `listCommits` API로 최대 100개 조회
- 첫 커밋 날짜 → `createdAt`, 최신 커밋 날짜 → `updatedAt`
- `upsertPost()` 및 `performFullSync()` 양쪽에 적용

## Test plan
- [ ] 상대경로 `.md` 링크 클릭 시 올바른 블로그 페이지로 이동 확인
- [ ] sync 후 포스트 헤더에 작성일/수정일이 정확하게 표시되는지 확인
- [ ] 작성일 = 수정일인 경우 수정일이 숨겨지는지 확인
- [ ] `pnpm type-check` 및 `pnpm lint` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)