### PR TITLE
fix: sync 시 숨김 경로(.claude, .gemini 등) 파일 제외 및 테스트 추가

### DIFF
--- a/lib/sync-github.test.ts
+++ b/lib/sync-github.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { shouldSyncFile } from "./sync-github";
+
+describe("shouldSyncFile", () => {
+  // ===== 정상 동기화 대상 =====
+  it("일반 .md 파일은 동기화한다", () => {
+    expect(shouldSyncFile("javascript/closure.md")).toBe(true);
+  });
+
+  it("일반 .mdx 파일은 동기화한다", () => {
+    expect(shouldSyncFile("react/hooks.mdx")).toBe(true);
+  });
+
+  it("중첩 폴더의 .md 파일은 동기화한다", () => {
+    expect(shouldSyncFile("java/spring/boot/getting-started.md")).toBe(true);
+  });
+
+  it("루트 레벨 .md 파일은 동기화한다", () => {
+    expect(shouldSyncFile("intro.md")).toBe(true);
+  });
+
+  // ===== 확장자 필터 =====
+  it(".md / .mdx 이외 파일은 동기화하지 않는다", () => {
+    expect(shouldSyncFile("javascript/index.ts")).toBe(false);
+    expect(shouldSyncFile("README.txt")).toBe(false);
+    expect(shouldSyncFile("image.png")).toBe(false);
+  });
+
+  // ===== 숨김 경로 필터 (.으로 시작하는 폴더/파일) =====
+  it(".claude 폴더의 파일은 동기화하지 않는다", () => {
+    expect(shouldSyncFile(".claude/skills/deploy.md")).toBe(false);
+  });
+
+  it(".gemini 폴더의 파일은 동기화하지 않는다", () => {
+    expect(shouldSyncFile(".gemini/context.md")).toBe(false);
+  });
+
+  it(".github 폴더의 파일은 동기화하지 않는다", () => {
+    expect(shouldSyncFile(".github/PULL_REQUEST_TEMPLATE.md")).toBe(false);
+  });
+
+  it("중첩 경로 중간에 숨김 폴더가 있으면 동기화하지 않는다", () => {
+    expect(shouldSyncFile("docs/.hidden/note.md")).toBe(false);
+  });
+
+  it("숨김 파일(.으로 시작)은 동기화하지 않는다", () => {
+    expect(shouldSyncFile("docs/.secret.md")).toBe(false);
+  });
+
+  // ===== AI 에이전트 컨텍스트 파일 필터 =====
+  it("AGENTS.md는 동기화하지 않는다", () => {
+    expect(shouldSyncFile("AGENTS.md")).toBe(false);
+    expect(shouldSyncFile("java/AGENTS.md")).toBe(false);
+  });
+
+  it("CLAUDE.md는 동기화하지 않는다", () => {
+    expect(shouldSyncFile("CLAUDE.md")).toBe(false);
+    expect(shouldSyncFile("project/CLAUDE.md")).toBe(false);
+  });
+
+  it("GEMINI.md는 동기화하지 않는다", () => {
+    expect(shouldSyncFile("GEMINI.md")).toBe(false);
+  });
+
+  it("COPILOT.md는 동기화하지 않는다", () => {
+    expect(shouldSyncFile("COPILOT.md")).toBe(false);
+  });
+
+  it("CURSOR.md는 동기화하지 않는다", () => {
+    expect(shouldSyncFile("CURSOR.md")).toBe(false);
+  });
+
+  it("에이전트 컨텍스트 파일명은 대소문자 무관하게 필터링한다", () => {
+    expect(shouldSyncFile("agents.md")).toBe(false);
+    expect(shouldSyncFile("Agents.md")).toBe(false);
+    expect(shouldSyncFile("claude.md")).toBe(false);
+    expect(shouldSyncFile("Claude.MD")).toBe(false);
+  });
+});

--- a/lib/sync-github.ts
+++ b/lib/sync-github.ts
@@ -202,10 +202,23 @@ const EXCLUDED_FILENAMES = new Set([
   "CODY.MD",
 ]);
 
-function isMdFile(filename: string) {
-  const basename = (filename.split("/").pop() ?? "").toUpperCase();
+/**
+ * 주어진 파일 경로가 동기화 대상인지 판단한다.
+ * - .md / .mdx 확장자여야 함
+ * - 경로의 어느 세그먼트도 "."으로 시작하지 않아야 함 (.claude/, .gemini/ 등 제외)
+ * - AI 에이전트 컨텍스트 파일(AGENTS.MD, CLAUDE.MD 등)이 아니어야 함
+ */
+export function shouldSyncFile(filename: string): boolean {
+  if (!filename.endsWith(".md") && !filename.endsWith(".mdx")) return false;
+  const parts = filename.split("/");
+  if (parts.some((p) => p.startsWith("."))) return false;
+  const basename = (parts[parts.length - 1] ?? "").toUpperCase();
   if (EXCLUDED_FILENAMES.has(basename)) return false;
-  return filename.endsWith(".md") || filename.endsWith(".mdx");
+  return true;
+}
+
+function isMdFile(filename: string) {
+  return shouldSyncFile(filename);
 }
 
 async function upsertPost(filePath: string): Promise<"added" | "updated" | "skipped"> {


### PR DESCRIPTION
## Summary
- `.`으로 시작하는 경로 세그먼트가 있는 파일을 sync 대상에서 제외 (`.claude/`, `.gemini/`, `.github/` 등)
- `shouldSyncFile()` 함수로 로직을 분리하여 export — 전체/증분 sync 양쪽 적용
- 에이전트 컨텍스트 파일 필터(`AGENTS.md`, `CLAUDE.md` 등)도 동일 함수에 통합
- 16개 단위 테스트 추가로 동작 검증

## Test plan
- [x] `pnpm test` — 16개 통과
- [ ] sync API 호출 후 `.claude/` 하위 파일이 DB에 포스트로 생성되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)