### PR TITLE
style: 모바일 반응형 타이포그래피·레이아웃 개선

### DIFF
--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -27,7 +27,7 @@ export default async function CategoriesPage() {
   const categories = dbQueries ? await dbQueries.getCategories() : [];
 
   return (
-    <div className="container mx-auto px-4 py-12">
+    <div className="container mx-auto px-4 py-6 md:py-12">
       <div className="mb-8">
         <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
           카테고리

--- a/app/category/[...path]/page.tsx
+++ b/app/category/[...path]/page.tsx
@@ -115,7 +115,7 @@ export default async function FolderPage({ params }: FolderPageProps) {
   return (
     <>
       <BreadcrumbJsonLd items={breadcrumbJsonLdItems} />
-    <div className="container mx-auto px-4 py-12">
+    <div className="container mx-auto px-4 py-6 md:py-12">
       {/* Back button */}
       {pathSegments.length > 1 ? (
         <Link

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,9 +34,9 @@ export default async function HomePage() {
         name="FOS Study"
         description="개발 공부 기록을 정리하는 블로그입니다. AI, 알고리즘, 아키텍처, 데이터베이스, DevOps 등 다양한 주제를 다룹니다."
       />
-      <div className="container mx-auto px-4 py-12">
+      <div className="container mx-auto px-4 py-6 md:py-12">
         {/* Hero Section */}
-        <section className="relative text-center mb-16 animate-fade-in py-8 overflow-hidden">
+        <section className="relative text-center mb-8 md:mb-16 animate-fade-in py-4 md:py-8 overflow-hidden">
           {/* Decorative background blobs */}
           <div aria-hidden="true" className="absolute inset-0 -z-10 pointer-events-none">
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[300px] rounded-full bg-blue-500/5 dark:bg-blue-400/10 blur-3xl" />
@@ -48,7 +48,7 @@ export default async function HomePage() {
             <Sparkles className="w-4 h-4" />
             <span>개발 학습 기록 블로그</span>
           </div>
-          <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold text-gray-900 dark:text-white mb-6 tracking-tight">
+          <h1 className="text-3xl md:text-6xl lg:text-7xl font-bold text-gray-900 dark:text-white mb-6 tracking-tight">
             FOS Study
           </h1>
           <p className="text-lg md:text-xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto leading-relaxed">
@@ -58,9 +58,9 @@ export default async function HomePage() {
         </section>
 
         {/* Categories Section */}
-        <section className="mb-16">
-          <div className="flex items-center justify-between mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
+        <section className="mb-8 md:mb-16">
+          <div className="flex items-center justify-between mb-4 md:mb-8">
+            <h2 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">
               카테고리
             </h2>
             <Link
@@ -76,13 +76,13 @@ export default async function HomePage() {
 
         {/* Recent Posts Section */}
         <section>
-          <div className="flex items-center justify-between mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
+          <div className="flex items-center justify-between mb-4 md:mb-8">
+            <h2 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">
               최근 글
             </h2>
           </div>
           {recentPosts.length > 0 ? (
-            <div className="space-y-4">
+            <div className="space-y-2 md:space-y-4">
               {recentPosts.map((post) => (
                 <PostCard
                   key={post.path}
@@ -99,28 +99,28 @@ export default async function HomePage() {
         </section>
 
         {/* Stats Section */}
-        <section className="mt-16 grid grid-cols-2 md:grid-cols-3 gap-6">
-          <div className="p-6 rounded-xl bg-linear-to-br from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20 text-center">
-            <div className="text-3xl font-bold text-blue-600 dark:text-blue-400 mb-2">
+        <section className="mt-8 md:mt-16 grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-6">
+          <div className="p-4 md:p-6 rounded-xl bg-linear-to-br from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20 text-center">
+            <div className="text-2xl md:text-3xl font-bold text-blue-600 dark:text-blue-400 mb-1 md:mb-2">
               {categories.length}
             </div>
-            <div className="text-sm text-gray-600 dark:text-gray-400">
+            <div className="text-xs md:text-sm text-gray-600 dark:text-gray-400">
               카테고리
             </div>
           </div>
-          <div className="p-6 rounded-xl bg-linear-to-br from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20 text-center">
-            <div className="text-3xl font-bold text-purple-600 dark:text-purple-400 mb-2">
+          <div className="p-4 md:p-6 rounded-xl bg-linear-to-br from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20 text-center">
+            <div className="text-2xl md:text-3xl font-bold text-purple-600 dark:text-purple-400 mb-1 md:mb-2">
               {categories.reduce((acc, cat) => acc + cat.count, 0)}
             </div>
-            <div className="text-sm text-gray-600 dark:text-gray-400">
+            <div className="text-xs md:text-sm text-gray-600 dark:text-gray-400">
               전체 글
             </div>
           </div>
-          <div className="p-6 rounded-xl bg-linear-to-br from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20 text-center col-span-2 md:col-span-1">
-            <div className="text-3xl font-bold text-green-600 dark:text-green-400 mb-2">
+          <div className="p-4 md:p-6 rounded-xl bg-linear-to-br from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20 text-center col-span-2 md:col-span-1">
+            <div className="text-2xl md:text-3xl font-bold text-green-600 dark:text-green-400 mb-1 md:mb-2">
               ∞
             </div>
-            <div className="text-sm text-gray-600 dark:text-gray-400">
+            <div className="text-xs md:text-sm text-gray-600 dark:text-gray-400">
               계속 성장 중
             </div>
           </div>

--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -151,7 +151,7 @@ export default async function PostPage({ params }: PostPageProps) {
       />
       <BreadcrumbJsonLd items={breadcrumbItems} />
 
-      <div className="container mx-auto px-4 py-12">
+      <div className="container mx-auto px-4 py-6 md:py-12">
         {/* Back button */}
         <Link
           href={`/category/${encodeURIComponent(post.category)}`}
@@ -181,7 +181,7 @@ export default async function PostPage({ params }: PostPageProps) {
                 )}
               </div>
 
-              <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+              <h1 className="text-2xl md:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-white mb-4">
                 {title}
               </h1>
 

--- a/components/CategoryCard.tsx
+++ b/components/CategoryCard.tsx
@@ -27,16 +27,16 @@ export function CategoryCard({ category }: CategoryCardProps) {
   return (
     <Link
       href={`/category/${encodeURIComponent(category.slug)}`}
-      className={`group block p-5 rounded-xl border border-l-4 border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-700 transition-all duration-300 ${accent}`}
+      className={`group block p-3 md:p-5 rounded-xl border border-l-4 border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-700 transition-all duration-300 ${accent}`}
     >
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-3">
-          <span className="text-3xl">{category.icon}</span>
+          <span className="text-2xl md:text-3xl">{category.icon}</span>
           <div>
-            <h3 className="font-semibold text-lg text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+            <h3 className="font-semibold text-base md:text-lg text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
               {category.name}
             </h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-xs md:text-sm text-gray-500 dark:text-gray-400">
               {category.count}개의 글
             </p>
           </div>

--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -19,24 +19,24 @@ export function MarkdownRenderer({ content, basePath }: MarkdownRendererProps) {
   const components: Partial<Components> = {
     h1: ({ children, ...props }) => (
       <h1
-        className="text-3xl md:text-4xl font-bold mt-8 mb-4 pb-2 border-b border-gray-200 dark:border-gray-800"
+        className="text-2xl md:text-4xl font-bold mt-8 mb-4 pb-2 border-b border-gray-200 dark:border-gray-800"
         {...props}
       >
         {children}
       </h1>
     ),
     h2: ({ children, ...props }) => (
-      <h2 className="text-2xl md:text-3xl font-bold mt-8 mb-4" {...props}>
+      <h2 className="text-xl md:text-3xl font-bold mt-8 mb-4" {...props}>
         {children}
       </h2>
     ),
     h3: ({ children, ...props }) => (
-      <h3 className="text-xl md:text-2xl font-bold mt-6 mb-3" {...props}>
+      <h3 className="text-lg md:text-2xl font-bold mt-6 mb-3" {...props}>
         {children}
       </h3>
     ),
     h4: ({ children, ...props }) => (
-      <h4 className="text-lg md:text-xl font-bold mt-4 mb-2" {...props}>
+      <h4 className="text-base md:text-xl font-bold mt-4 mb-2" {...props}>
         {children}
       </h4>
     ),

--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -171,7 +171,7 @@ export function MarkdownRenderer({ content, basePath }: MarkdownRendererProps) {
   };
 
   return (
-    <article className="prose prose-gray dark:prose-invert max-w-none">
+    <article className="prose-sm md:prose prose-gray dark:prose-invert max-w-none">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeSlug, rehypeHighlight, rehypeRaw]}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -47,10 +47,10 @@ export function PostCard({
   return (
     <Link
       href={`/posts/${post.slug.split("/").map(encodeURIComponent).join("/")}`}
-      className="group flex items-center gap-4 p-4 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 hover:border-blue-300 dark:hover:border-blue-700 hover:shadow-md transition-all duration-300"
+      className="group flex items-center gap-3 md:gap-4 p-3 md:p-4 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 hover:border-blue-300 dark:hover:border-blue-700 hover:shadow-md transition-all duration-300"
     >
-      <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center group-hover:bg-blue-100 dark:group-hover:bg-blue-900/30 transition-colors">
-        <FileText className="w-5 h-5 text-gray-500 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-400" />
+      <div className="flex-shrink-0 w-8 h-8 md:w-10 md:h-10 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center group-hover:bg-blue-100 dark:group-hover:bg-blue-900/30 transition-colors">
+        <FileText className="w-4 h-4 md:w-5 md:h-5 text-gray-500 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-400" />
       </div>
 
       <div className="flex-grow min-w-0">


### PR DESCRIPTION
## Summary
- 모바일(< 768px)에서 전체적으로 글자 크기와 여백이 과도하게 큰 문제 개선
- `md:` breakpoint 기준으로 모바일/데스크탑 크기를 이원화하여 일관성 있는 레이아웃 구성

## 변경사항

### 페이지 컨테이너 · 섹션 여백
- 컨테이너 padding: `py-12` → `py-6 md:py-12`
- Hero 섹션: `py-8 mb-16` → `py-4 md:py-8 mb-8 md:mb-16`
- 섹션 헤더 margin: `mb-8` → `mb-4 md:mb-8`
- PostCard 간격: `space-y-4` → `space-y-2 md:space-y-4`
- 통계 카드: `mt-16 gap-6 p-6` → `mt-8 md:mt-16 gap-3 md:gap-6 p-4 md:p-6`

### 컴포넌트 크기
- Hero h1: `text-5xl` → `text-3xl` (모바일)
- 섹션 h2: `text-2xl` → `text-xl` (모바일)
- 포스트 제목: `text-3xl` → `text-2xl` (모바일)
- MarkdownRenderer h1~h4: 한 단계씩 축소
- CategoryCard: 패딩 `p-5→p-3`, 이모지 `text-3xl→text-2xl`, 텍스트 `text-lg→text-base`
- PostCard: 패딩 `p-4→p-3`, 아이콘 `w-10→w-8` (모바일)

## Test plan
- [ ] 실제 모바일 디바이스(390px)에서 홈, 카테고리, 포스트 페이지 확인
- [ ] 데스크탑(1280px+)에서 기존 디자인과 동일한지 확인
- [ ] `pnpm lint && pnpm type-check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)