### PR TITLE
fix: 마크다운 .md 링크 변환 시 확장자 유지

### DIFF
--- a/lib/resolve-markdown-link.test.ts
+++ b/lib/resolve-markdown-link.test.ts
@@ -3,82 +3,96 @@ import { resolveMarkdownLink } from "./resolve-markdown-link";
 
 describe("resolveMarkdownLink", () => {
   describe("절대경로 (/로 시작)", () => {
-    it("루트 절대경로를 /posts/ URL로 변환한다", () => {
+    it("루트 절대경로를 /posts/ URL로 변환한다 (.md 유지)", () => {
       expect(
-        resolveMarkdownLink("/java/spring-batch/0.1-introduce.md", "java/spring-batch/README")
-      ).toBe("/posts/java/spring-batch/0.1-introduce");
+        resolveMarkdownLink("/java/spring-batch/0.1-introduce.md", "java/spring-batch/README.md")
+      ).toBe("/posts/java/spring-batch/0.1-introduce.md");
     });
 
     it("절대경로에 앵커가 포함된 경우 유지한다", () => {
       expect(
-        resolveMarkdownLink("/java/spring-batch/post.md#section", "java/spring-batch/README")
-      ).toBe("/posts/java/spring-batch/post#section");
+        resolveMarkdownLink("/java/spring-batch/post.md#section", "java/spring-batch/README.md")
+      ).toBe("/posts/java/spring-batch/post.md#section");
     });
 
-    it(".mdx 확장자도 제거한다", () => {
+    it(".mdx 확장자도 유지한다", () => {
       expect(
-        resolveMarkdownLink("/java/post.mdx", "java/README")
-      ).toBe("/posts/java/post");
+        resolveMarkdownLink("/java/post.mdx", "java/README.md")
+      ).toBe("/posts/java/post.mdx");
     });
   });
 
   describe("상대경로 (같은 디렉토리)", () => {
-    it("./로 시작하는 링크를 변환한다", () => {
+    it("./로 시작하는 링크를 변환한다 (.md 유지)", () => {
       expect(
-        resolveMarkdownLink("./other.md", "AI/RAG/embedding")
-      ).toBe("/posts/AI/RAG/other");
+        resolveMarkdownLink("./other.md", "AI/RAG/embedding.md")
+      ).toBe("/posts/AI/RAG/other.md");
     });
 
     it("확장자 없이 파일명만 있는 링크를 변환한다 (async-item-processor.md 패턴)", () => {
       expect(
-        resolveMarkdownLink("async-item-processor.md", "java/spring-batch/README")
-      ).toBe("/posts/java/spring-batch/async-item-processor");
+        resolveMarkdownLink("async-item-processor.md", "java/spring-batch/README.md")
+      ).toBe("/posts/java/spring-batch/async-item-processor.md");
     });
 
     it("같은 디렉토리 링크에 앵커가 포함된 경우 유지한다", () => {
       expect(
-        resolveMarkdownLink("./post.md#heading", "AI/RAG/embedding")
-      ).toBe("/posts/AI/RAG/post#heading");
+        resolveMarkdownLink("./post.md#heading", "AI/RAG/embedding.md")
+      ).toBe("/posts/AI/RAG/post.md#heading");
     });
   });
 
   describe("상대경로 (상위 디렉토리)", () => {
     it("../로 한 단계 상위 디렉토리로 이동한다", () => {
       expect(
-        resolveMarkdownLink("../intro.md", "AI/RAG/embedding")
-      ).toBe("/posts/AI/intro");
+        resolveMarkdownLink("../intro.md", "AI/RAG/embedding.md")
+      ).toBe("/posts/AI/intro.md");
     });
 
     it("../로 다른 하위 디렉토리로 이동한다", () => {
       expect(
-        resolveMarkdownLink("../NLP/tokenizer.md", "AI/RAG/embedding")
-      ).toBe("/posts/AI/NLP/tokenizer");
+        resolveMarkdownLink("../NLP/tokenizer.md", "AI/RAG/embedding.md")
+      ).toBe("/posts/AI/NLP/tokenizer.md");
     });
 
     it("../../로 두 단계 상위 디렉토리로 이동한다", () => {
       expect(
-        resolveMarkdownLink("../../Other/post.md", "AI/RAG/embedding")
-      ).toBe("/posts/Other/post");
+        resolveMarkdownLink("../../Other/post.md", "AI/RAG/embedding.md")
+      ).toBe("/posts/Other/post.md");
     });
 
     it("상위 이동에 앵커가 포함된 경우 유지한다", () => {
       expect(
-        resolveMarkdownLink("../NLP/tokenizer.md#section", "AI/RAG/embedding")
-      ).toBe("/posts/AI/NLP/tokenizer#section");
+        resolveMarkdownLink("../NLP/tokenizer.md#section", "AI/RAG/embedding.md")
+      ).toBe("/posts/AI/NLP/tokenizer.md#section");
     });
   });
 
   describe("폴더 README 기준 링크 (실제 spring-batch 케이스)", () => {
     it("README에서 절대경로 .md 링크를 변환한다", () => {
       expect(
-        resolveMarkdownLink("/java/spring-batch/1.1-type-of-steps.md", "java/spring-batch/README")
-      ).toBe("/posts/java/spring-batch/1.1-type-of-steps");
+        resolveMarkdownLink("/java/spring-batch/1.1-type-of-steps.md", "java/spring-batch/README.md")
+      ).toBe("/posts/java/spring-batch/1.1-type-of-steps.md");
     });
 
     it("README에서 상대경로 .md 링크를 변환한다", () => {
       expect(
-        resolveMarkdownLink("async-item-processor.md", "java/spring-batch/README")
-      ).toBe("/posts/java/spring-batch/async-item-processor");
+        resolveMarkdownLink("async-item-processor.md", "java/spring-batch/README.md")
+      ).toBe("/posts/java/spring-batch/async-item-processor.md");
+    });
+  });
+
+  describe("task/nsc-slot/README.md 케이스", () => {
+    it("README.md에서 같은 디렉토리 링크를 변환한다", () => {
+      expect(
+        resolveMarkdownLink("./slot-machine.md", "task/nsc-slot/README.md")
+      ).toBe("/posts/task/nsc-slot/slot-machine.md");
+    });
+
+    it("README.md에서 절대경로 링크를 변환한다", () => {
+      expect(
+        resolveMarkdownLink("/task/nsc-slot/slot-machine.md", "task/nsc-slot/README.md")
+      ).toBe("/posts/task/nsc-slot/slot-machine.md");
     });
   });
 });

--- a/lib/resolve-markdown-link.ts
+++ b/lib/resolve-markdown-link.ts
@@ -2,30 +2,28 @@
  * 마크다운의 상대/절대경로 .md 링크를 블로그 URL로 변환
  *
  * 지원하는 링크 형식:
- * - 절대경로: /java/spring-batch/post.md → /posts/java/spring-batch/post
+ * - 절대경로: /java/spring-batch/post.md → /posts/java/spring-batch/post.md
  * - 상대경로: ./other.md, ../category/post.md → /posts/...
- * - 앵커 포함: post.md#section → /posts/.../post#section
+ * - 앵커 포함: post.md#section → /posts/.../post.md#section
  *
  * @param href 마크다운 링크의 href 값
- * @param basePath 현재 파일의 경로 (예: "java/spring-batch/README" 또는 "AI/RAG/embedding")
+ * @param basePath 현재 파일의 경로 (예: "java/spring-batch/README.md" 또는 "AI/RAG/embedding.md")
  */
 export function resolveMarkdownLink(href: string, basePath: string): string {
   const hashIdx = href.indexOf("#");
   const fragment = hashIdx !== -1 ? href.slice(hashIdx) : "";
   const linkPath = hashIdx !== -1 ? href.slice(0, hashIdx) : href;
 
-  const pathWithoutExt = linkPath.replace(/\.mdx?$/, "");
-
   // /로 시작하는 절대경로 (repo root 기준) → /posts/ 앞에 붙이기
-  if (pathWithoutExt.startsWith("/")) {
-    return `/posts${pathWithoutExt}${fragment}`;
+  if (linkPath.startsWith("/")) {
+    return `/posts${linkPath}${fragment}`;
   }
 
   // 상대경로: basePath의 디렉토리 기준으로 해석
   const baseSegments = basePath.split("/").slice(0, -1);
   const resolved = [...baseSegments];
 
-  for (const seg of pathWithoutExt.split("/")) {
+  for (const seg of linkPath.split("/")) {
     if (seg === ".") continue;
     else if (seg === "..") resolved.pop();
     else resolved.push(seg);


### PR DESCRIPTION
## Summary
- `resolveMarkdownLink`에서 `.md` 확장자를 제거하던 로직 삭제
- 포스트 경로에 `.md`가 포함되는 구조이므로 링크 URL도 `.md`를 유지해야 함
- 예: `./slot-machine.md` → `/posts/task/nsc-slot/slot-machine.md` (이전엔 `.md` 없어서 404)
- 테스트 케이스 업데이트 및 `task/nsc-slot` 실제 케이스 추가

## Test plan
- [ ] 마크다운 내 상대경로 링크(`./file.md`) 클릭 시 정상 이동 확인
- [ ] 절대경로 링크(`/category/post.md`) 클릭 시 정상 이동 확인
- [ ] 앵커 포함 링크(`./file.md#section`) 동작 확인
- [ ] `pnpm test` 43개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)