### PR TITLE
feat: 인기글 섹션 · 폴더 사이드바 · h1 제목 동기화 추가

### DIFF
--- a/app/components/FolderSidebarWrapper.tsx
+++ b/app/components/FolderSidebarWrapper.tsx
@@ -1,0 +1,17 @@
+import { getDbQueries } from "@/db/queries";
+import { categoryIcons } from "@/db/constants";
+import { FolderSidebar } from "@/components/FolderSidebar";
+
+export async function FolderSidebarWrapper() {
+  const dbQueries = getDbQueries();
+  if (!dbQueries) return null;
+
+  const folderPaths = await dbQueries.getAllFolderPaths();
+
+  return (
+    <FolderSidebar
+      folderPaths={folderPaths}
+      categoryIcons={categoryIcons}
+    />
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Header } from "@/components/Header";
 import { VisitorCount } from "@/components/VisitorCount";
+import { FolderSidebarWrapper } from "@/app/components/FolderSidebarWrapper";
 
 const notoSansKR = Noto_Sans_KR({
   subsets: ["latin"],
@@ -139,7 +140,12 @@ export default function RootLayout({
         >
           <div className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100">
             <Header />
-            <main>{children}</main>
+            <div className="flex">
+              <div className="hidden lg:block">
+                <FolderSidebarWrapper />
+              </div>
+              <main className="flex-1 min-w-0">{children}</main>
+            </div>
             <footer className="border-t border-gray-200 dark:border-gray-800 py-12 mt-16">
               <div className="container mx-auto px-4">
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { getDbQueries } from "@/db/queries";
 import { CategoryList } from "@/components/CategoryList";
 import { PostCard } from "@/components/PostCard";
 import { WebsiteJsonLd } from "@/components/JsonLd";
-import { ArrowRight, Sparkles } from "lucide-react";
+import { ArrowRight, Sparkles, Flame } from "lucide-react";
 import Link from "next/link";
 
 const siteUrl =
@@ -13,12 +13,13 @@ export const revalidate = 60;
 
 export default async function HomePage() {
   const dbQueries = getDbQueries();
-  const [categories, recentPosts] = dbQueries
+  const [categories, recentPosts, popularPosts] = dbQueries
     ? await Promise.all([
         dbQueries.getCategories(),
         dbQueries.getRecentPosts(6),
+        dbQueries.getPopularPosts(6),
       ])
-    : [[], []];
+    : [[], [], []];
 
   // 최근 글의 조회수 일괄 조회
   const postPaths = recentPosts.map((p) => p.path);
@@ -73,6 +74,27 @@ export default async function HomePage() {
           </div>
           <CategoryList categories={categories.slice(0, 6)} />
         </section>
+
+        {/* Popular Posts Section */}
+        {popularPosts.length > 0 && (
+          <section className="mb-16">
+            <div className="flex items-center gap-2 mb-8">
+              <Flame className="w-6 h-6 text-orange-500" />
+              <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
+                인기 글
+              </h2>
+            </div>
+            <div className="space-y-4">
+              {popularPosts.map((post) => (
+                <PostCard
+                  key={post.path}
+                  post={post}
+                  viewCount={post.visitCount}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Recent Posts Section */}
         <section>

--- a/components/FolderSidebar.tsx
+++ b/components/FolderSidebar.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { ChevronRight, Folder, FolderOpen } from "lucide-react";
+
+interface FolderNode {
+  name: string;
+  path: string;
+  children: FolderNode[];
+  count?: number;
+  icon?: string;
+}
+
+interface FolderSidebarProps {
+  folderPaths: string[][];
+  categoryIcons?: Record<string, string>;
+}
+
+function buildTree(folderPaths: string[][]): FolderNode[] {
+  const root: FolderNode[] = [];
+
+  for (const parts of folderPaths) {
+    if (parts.length === 0) continue;
+
+    let currentLevel = root;
+    let cumulativePath = "";
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      cumulativePath = cumulativePath ? `${cumulativePath}/${part}` : part;
+
+      let existing = currentLevel.find((n) => n.name === part);
+      if (!existing) {
+        existing = { name: part, path: cumulativePath, children: [] };
+        currentLevel.push(existing);
+      }
+
+      currentLevel = existing.children;
+    }
+  }
+
+  return root;
+}
+
+function FolderTreeNode({
+  node,
+  depth,
+  currentPath,
+  icons,
+}: {
+  node: FolderNode;
+  depth: number;
+  currentPath: string;
+  icons: Record<string, string>;
+}) {
+  const [open, setOpen] = useState(depth === 0);
+  const hasChildren = node.children.length > 0;
+  const href = `/category/${node.path}`;
+  const isActive = currentPath === href || currentPath.startsWith(href + "/");
+  const icon = depth === 0 ? (icons[node.name] ?? "📁") : null;
+
+  return (
+    <li>
+      <div
+        className={`flex items-center gap-1 rounded-lg transition-colors ${
+          depth === 0 ? "mb-0.5" : ""
+        }`}
+        style={{ paddingLeft: `${depth * 12}px` }}
+      >
+        {hasChildren ? (
+          <button
+            onClick={() => setOpen((v) => !v)}
+            className="flex items-center gap-1.5 flex-1 text-left py-1.5 px-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            <ChevronRight
+              className={`w-3.5 h-3.5 flex-shrink-0 text-gray-400 transition-transform ${open ? "rotate-90" : ""}`}
+            />
+            {icon ? (
+              <span className="text-base leading-none">{icon}</span>
+            ) : open ? (
+              <FolderOpen className="w-3.5 h-3.5 flex-shrink-0 text-blue-400" />
+            ) : (
+              <Folder className="w-3.5 h-3.5 flex-shrink-0 text-gray-400" />
+            )}
+            <span
+              className={`text-sm font-medium truncate ${
+                depth === 0
+                  ? "text-gray-800 dark:text-gray-200"
+                  : "text-gray-600 dark:text-gray-400"
+              }`}
+            >
+              {node.name}
+            </span>
+          </button>
+        ) : (
+          <Link
+            href={href}
+            className={`flex items-center gap-1.5 flex-1 py-1.5 px-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors ${
+              isActive
+                ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+                : ""
+            }`}
+          >
+            <span className="w-3.5 h-3.5 flex-shrink-0" />
+            {icon ? (
+              <span className="text-base leading-none">{icon}</span>
+            ) : (
+              <Folder className="w-3.5 h-3.5 flex-shrink-0 text-gray-400" />
+            )}
+            <span
+              className={`text-sm truncate ${
+                isActive
+                  ? "font-medium"
+                  : depth === 0
+                    ? "font-medium text-gray-800 dark:text-gray-200"
+                    : "text-gray-600 dark:text-gray-400"
+              }`}
+            >
+              {node.name}
+            </span>
+          </Link>
+        )}
+
+        {hasChildren && (
+          <Link
+            href={href}
+            className={`py-1.5 px-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors ${
+              isActive
+                ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+                : "text-gray-600 dark:text-gray-400"
+            }`}
+          >
+            <span className="sr-only">{node.name} 페이지로 이동</span>
+          </Link>
+        )}
+      </div>
+
+      {hasChildren && open && (
+        <ul>
+          {node.children.map((child) => (
+            <FolderTreeNode
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              currentPath={currentPath}
+              icons={icons}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export function FolderSidebar({ folderPaths, categoryIcons = {} }: FolderSidebarProps) {
+  const pathname = usePathname();
+  const tree = buildTree(folderPaths);
+
+  return (
+    <aside className="w-56 flex-shrink-0 h-[calc(100vh-4rem)] sticky top-16 overflow-y-auto border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 px-3 py-4">
+      <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 px-2 mb-3">
+        카테고리
+      </p>
+      <nav>
+        <ul className="space-y-0.5">
+          {tree.map((node) => (
+            <FolderTreeNode
+              key={node.path}
+              node={node}
+              depth={0}
+              currentPath={pathname}
+              icons={categoryIcons}
+            />
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/db/queries.ts
+++ b/db/queries.ts
@@ -114,6 +114,19 @@ export class DbQueries {
     return this.commentRepo.getCommentCount(postSlug);
   }
 
+  getPopularPosts(limit?: number): Promise<Array<PostData & { visitCount: number }>> {
+    return this.visitRepo.getPopularPostPaths((limit ?? 6) * 3).then(async (popularPaths) => {
+      if (popularPaths.length === 0) return [];
+      const paths = popularPaths.map(p => p.path);
+      const postDataList = await this.postRepo.getPostsByPaths(paths);
+      const visitMap = new Map(popularPaths.map(p => [p.path, p.visitCount]));
+      return postDataList
+        .map(post => ({ ...post, visitCount: visitMap.get(post.path) ?? 0 }))
+        .sort((a, b) => b.visitCount - a.visitCount)
+        .slice(0, limit ?? 6);
+    });
+  }
+
   // ===== Visit =====
   recordVisit(pagePath: string, ipHash: string): Promise<boolean> {
     return this.visitRepo.recordVisit(pagePath, ipHash);

--- a/db/repositories/PostRepository.ts
+++ b/db/repositories/PostRepository.ts
@@ -1,4 +1,4 @@
-import { eq, desc, and, or, like, sql } from "drizzle-orm";
+import { eq, desc, and, or, like, sql, inArray } from "drizzle-orm";
 import { posts } from "../schema";
 import type { PostData } from "../types";
 import { BaseRepository } from "./BaseRepository";
@@ -93,6 +93,23 @@ export class PostRepository extends BaseRepository {
       .select({ path: posts.path, updatedAt: posts.updatedAt })
       .from(posts)
       .where(eq(posts.isActive, true));
+  }
+
+  async getPostsByPaths(paths: string[]): Promise<PostData[]> {
+    if (paths.length === 0) return [];
+    const result = await this.db
+      .select({
+        title: posts.title,
+        path: posts.path,
+        slug: posts.slug,
+        category: posts.category,
+        subcategory: posts.subcategory,
+        folders: posts.folders,
+        description: posts.description,
+      })
+      .from(posts)
+      .where(and(inArray(posts.path, paths), eq(posts.isActive, true)));
+    return result.map(p => ({ ...p, folders: p.folders || [] }));
   }
 
   async searchPosts(query: string, limit: number = 20): Promise<PostData[]> {

--- a/db/repositories/VisitRepository.ts
+++ b/db/repositories/VisitRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, inArray } from "drizzle-orm";
+import { eq, and, sql, inArray, desc } from "drizzle-orm";
 import { visitLogs, visitStats } from "../schema";
 import { BaseRepository } from "./BaseRepository";
 
@@ -114,6 +114,20 @@ export class VisitRepository extends BaseRepository {
     } catch {
       return {};
     }
+  }
+
+  /**
+   * 방문수 기준 인기 포스트 경로 목록 반환
+   */
+  async getPopularPostPaths(limit: number = 6): Promise<{ path: string; visitCount: number }[]> {
+    try {
+      const results = await this.db
+        .select({ pagePath: visitStats.pagePath, visitCount: visitStats.visitCount })
+        .from(visitStats)
+        .orderBy(desc(visitStats.visitCount))
+        .limit(limit);
+      return results.map(r => ({ path: r.pagePath, visitCount: r.visitCount }));
+    } catch { return []; }
   }
 
   /**

--- a/lib/sync-github.ts
+++ b/lib/sync-github.ts
@@ -2,7 +2,7 @@ import { Octokit } from "@octokit/rest";
 import { getDb as getDbInstance } from "@/db";
 import { posts, categories, syncLogs, folders } from "@/db/schema";
 import { eq, sql, desc } from "drizzle-orm";
-import { extractDescription } from "./markdown";
+import { extractDescription, extractTitle } from "./markdown";
 
 function getDb() {
   const db = getDbInstance();
@@ -203,7 +203,8 @@ async function upsertPost(filePath: string): Promise<"added" | "updated" | "skip
   ]);
   if (!fileData) return "skipped";
 
-  const { category, foldersList, subcategory, title } = parsePath(filePath);
+  const { category, foldersList, subcategory, title: filenameTitle } = parsePath(filePath);
+  const title = extractTitle(fileData.content) || filenameTitle;
   const description = extractDescription(fileData.content, 200);
 
   const existing = await database
@@ -359,7 +360,8 @@ async function performFullSync(): Promise<{
     ]);
     if (!fileData) continue;
 
-    const { title } = parsePath(file.path);
+    const { title: filenameTitle } = parsePath(file.path);
+    const title = extractTitle(fileData.content) || filenameTitle;
     const description = extractDescription(fileData.content, 200);
 
     if (existing) {


### PR DESCRIPTION
## Summary
- 홈 화면에 조회수 기반 인기글 섹션(상위 6개) 추가
- 데스크탑(lg 이상)에서 폴더 트리 사이드바 표시 (접이식, 현재 경로 하이라이트)
- GitHub 동기화 시 마크다운 `# h1` 태그에서 문서 제목 추출 (파일명 대신)

## Test plan
- [ ] 홈 화면에서 인기글 섹션이 조회수 순으로 표시되는지 확인
- [ ] 데스크탑에서 왼쪽 폴더 사이드바 표시, 모바일에서 숨김 확인
- [ ] 폴더 클릭 시 접기/펼치기 동작, 현재 페이지 하이라이트 확인
- [ ] GitHub 동기화 후 h1 제목이 DB에 저장되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)