### PR TITLE
fix: sync 시 AI 에이전트 컨텍스트 파일 제외 (AGENTS/CLAUDE/GEMINI/COPILOT/CURSOR 등)

### DIFF
--- a/lib/sync-github.ts
+++ b/lib/sync-github.ts
@@ -191,9 +191,20 @@ function parsePath(filePath: string) {
   return { category, foldersList, subcategory, title };
 }
 
+// AI 에이전트 컨텍스트 파일 — 블로그 포스트로 동기화하지 않음
+const EXCLUDED_FILENAMES = new Set([
+  "AGENTS.MD",
+  "CLAUDE.MD",
+  "GEMINI.MD",
+  "COPILOT.MD",
+  "CURSOR.MD",
+  "CODERABBIT.MD",
+  "CODY.MD",
+]);
+
 function isMdFile(filename: string) {
-  const basename = filename.split("/").pop() ?? "";
-  if (basename.toUpperCase() === "AGENTS.MD") return false;
+  const basename = (filename.split("/").pop() ?? "").toUpperCase();
+  if (EXCLUDED_FILENAMES.has(basename)) return false;
   return filename.endsWith(".md") || filename.endsWith(".mdx");
 }
 


### PR DESCRIPTION
## Summary
- `EXCLUDED_FILENAMES` Set을 도입하여 AI 에이전트 컨텍스트 파일을 동기화 대상에서 일괄 제외
- 제외 목록: `AGENTS.MD`, `CLAUDE.MD`, `GEMINI.MD`, `COPILOT.MD`, `CURSOR.MD`, `CODERABBIT.MD`, `CODY.MD`
- 파일명 비교는 대소문자 무관하게 처리 (`.toUpperCase()`)
- 전체 sync(`collectMarkdownFiles`)와 증분 sync(`performIncrementalSync`) 양쪽 모두 적용

## Test plan
- [ ] sync API 호출 후 CLAUDE.md, GEMINI.md 등이 DB에 포스트로 생성되지 않는지 확인
- [ ] 일반 `.md` 파일은 정상 동기화되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)