### PR TITLE
fix: sync 시 AGENTS.md 제외 + 파일/제목 통합 동기화 및 응답 개선

### DIFF
--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { syncGitHubToDatabase, retitleExistingPosts } from "@/lib/sync-github";
 
 // 동기화 API - 수동 호출 또는 cron job에서 사용
-// ?retitle=true : GitHub 호출 없이 DB content에서 h1 제목 재추출
+// 파일 동기화 + 제목 재추출을 항상 함께 수행
 export async function POST(request: Request) {
   // API 키 검증 (선택사항)
   const authHeader = request.headers.get("authorization");
@@ -12,25 +12,24 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { searchParams } = new URL(request.url);
-  const retitle = searchParams.get("retitle") === "true";
-
   try {
-    if (retitle) {
-      const result = await retitleExistingPosts();
-      return NextResponse.json({
-        success: true,
-        message: `제목 재적용 완료: ${result.updated}개 업데이트`,
-        ...result,
-      });
-    }
-
-    const result = await syncGitHubToDatabase();
+    const syncResult = await syncGitHubToDatabase();
+    const retitleResult = await retitleExistingPosts();
 
     return NextResponse.json({
       success: true,
-      message: result.upToDate ? "Already up to date" : "Sync completed successfully",
-      ...result,
+      message: syncResult.upToDate ? "Already up to date" : "Sync completed successfully",
+      commitSha: syncResult.commitSha,
+      files: {
+        added: syncResult.added,
+        updated: syncResult.updated,
+        deleted: syncResult.deleted,
+      },
+      titles: {
+        updated: retitleResult.updated,
+        skipped: retitleResult.skipped,
+        total: retitleResult.total,
+      },
     });
   } catch (error) {
     console.error("Sync error:", error);

--- a/lib/sync-github.ts
+++ b/lib/sync-github.ts
@@ -192,6 +192,8 @@ function parsePath(filePath: string) {
 }
 
 function isMdFile(filename: string) {
+  const basename = filename.split("/").pop() ?? "";
+  if (basename.toUpperCase() === "AGENTS.MD") return false;
   return filename.endsWith(".md") || filename.endsWith(".mdx");
 }
 


### PR DESCRIPTION
## Summary
- `isMdFile()` 함수에서 `AGENTS.md`(대소문자 무관) 파일을 동기화 대상에서 제외
- sync 호출 시 파일 동기화와 제목 재추출(`retitleExistingPosts`)을 항상 함께 수행
- 응답에 파일 추가/수정/삭제 수, 반영된 커밋 해시, 제목 업데이트 수를 포함하도록 개선

### 응답 예시
\`\`\`json
{
  "success": true,
  "message": "Sync completed successfully",
  "commitSha": "abc1234...",
  "files": { "added": 2, "updated": 5, "deleted": 0 },
  "titles": { "updated": 3, "skipped": 160, "total": 163 }
}
\`\`\`

## Test plan
- [ ] sync API 호출 후 AGENTS.md 경로의 포스트가 DB에 생성되지 않는지 확인
- [ ] 일반 `.md` 파일은 정상 동기화되는지 확인
- [ ] 응답에 `files`, `titles`, `commitSha` 필드가 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)