### PR TITLE
fix: 라이트 모드에서 코드 블록 텍스트 색상 수정

### DIFF
--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -119,7 +119,7 @@ export function MarkdownRenderer({ content, basePath }: MarkdownRendererProps) {
     },
     pre: ({ children, ...props }) => (
       <pre
-        className="my-4 p-4 rounded-lg bg-gray-900 dark:bg-gray-800 overflow-x-auto text-sm border border-gray-700 dark:border-gray-700"
+        className="my-4 p-4 rounded-lg bg-gray-900 dark:bg-gray-800 text-gray-100 overflow-x-auto text-sm border border-gray-700 dark:border-gray-700"
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary
- 라이트 모드에서 코드 블록이 보이지 않는 문제 수정
- 원인: `bg-gray-900`(다크 배경)은 모드 무관하게 적용되지만 `prose-gray`가 라이트 모드에서 텍스트를 검정(`rgb(23,23,23)`)으로 상속 → 검정 배경 + 검정 글자
- 해결: `<pre>`에 `text-gray-100` 명시적으로 추가

## Test plan
- [ ] 라이트 모드에서 코드 블록 텍스트가 밝게 보이는지 확인
- [ ] 다크 모드에서 코드 블록 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)