### PR TITLE
feat: sync 시 상대경로 이미지를 GitHub raw URL로 변환

### DIFF
--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -7,6 +7,7 @@ import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import { Components } from "react-markdown";
 import "highlight.js/styles/github-dark.css";
+import Image from "next/image";
 import { Mermaid } from "./Mermaid";
 import { resolveMarkdownLink } from "@/lib/resolve-markdown-link";
 
@@ -156,13 +157,15 @@ export function MarkdownRenderer({ content, basePath }: MarkdownRendererProps) {
         {children}
       </td>
     ),
-    img: ({ src, alt, ...props }) => (
-      <img
-        src={src}
+    img: ({ src, alt }) => (
+      <Image
+        src={typeof src === "string" ? src : ""}
         alt={alt || ""}
+        width={0}
+        height={0}
+        sizes="100vw"
         className="my-4 rounded-lg shadow-lg max-w-full h-auto"
-        loading="lazy"
-        {...props}
+        style={{ width: "100%", height: "auto" }}
       />
     ),
     hr: ({ ...props }) => (

--- a/lib/sync-github.test.ts
+++ b/lib/sync-github.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldSyncFile } from "./sync-github";
+import { shouldSyncFile, rewriteImagePaths } from "./sync-github";
 
 describe("shouldSyncFile", () => {
   // ===== 정상 동기화 대상 =====
@@ -75,5 +75,78 @@ describe("shouldSyncFile", () => {
     expect(shouldSyncFile("Agents.md")).toBe(false);
     expect(shouldSyncFile("claude.md")).toBe(false);
     expect(shouldSyncFile("Claude.MD")).toBe(false);
+  });
+});
+
+describe("rewriteImagePaths", () => {
+  const BASE = "https://raw.githubusercontent.com/jon889/fos-study/main";
+
+  // ===== 마크다운 이미지 문법 =====
+  it("./images/ 상대경로를 GitHub raw URL로 변환한다", () => {
+    const content = "![alt](./images/foo.png)";
+    const result = rewriteImagePaths(content, "AI/RAG/storm-parse.md");
+    expect(result).toBe(`![alt](${BASE}/AI/RAG/images/foo.png)`);
+  });
+
+  it("images/ 접두사 없는 상대경로도 변환한다", () => {
+    const content = "![실록](fe-silok.png)";
+    const result = rewriteImagePaths(content, "AI/RAG/toss-parkssi.md");
+    expect(result).toBe(`![실록](${BASE}/AI/RAG/fe-silok.png)`);
+  });
+
+  it("../ 상위 디렉토리 상대경로를 올바르게 변환한다", () => {
+    const content = "![alt](../shared/banner.png)";
+    const result = rewriteImagePaths(content, "devops/k8s/pods.md");
+    expect(result).toBe(`![alt](${BASE}/devops/shared/banner.png)`);
+  });
+
+  it("루트 레벨 파일의 상대경로를 변환한다", () => {
+    const content = "![alt](./images/intro.png)";
+    const result = rewriteImagePaths(content, "intro.md");
+    expect(result).toBe(`![alt](${BASE}/images/intro.png)`);
+  });
+
+  it("이미 절대 URL인 이미지는 변환하지 않는다", () => {
+    const content = "![alt](https://example.com/image.png)";
+    const result = rewriteImagePaths(content, "AI/RAG/doc.md");
+    expect(result).toBe(content);
+  });
+
+  it("http:// URL도 변환하지 않는다", () => {
+    const content = "![alt](http://example.com/image.png)";
+    const result = rewriteImagePaths(content, "AI/RAG/doc.md");
+    expect(result).toBe(content);
+  });
+
+  it("이미지가 없는 콘텐츠는 그대로 반환한다", () => {
+    const content = "# 제목\n\n일반 텍스트입니다.";
+    const result = rewriteImagePaths(content, "java/spring.md");
+    expect(result).toBe(content);
+  });
+
+  it("본문에 여러 이미지가 있으면 모두 변환한다", () => {
+    const content = [
+      "![img1](./images/a.png)",
+      "텍스트",
+      "![img2](./images/b.webp)",
+    ].join("\n");
+    const result = rewriteImagePaths(content, "devops/k8s-in-action/pods.md");
+    expect(result).toContain(`${BASE}/devops/k8s-in-action/images/a.png`);
+    expect(result).toContain(`${BASE}/devops/k8s-in-action/images/b.webp`);
+  });
+
+  // ===== HTML img 태그 =====
+  it("HTML img 태그의 상대경로도 변환한다", () => {
+    const content = `<img src="./images/diagram.png" alt="diagram">`;
+    const result = rewriteImagePaths(content, "database/design/erd.md");
+    expect(result).toBe(
+      `<img src="${BASE}/database/design/images/diagram.png" alt="diagram">`
+    );
+  });
+
+  it("HTML img 태그의 절대 URL은 변환하지 않는다", () => {
+    const content = `<img src="https://example.com/img.png" alt="x">`;
+    const result = rewriteImagePaths(content, "database/design/erd.md");
+    expect(result).toBe(content);
   });
 });

--- a/lib/sync-github.ts
+++ b/lib/sync-github.ts
@@ -221,6 +221,38 @@ function isMdFile(filename: string) {
   return shouldSyncFile(filename);
 }
 
+/**
+ * 마크다운 content 내 상대경로 이미지를 GitHub raw URL로 변환한다.
+ * ./images/foo.png → https://raw.githubusercontent.com/OWNER/REPO/BRANCH/dir/images/foo.png
+ */
+export function rewriteImagePaths(content: string, filePath: string): string {
+  const dir = filePath.split("/").slice(0, -1).join("/");
+  const baseUrl = `https://raw.githubusercontent.com/${OWNER}/${REPO}/${BRANCH}`;
+
+  const resolve = (relativePath: string): string => {
+    const parts = dir ? dir.split("/") : [];
+    for (const part of relativePath.split("/")) {
+      if (part === "..") parts.pop();
+      else if (part !== ".") parts.push(part);
+    }
+    return `${baseUrl}/${parts.join("/")}`;
+  };
+
+  // ![alt](relative/path)
+  let result = content.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, src) => {
+    if (src.startsWith("http://") || src.startsWith("https://")) return match;
+    return `![${alt}](${resolve(src)})`;
+  });
+
+  // <img src="relative/path">
+  result = result.replace(/<img([^>]+)src="([^"]+)"/g, (match, attrs, src) => {
+    if (src.startsWith("http://") || src.startsWith("https://")) return match;
+    return `<img${attrs}src="${resolve(src)}"`;
+  });
+
+  return result;
+}
+
 async function upsertPost(filePath: string): Promise<"added" | "updated" | "skipped"> {
   const database = getDb();
   const [fileData, commitDates] = await Promise.all([
@@ -230,8 +262,9 @@ async function upsertPost(filePath: string): Promise<"added" | "updated" | "skip
   if (!fileData) return "skipped";
 
   const { category, foldersList, subcategory, title: filenameTitle } = parsePath(filePath);
-  const title = extractTitle(fileData.content) || filenameTitle;
-  const description = extractDescription(fileData.content, 200);
+  const content = rewriteImagePaths(fileData.content, filePath);
+  const title = extractTitle(content) || filenameTitle;
+  const description = extractDescription(content, 200);
 
   const existing = await database
     .select({ id: posts.id })
@@ -244,7 +277,7 @@ async function upsertPost(filePath: string): Promise<"added" | "updated" | "skip
       .update(posts)
       .set({
         title,
-        content: fileData.content,
+        content,
         description,
         sha: fileData.sha,
         category,
@@ -263,7 +296,7 @@ async function upsertPost(filePath: string): Promise<"added" | "updated" | "skip
       category,
       subcategory,
       folders: foldersList,
-      content: fileData.content,
+      content,
       description,
       sha: fileData.sha,
       ...(commitDates && {
@@ -387,15 +420,16 @@ async function performFullSync(): Promise<{
     if (!fileData) continue;
 
     const { title: filenameTitle } = parsePath(file.path);
-    const title = extractTitle(fileData.content) || filenameTitle;
-    const description = extractDescription(fileData.content, 200);
+    const content = rewriteImagePaths(fileData.content, file.path);
+    const title = extractTitle(content) || filenameTitle;
+    const description = extractDescription(content, 200);
 
     if (existing) {
       await database
         .update(posts)
         .set({
           title,
-          content: fileData.content,
+          content,
           description,
           sha: fileData.sha,
           category: file.category,
@@ -415,7 +449,7 @@ async function performFullSync(): Promise<{
         category: file.category,
         subcategory: file.subcategory,
         folders: file.folders,
-        content: fileData.content,
+        content,
         description,
         sha: fileData.sha,
         ...(commitDates && {


### PR DESCRIPTION
## Summary
- `lib/sync-github.ts`에 `rewriteImagePaths()` 함수 추가 — 마크다운 content를 DB에 저장하기 전에 `./images/foo.png` 같은 상대경로를 `https://raw.githubusercontent.com/jon891/fos-study/main/...` 형태의 절대 URL로 변환
- `upsertPost`, `performFullSync` 두 곳 모두 content 저장 전에 변환 적용
- `components/MarkdownRenderer.tsx`의 `<img>` 태그를 `next/image`로 교체 (이미 `next.config.js`에 `raw.githubusercontent.com` remotePattern 등록되어 있음)

## Test plan
- [ ] sync API 호출 후 이미지가 있는 포스트에서 이미지가 정상 렌더링되는지 확인
- [ ] `./images/`, `../images/` 등 다양한 상대경로 패턴이 올바르게 변환되는지 확인
- [ ] 이미 절대 URL인 이미지는 변환 없이 그대로 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)