### PR TITLE
feat: h1 제목 재적용 API

### DIFF
--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
-import { syncGitHubToDatabase } from "@/lib/sync-github";
+import { syncGitHubToDatabase, retitleExistingPosts } from "@/lib/sync-github";
 
 // 동기화 API - 수동 호출 또는 cron job에서 사용
+// ?retitle=true : GitHub 호출 없이 DB content에서 h1 제목 재추출
 export async function POST(request: Request) {
   // API 키 검증 (선택사항)
   const authHeader = request.headers.get("authorization");
@@ -11,7 +12,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const { searchParams } = new URL(request.url);
+  const retitle = searchParams.get("retitle") === "true";
+
   try {
+    if (retitle) {
+      const result = await retitleExistingPosts();
+      return NextResponse.json({
+        success: true,
+        message: `제목 재적용 완료: ${result.updated}개 업데이트`,
+        ...result,
+      });
+    }
+
     const result = await syncGitHubToDatabase();
 
     return NextResponse.json({

--- a/lib/sync-github.ts
+++ b/lib/sync-github.ts
@@ -565,3 +565,37 @@ export async function syncGitHubToDatabase(): Promise<{
     throw error;
   }
 }
+
+// DB에 저장된 content에서 h1 제목을 재추출하여 title 일괄 업데이트
+// GitHub API 호출 없이 로컬 DB만 사용
+export async function retitleExistingPosts(): Promise<{
+  total: number;
+  updated: number;
+  skipped: number;
+}> {
+  const database = getDb();
+
+  const allPosts = await database
+    .select({ path: posts.path, title: posts.title, content: posts.content })
+    .from(posts);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const post of allPosts) {
+    if (!post.content) { skipped++; continue; }
+
+    const extractedTitle = extractTitle(post.content);
+    if (!extractedTitle || extractedTitle === post.title) { skipped++; continue; }
+
+    await database
+      .update(posts)
+      .set({ title: extractedTitle })
+      .where(eq(posts.path, post.path));
+
+    updated++;
+    console.log(`제목 업데이트: ${post.path} → ${extractedTitle}`);
+  }
+
+  return { total: allPosts.length, updated, skipped };
+}


### PR DESCRIPTION
## Summary
- 헤더 `PanelLeft` 버튼으로 폴더 트리 Drawer 열기/닫기 (오버레이 방식)
- 폴더 트리에 문서 파일(leaf)도 함께 표시 — 폴더 + 파일 혼합 트리
- 백드롭 클릭 또는 페이지 이동 시 Drawer 자동 닫힘
- `POST /api/sync?retitle=true` — DB에 저장된 content에서 h1 재추출하여 기존 포스트 제목 일괄 업데이트 (GitHub API 호출 없음)

## Test plan
- [ ] 헤더 PanelLeft 버튼 클릭 시 왼쪽 Drawer 슬라이드 인/아웃 확인
- [ ] 폴더 접기/펼치기, 파일 링크(`/posts/...`) 이동 확인
- [ ] 백드롭 클릭 및 페이지 이동 시 Drawer 자동 닫힘 확인
- [ ] `POST /api/sync?retitle=true` 호출 후 기존 포스트 제목이 h1 기준으로 업데이트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)