### PR TITLE
feat: CLAUDE.md 추가 및 PR 자동 코드 리뷰 Action 설정

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,15 +1,15 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-03-30 -->
 
 # .github
 
 ## Purpose
-GitHub-specific configuration. Contains GitHub Actions CI/CD workflow definitions.
+GitHub-specific configuration. Contains GitHub Actions CI/CD workflow definitions and automated code review.
 
 ## Subdirectories
 
 | Directory | Purpose |
 |-----------|---------|
-| `workflows/` | CI (lint/test/build) and deploy (Docker → GHCR) pipelines — see `workflows/AGENTS.md` |
+| `workflows/` | CI (lint/test/build), deploy (Docker → GHCR), PR 자동 코드 리뷰 pipelines — see `workflows/AGENTS.md` |
 
 <!-- MANUAL: -->

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-03-30 -->
 
 # .github/workflows
 
@@ -12,6 +12,8 @@ GitHub Actions CI/CD pipelines — lint/test/build on every push/PR, and Docker 
 |------|-------------|
 | `ci.yml` | `CI` — runs on push/PR to main: `pnpm lint` → `pnpm type-check` → `pnpm test` → `pnpm build` (Node 22) |
 | `deploy.yml` | `Build and Push to GHCR` — builds Docker image and pushes to `ghcr.io/<owner>/<repo>` with semantic version tags |
+| `claude-code-review.yml` | `Claude Code Review` — PR 오픈/업데이트 시 TypeScript·컨벤션·보안·아키텍처 4개 병렬 에이전트가 코드 리뷰 후 인라인 코멘트와 요약 코멘트 게시 (`CLAUDE_CODE_OAUTH_TOKEN` secret 필요) |
+| `lighthouse.yml` | Lighthouse CI — 성능/접근성/SEO 점수 측정 |
 
 ## For AI Agents
 
@@ -20,6 +22,7 @@ GitHub Actions CI/CD pipelines — lint/test/build on every push/PR, and Docker 
 - `deploy.yml` tags images with: branch name, PR ref, semver `{{version}}`, `{{major}}.{{minor}}`, commit SHA, and `latest` (on default branch)
 - Both workflows use `pnpm/action-setup@v4` + `actions/setup-node@v4` with pnpm cache
 - To add a new workflow step, ensure secrets are declared in GitHub repo settings first
+- `claude-code-review.yml`은 `CLAUDE_CODE_OAUTH_TOKEN` secret이 없으면 동작하지 않음 — repo Settings → Secrets에 등록 필요
 
 ### Common Patterns
 ```yaml
@@ -37,5 +40,6 @@ gh workflow run deploy.yml
 ### External
 - `GH_PAT` — GitHub Personal Access Token (repo secret)
 - `GITHUB_TOKEN` — auto-provided by GitHub Actions for GHCR push
+- `CLAUDE_CODE_OAUTH_TOKEN` — Claude Code OAuth 토큰 (`claude-code-review.yml` 전용)
 
 <!-- MANUAL: -->

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,332 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    # 같은 PR에 대해 동시에 실행 중인 이전 리뷰 run을 취소하여 중복 코멘트 방지
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Dismiss old Claude bot comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # 이전 일반 코멘트 숨기기
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "claude[bot]") | .node_id' \
+            | while read -r comment_node_id; do
+              if [ -n "$comment_node_id" ]; then
+                echo "Hiding outdated Claude comment: $comment_node_id"
+                gh api graphql -f query='
+                  mutation($id: ID!) {
+                    minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                      minimizedComment {
+                        isMinimized
+                      }
+                    }
+                  }' -f id="$comment_node_id"
+              fi
+            done
+
+      - name: Run Claude Code Review (Parallel Agents + Inline Review)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "*"
+          prompt: |
+            You are a code review orchestrator for the fos-blog project (Next.js 16 App Router blog, TypeScript, MySQL + Drizzle ORM, Tailwind CSS).
+            Your job is to coordinate 4 parallel specialist reviewers, then:
+            1. Post inline review comments on specific changed lines via GitHub's review API
+            2. Post one general summary comment with all findings
+
+            ## Step 1: Fetch PR Data
+
+            Run these two commands first:
+            ```
+            gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+            gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+            ```
+
+            ## Step 2: Spawn 4 Parallel Specialist Agents
+
+            Launch all 4 agents simultaneously using the Agent tool.
+            Pass the full diff content in each agent's prompt so they can work independently.
+
+            Each agent MUST format their findings using this EXACT structure (parse-friendly):
+
+            ```
+            FINDING_START
+            TYPE: INLINE
+            SEVERITY: 🔴
+            PATH: lib/sync-github.ts
+            LINE: 42
+            ISSUE: 문제 설명 (한국어)
+            FIX: 수정 제안 (한국어)
+            FINDING_END
+
+            FINDING_START
+            TYPE: GENERAL
+            SEVERITY: 🟡
+            ISSUE: 특정 라인을 꼬집기 어려운 일반적인 문제 (한국어)
+            FIX: 수정 제안 (한국어)
+            FINDING_END
+            ```
+
+            Rules for TYPE selection:
+            - Use `TYPE: INLINE` only when you can identify the EXACT file path and line number from the diff
+            - PATH must be a relative path matching the diff (e.g., `lib/sync-github.ts`)
+            - LINE must be the actual line number in the NEW file (right side of diff, lines starting with `+` or context)
+            - Use `TYPE: GENERAL` for findings that span multiple files or cannot be pinpointed to one line
+            - If no issues found at all, output: `NO_ISSUES`
+
+            ---
+
+            **Agent 1 — TypeScript & Type Safety**
+
+            Prompt template:
+            ```
+            You are a TypeScript specialist reviewer. Analyze this PR diff for type safety issues only.
+
+            PR DIFF:
+            <insert full diff here>
+
+            Check for:
+            - `any` type usage (explicit or implicit)
+            - Non-nullable types that could be null/undefined at runtime (optional chaining missing)
+            - Type assertions (`as X`) that bypass safety
+            - Incorrect return types on async functions or API route handlers
+            - Type definitions that don't match actual data shape (e.g., Drizzle schema vs usage)
+
+            Output each finding using EXACTLY this format:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE only — must match diff path exactly)
+            LINE: 42  (INLINE only — exact line number in the new file)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            If no issues found, output: NO_ISSUES
+            ```
+
+            ---
+
+            **Agent 2 — Project Conventions**
+
+            Prompt template:
+            ```
+            You are a code convention specialist. Analyze this PR diff for convention violations only.
+
+            PR DIFF:
+            <insert full diff here>
+
+            Project rules:
+            🔴 MUST FIX:
+            - `console.log` in production code (console.error/warn for error logging is OK)
+            - GitHub sync 관련 함수에서 환경변수(GITHUB_TOKEN, DATABASE_URL 등)를 직접 하드코딩
+            - shouldSyncFile 우회: .md/.mdx 이외 파일을 DB에 저장하는 코드
+            - 마크다운 content를 DB 저장 전에 rewriteImagePaths를 거치지 않고 저장
+
+            🟡 SHOULD FIX:
+            - `console.error` left in client components
+            - Inline `style={{ }}` when a Tailwind class can be used instead
+            - Magic numbers/strings that should be constants
+            - 테스트 없이 추가된 순수 유틸 함수 (lib/ 하위)
+
+            Output each finding using EXACTLY this format:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE only — must match diff path exactly)
+            LINE: 42  (INLINE only — exact line number in the new file)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            If no issues found, output: NO_ISSUES
+            ```
+
+            ---
+
+            **Agent 3 — Security**
+
+            Prompt template:
+            ```
+            You are a security specialist. Analyze this PR diff for security issues only.
+
+            PR DIFF:
+            <insert full diff here>
+
+            Check for:
+            🔴 MUST FIX:
+            - Sync API endpoint(/api/sync) missing secret token validation (should verify SYNC_SECRET env var)
+            - Environment variables without NEXT_PUBLIC_ prefix used in client components (exposes secrets)
+            - Unvalidated external input passed directly to database queries
+            - GitHub API token or database credentials exposed in logs or responses
+
+            🟡 SHOULD FIX:
+            - Missing input sanitization for markdown content before rendering
+            - Sensitive data (tokens, keys) logged to console
+            - Rate limiting missing on public API routes
+
+            Output each finding using EXACTLY this format:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE only — must match diff path exactly)
+            LINE: 42  (INLINE only — exact line number in the new file)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            If no issues found, output: NO_ISSUES
+            ```
+
+            ---
+
+            **Agent 4 — Architecture & Next.js Patterns**
+
+            Prompt template:
+            ```
+            You are a Next.js architecture specialist. Analyze this PR diff for architectural issues only.
+
+            PR DIFF:
+            <insert full diff here>
+
+            This project uses Next.js 16 App Router. Check for:
+            🔴 MUST FIX:
+            - React hooks (useState, useEffect, useRouter, etc.) used in Server Components (missing "use client")
+            - Server-only code (database access, GitHub token usage) in Client Components
+            - "use client" or "use server" directive not at the very first line of the file
+
+            🟡 SHOULD FIX:
+            - Unnecessary "use client" on components with no hooks or event handlers (should be Server Component)
+            - Data fetching in Client Components that could be done in Server Components
+            - GitHub sync logic mixed into route handlers instead of lib/ functions
+            - Missing error handling in API routes (unhandled promise rejections)
+            - Drizzle ORM queries without error handling in sync functions
+
+            Output each finding using EXACTLY this format:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE only — must match diff path exactly)
+            LINE: 42  (INLINE only — exact line number in the new file)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            If no issues found, output: NO_ISSUES
+            ```
+
+            ## Step 3: Post Inline Review Comments
+
+            After all 4 agents complete, collect and deduplicate all FINDING_START/FINDING_END blocks.
+
+            For all `TYPE: INLINE` findings, build a single GitHub PR review with inline comments.
+
+            Construct the JSON and run this command (replace the comments array with the actual parsed findings):
+
+            ```bash
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+              --method POST \
+              --header "Content-Type: application/json" \
+              --input - <<'REVIEW_EOF'
+            {
+              "event": "COMMENT",
+              "comments": [
+                {
+                  "path": "lib/sync-github.ts",
+                  "line": 42,
+                  "side": "RIGHT",
+                  "body": "🔴 **문제**: ...\n\n**수정**: ..."
+                }
+              ]
+            }
+            REVIEW_EOF
+            ```
+
+            Format each inline comment body as:
+            `{SEVERITY} **문제**: {ISSUE}\n\n**수정**: {FIX}`
+
+            Important rules:
+            - `path` must be a relative path exactly matching the diff (do NOT add leading `/`)
+            - `line` must be a number that appears in the diff for that file — if unsure, treat as GENERAL instead
+            - `side` is always `"RIGHT"` (new file side)
+            - If there are NO inline findings, skip this step entirely
+            - If the `gh api` call fails (e.g., 422 invalid line), log the error and continue to Step 4 without retrying
+
+            ## Step 4: Post General Summary Comment
+
+            Post exactly ONE general summary comment containing ALL findings (both INLINE and GENERAL):
+
+            ```
+            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "..."
+            ```
+
+            ## Summary Comment Format
+
+            Write in Korean. Use this exact structure:
+
+            ```
+            ## 코드 리뷰 [PR 제목 요약]
+
+            [한 줄 전체 평가]
+
+            ---
+
+            ### 🔴 머지 전 필수 수정 (있는 경우만)
+
+            **파일명 라인번호**
+            문제: ...
+            수정: ...
+
+            ### 🟡 개선 권장 (있는 경우만)
+
+            **파일명 라인번호**
+            문제: ...
+            수정: ...
+
+            ### 🟢 잘 된 점
+
+            - ...
+
+            ---
+            🤖 Reviewed with [Claude Code](https://claude.com/claude-code) (parallel agents: TypeScript · Conventions · Security · Architecture)
+            💬 인라인 코멘트는 **Files changed** 탭에서 확인하세요
+            ```
+
+            ## Critical Rules
+
+            - **DO NOT post test comments** — this is a real production review
+            - **Post exactly ONE general comment** (Step 4) — do not call `gh pr comment` more than once
+            - **Inline review (Step 3) and general comment (Step 4) are separate** — always post both if there are findings
+            - **Only include sections that have content** — omit empty 🔴 or 🟡 sections entirely
+            - **Be specific** — reference exact file names and line numbers
+            - **If zero issues found**, skip Step 3 and write a short positive review with 🟢 section only in Step 4
+
+          claude_args: '--allowedTools "Agent,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*)" --disallowedTools "Read,Write,Edit,Glob,Grep,LS"'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Generated: 2026-03-17 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-17 | Updated: 2026-03-30 -->
 
 # fos-blog
 
@@ -120,11 +120,12 @@ pnpm db:down      # Stop MySQL container
 
 ## Subdirectories
 
-| Directory     | Purpose                                                                                                |
-| ------------- | ------------------------------------------------------------------------------------------------------ |
-| `proxy.ts`    | Next.js middleware — records page visits to DB via `waitUntil` (fire-and-forget); runs on Edge Runtime |
-| `app/`        | Next.js pages and API routes (see `app/AGENTS.md`)                                                     |
-| `components/` | Reusable React UI components (see `components/AGENTS.md`)                                              |
-| `db/`         | Database schema and repositories (see `db/AGENTS.md`)                                                  |
-| `lib/`        | Shared utilities and GitHub sync (see `lib/AGENTS.md`)                                                 |
-| `docker/`     | Docker MySQL config (see `docker/AGENTS.md`)                                                           |
+| Directory / File | Purpose                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `CLAUDE.md`      | AI 에이전트용 프로젝트 컨텍스트 문서 — 기술 스택, 디렉토리 구조, 컨벤션, 환경변수 상세 정리          |
+| `proxy.ts`       | Next.js middleware — records page visits to DB via `waitUntil` (fire-and-forget); runs on Edge Runtime |
+| `app/`           | Next.js pages and API routes (see `app/AGENTS.md`)                                                     |
+| `components/`    | Reusable React UI components (see `components/AGENTS.md`)                                              |
+| `db/`            | Database schema and repositories (see `db/AGENTS.md`)                                                  |
+| `lib/`           | Shared utilities and GitHub sync (see `lib/AGENTS.md`)                                                 |
+| `docker/`        | Docker MySQL config (see `docker/AGENTS.md`)                                                           |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,53 +8,57 @@
 
 ### Key Features
 
-*   **GitHub Sync:** Fetches Markdown files from a remote repository via GitHub API.
-*   **Database Caching:** Caches content in a MySQL database using Drizzle ORM for faster access and search.
-*   **Categorization:** Automatically categorizes posts based on the directory structure of the source repository.
-*   **Markdown Rendering:** Renders GFM (GitHub Flavored Markdown) with syntax highlighting (highlight.js github-dark theme) and Mermaid diagram support.
-*   **Comments:** Per-post comment system stored in MySQL.
-*   **Visit Tracking:** Records and aggregates post view counts.
-*   **Responsive Design:** Built with Tailwind CSS v4 and fully responsive.
-*   **Dark/Light Mode:** Integrated theme switching (defaults to dark).
+- **GitHub Sync:** Fetches Markdown files from a remote repository via GitHub API.
+- **Database Caching:** Caches content in a MySQL database using Drizzle ORM for faster access and search.
+- **Categorization:** Automatically categorizes posts based on the directory structure of the source repository.
+- **Markdown Rendering:** Renders GFM (GitHub Flavored Markdown) with syntax highlighting (highlight.js github-dark theme) and Mermaid diagram support.
+- **Comments:** Per-post comment system stored in MySQL.
+- **Visit Tracking:** Records and aggregates post view counts.
+- **Responsive Design:** Built with Tailwind CSS v4 and fully responsive.
+- **Dark/Light Mode:** Integrated theme switching (defaults to dark).
 
 ### Tech Stack
 
-*   **Framework:** Next.js 16 (App Router, Turbopack)
-*   **Language:** TypeScript
-*   **Styling:** Tailwind CSS v4 + `@tailwindcss/typography`
-*   **Database:** MySQL 8.4 (running via Docker)
-*   **ORM:** Drizzle ORM
-*   **GitHub Integration:** Octokit
-*   **Package Manager:** pnpm
+- **Framework:** Next.js 16 (App Router, Turbopack)
+- **Language:** TypeScript
+- **Styling:** Tailwind CSS v4 + `@tailwindcss/typography`
+- **Database:** MySQL 8.4 (running via Docker)
+- **ORM:** Drizzle ORM
+- **GitHub Integration:** Octokit
+- **Package Manager:** pnpm
 
 ## Building and Running
 
 ### Prerequisites
 
-*   Node.js (v20+ recommended, see `.tool-versions`)
-*   pnpm
-*   Docker & Docker Compose (for the database)
+- Node.js (v20+ recommended, see `.tool-versions`)
+- pnpm
+- Docker & Docker Compose (for the database)
 
 ### Initial Setup
 
 1.  **Install dependencies:**
+
     ```bash
     pnpm install
     ```
 
 2.  **Environment Configuration:**
     Copy `.env.example` to `.env` and configure:
+
     ```bash
     cp .env.example .env
     ```
+
     Required variables:
-    *   `GITHUB_TOKEN`: GitHub Personal Access Token
-    *   `GITHUB_OWNER`: Owner of the content repo (default: `jon890`)
-    *   `GITHUB_REPO`: Name of the content repo (default: `fos-study`)
-    *   `DATABASE_URL`: Connection string for MySQL (e.g., `mysql://fos_user:fos_password@localhost:13307/fos_blog`)
-    *   `SYNC_API_KEY`: API key to protect the `/api/sync` endpoint
+    - `GITHUB_TOKEN`: GitHub Personal Access Token
+    - `GITHUB_OWNER`: Owner of the content repo (default: `jon890`)
+    - `GITHUB_REPO`: Name of the content repo (default: `fos-study`)
+    - `DATABASE_URL`: Connection string for MySQL (e.g., `mysql://fos_user:fos_password@localhost:13307/fos_blog`)
+    - `SYNC_API_KEY`: API key to protect the `/api/sync` endpoint
 
 3.  **Start Database:**
+
     ```bash
     docker compose up -d
     # or
@@ -62,6 +66,7 @@
     ```
 
 4.  **Database Migration:**
+
     ```bash
     pnpm db:push
     ```
@@ -91,35 +96,35 @@ pnpm db:down      # Stop MySQL container
 
 ## Project Structure
 
-*   `app/`: Next.js App Router pages, layouts, and API routes.
-    *   `api/comments/`: Comment CRUD API
-    *   `api/search/`: Full-text post search API
-    *   `api/sync/`: GitHub→DB sync trigger API
-    *   `api/visit/`: Post view count tracking API
-    *   `categories/`, `category/`, `posts/`: Page routes
-    *   `globals.css`: Global Tailwind CSS — **must include `@source` for both `app/` and `components/`**
-*   `components/`: Reusable React components (MarkdownRenderer, TableOfContents, Comments, etc.).
-*   `db/`: Database layer — Drizzle connection, schema definitions (`db/schema/`), and repository classes (`db/repositories/`).
-*   `drizzle/`: Drizzle migration artifacts (auto-generated, do not edit).
-*   `lib/`: Utility functions — GitHub API client, markdown processing, sync orchestration.
-*   `docker/`: MySQL Docker initialization scripts.
-*   `public/`: Static assets.
+- `app/`: Next.js App Router pages, layouts, and API routes.
+  - `api/comments/`: Comment CRUD API
+  - `api/search/`: Full-text post search API
+  - `api/sync/`: GitHub→DB sync trigger API
+  - `api/visit/`: Post view count tracking API
+  - `categories/`, `category/`, `posts/`: Page routes
+  - `globals.css`: Global Tailwind CSS — **must include `@source` for both `app/` and `components/`**
+- `components/`: Reusable React components (MarkdownRenderer, TableOfContents, Comments, etc.).
+- `db/`: Database layer — Drizzle connection, schema definitions (`db/schema/`), and repository classes (`db/repositories/`).
+- `drizzle/`: Drizzle migration artifacts (auto-generated, do not edit).
+- `lib/`: Utility functions — GitHub API client, markdown processing, sync orchestration.
+- `docker/`: MySQL Docker initialization scripts.
+- `public/`: Static assets.
 
 ## Development Conventions
 
-*   **Routing:** Next.js App Router file-system based routing.
-*   **Data Fetching:** Server-side fetching preferred. Content served from MySQL, populated via sync.
-*   **Styling:** Utility-first CSS using Tailwind v4. **Important:** `app/globals.css` must have `@source` directives for all directories containing Tailwind classes (currently `app/` and `components/`).
-*   **Type Safety:** Strict TypeScript. Drizzle schema provides type inference.
-*   **Content Updates:** Modify source files in `jon890/fos-study` GitHub repo, then trigger `/api/sync`.
+- **Routing:** Next.js App Router file-system based routing.
+- **Data Fetching:** Server-side fetching preferred. Content served from MySQL, populated via sync.
+- **Styling:** Utility-first CSS using Tailwind v4. **Important:** `app/globals.css` must have `@source` directives for all directories containing Tailwind classes (currently `app/` and `components/`).
+- **Type Safety:** Strict TypeScript. Drizzle schema provides type inference.
+- **Content Updates:** Modify source files in `jon890/fos-study` GitHub repo, then trigger `/api/sync`.
 
 ## Subdirectories
 
-| Directory | Purpose |
-|-----------|---------|
-| `proxy.ts` | Next.js middleware — records page visits to DB via `waitUntil` (fire-and-forget); runs on Edge Runtime |
-| `app/` | Next.js pages and API routes (see `app/AGENTS.md`) |
-| `components/` | Reusable React UI components (see `components/AGENTS.md`) |
-| `db/` | Database schema and repositories (see `db/AGENTS.md`) |
-| `lib/` | Shared utilities and GitHub sync (see `lib/AGENTS.md`) |
-| `docker/` | Docker MySQL config (see `docker/AGENTS.md`) |
+| Directory     | Purpose                                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------------------ |
+| `proxy.ts`    | Next.js middleware — records page visits to DB via `waitUntil` (fire-and-forget); runs on Edge Runtime |
+| `app/`        | Next.js pages and API routes (see `app/AGENTS.md`)                                                     |
+| `components/` | Reusable React UI components (see `components/AGENTS.md`)                                              |
+| `db/`         | Database schema and repositories (see `db/AGENTS.md`)                                                  |
+| `lib/`        | Shared utilities and GitHub sync (see `lib/AGENTS.md`)                                                 |
+| `docker/`     | Docker MySQL config (see `docker/AGENTS.md`)                                                           |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,7 @@ fos-blog/
 │       ├── commentRepository.ts
 │       └── ...
 ├── lib/                          # Shared utilities
-│   ├── github.ts                 # GitHub API client + utilities
-│   ├── sync-github.ts            # Core sync logic (fetch + cache + reconciliation)
+│   ├── sync-github.ts            # GitHub API client + core sync logic (fetch + cache + reconciliation)
 │   ├── markdown.ts               # Markdown parsing (frontmatter, title, TOC)
 │   ├── resolve-markdown-link.ts  # Markdown link resolver (GitHub → blog URLs)
 │   ├── markdown.test.ts          # Unit tests for markdown utilities
@@ -263,15 +262,15 @@ NEXT_PUBLIC_GOOGLE_ADSENSE_ID=ca-pub-xxx               # Google AdSense
 
 - `id` (INT): Primary key
 - `commitSha` (VARCHAR): GitHub commit SHA
-- `filesAdded`, `filesUpdated`, `filesDeleted` (INT): Change counts
+- `postsAdded`, `postsUpdated`, `postsDeleted` (INT): Change counts
 - `createdAt` (TIMESTAMP)
 
-**folders** — Category/folder hierarchy (optional)
+**folders** — Directory nodes with optional README content
 
 - `id` (INT): Primary key
-- `name` (VARCHAR): Folder name
-- `path` (VARCHAR): Full path
-- `parentId` (INT): Parent folder (for nesting)
+- `path` (VARCHAR): Full folder path, unique (e.g. `AI/RAG`)
+- `readme` (TEXT): README.md content if present
+- `sha` (VARCHAR 64): GitHub SHA for change detection
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,545 @@
+# fos-blog — Claude Code Project Context
+
+**Generated:** 2026-03-29  
+**Project:** FOS Study Blog  
+**Repository:** github.com/jon890/fos-blog
+
+---
+
+## Executive Summary
+
+`fos-blog` is a Next.js 16 developer blog that automatically synchronizes Markdown content from a remote GitHub repository (`jon890/fos-study`), caches it in MySQL via Drizzle ORM, and renders it with full Markdown/GFM support. The blog features categorization, dark/light mode, visit tracking, comments, and ISR caching.
+
+---
+
+## Tech Stack
+
+### Core Framework & Runtime
+
+- **Node.js:** 22.18.0 (via `.tool-versions`)
+- **Framework:** Next.js 16.1.6 (App Router + Turbopack)
+- **Language:** TypeScript 5.7 (strict mode enabled)
+- **Package Manager:** pnpm 9.15.0 (pinned in `package.json`)
+
+### UI & Styling
+
+- **React:** 19.2.0
+- **Styling:** Tailwind CSS 4.0 + `@tailwindcss/typography`
+- **Icons:** lucide-react 0.469.0
+- **Fonts:** Google Fonts (Noto Sans KR + JetBrains Mono)
+- **Theme Management:** next-themes 0.4.4
+
+### Markdown & Content Rendering
+
+- **Markdown Parser:** react-markdown 9.0.1
+- **Markdown Plugins:**
+  - remark-gfm 4.0.0 (GitHub Flavored Markdown)
+  - rehype-highlight 7.0.0 (syntax highlighting)
+  - rehype-raw 7.0.0 (raw HTML passthrough)
+  - rehype-slug 6.0.0 (auto heading slugs)
+- **Syntax Highlighting:** highlight.js 11.11.1 (github-dark theme)
+- **Diagrams:** mermaid 11.12.2
+
+### Database & ORM
+
+- **Database:** MySQL 8.4 (running via Docker Compose)
+- **ORM:** Drizzle ORM 0.45.1
+- **Migration Tool:** drizzle-kit 0.31.8
+- **Driver:** mysql2 3.16.2
+
+### GitHub Integration
+
+- **API Client:** @octokit/rest 21.0.0
+
+### Security & Auth
+
+- **Password Hashing:** bcryptjs 3.0.3
+
+### Dev Tools
+
+- **Linter:** ESLint 9.17.0 + TypeScript ESLint
+- **Type Checker:** tsc (via `pnpm type-check`)
+- **Test Runner:** Vitest 4.1.0
+- **Type Definitions:** @types/react 19.0, @types/node 22.10.0
+- **Build Transpiler:** tsx 4.21.0
+- **Environment Manager:** dotenv 17.2.3
+
+### Development Dependencies
+
+- ESLint plugins: react, react-hooks
+- ESLint config: eslint-config-next, @eslint/js, typescript-eslint
+- Post-CSS: @tailwindcss/postcss 4.0.0
+
+---
+
+## Directory Structure
+
+```
+fos-blog/
+├── app/                          # Next.js App Router pages and API routes
+│   ├── layout.tsx                # Root layout (metadata, fonts, providers)
+│   ├── page.tsx                  # Home page
+│   ├── globals.css               # Global Tailwind CSS (MUST include @source directives)
+│   ├── api/
+│   │   ├── comments/             # Comment CRUD endpoints
+│   │   ├── search/               # Full-text post search API
+│   │   ├── sync/                 # GitHub→DB sync trigger (POST /api/sync)
+│   │   └── visit/                # Post view count tracking
+│   ├── categories/               # /categories route (all categories list)
+│   ├── category/[category]/      # /category/[category] (posts in category)
+│   ├── posts/[...slug]/          # /posts/[...slug] (post detail page)
+│   ├── ads.txt                   # Google AdSense configuration
+│   └── components/               # App-specific components (sidebar, etc.)
+├── components/                   # Reusable React UI components
+│   ├── Header.tsx
+│   ├── PostCard.tsx
+│   ├── CategoryCard.tsx
+│   ├── MarkdownRenderer.tsx
+│   ├── ThemeToggle.tsx
+│   ├── ThemeProvider.tsx
+│   ├── Comments.tsx
+│   ├── TableOfContents.tsx
+│   ├── SidebarContext.tsx        # Context for folder sidebar state
+│   └── ...
+├── db/                           # Database layer
+│   ├── index.ts                  # Drizzle connection (neon, mysql, etc.)
+│   ├── schema/                   # Drizzle schema definitions
+│   │   ├── posts.ts              # Posts table + types
+│   │   ├── comments.ts           # Comments table + types
+│   │   ├── visitStats.ts         # Visit tracking table
+│   │   ├── folders.ts            # Folder/category hierarchy
+│   │   └── syncLogs.ts           # Sync operation logs
+│   └── repositories/             # Data access layer (repository pattern)
+│       ├── postRepository.ts
+│       ├── commentRepository.ts
+│       └── ...
+├── lib/                          # Shared utilities
+│   ├── github.ts                 # GitHub API client + utilities
+│   ├── sync-github.ts            # Core sync logic (fetch + cache + reconciliation)
+│   ├── markdown.ts               # Markdown parsing (frontmatter, title, TOC)
+│   ├── resolve-markdown-link.ts  # Markdown link resolver (GitHub → blog URLs)
+│   ├── markdown.test.ts          # Unit tests for markdown utilities
+│   ├── sync-github.test.ts       # Unit tests for sync logic
+│   └── resolve-markdown-link.test.ts
+├── docker/                       # Docker configuration
+│   └── mysql/
+│       └── init.sql              # MySQL initialization script
+├── drizzle/                      # Drizzle migration artifacts (auto-generated)
+├── public/                       # Static assets
+├── proxy.ts                      # Next.js middleware (records page visits via waitUntil)
+├── next.config.js                # Next.js config (output: standalone, image patterns)
+├── drizzle.config.ts             # Drizzle config (MySQL dialect, ./db/schema path)
+├── tsconfig.json                 # TypeScript config (strict: true, paths: @/*)
+├── eslint.config.mjs             # ESLint config (TS + React rules)
+├── postcss.config.mjs            # PostCSS config for Tailwind
+├── docker-compose.yml            # MySQL 8.4 container (port 13307)
+├── Dockerfile                    # Multi-stage build for production
+├── package.json                  # Dependencies + scripts
+├── pnpm-lock.yaml                # Lockfile (pnpm)
+├── .env.example                  # Example environment variables
+├── .tool-versions                # Node/pnpm versions (asdf/mise)
+├── .gitignore
+├── README.md                     # User-facing documentation
+├── AGENTS.md                     # Agent delegation guide (app/, components/, db/, lib/, docker/)
+└── CLAUDE.md                     # This file
+```
+
+---
+
+## Key Scripts
+
+### Package Manager
+
+```bash
+pnpm install                 # Install dependencies
+```
+
+### Development
+
+```bash
+pnpm dev                     # Start dev server with Turbopack (http://localhost:3000)
+pnpm type-check              # Run tsc --noEmit
+pnpm lint                    # Run ESLint
+pnpm test                    # Run Vitest
+```
+
+### Production
+
+```bash
+pnpm build                   # Next.js production build
+pnpm start                   # Start production server
+```
+
+### Database
+
+```bash
+pnpm db:up                   # Start MySQL container (docker compose up -d)
+pnpm db:down                 # Stop MySQL container (docker compose down)
+pnpm db:generate             # Generate Drizzle migration files
+pnpm db:push                 # Apply schema to database
+pnpm db:migrate              # Run pending migrations
+pnpm db:studio               # Open Drizzle Studio GUI
+pnpm db:logs                 # Tail MySQL container logs
+pnpm setup                   # Full setup: db:up + sleep 5 + db:push
+```
+
+### Content Sync
+
+- **Manual:** `curl -X POST http://localhost:3000/api/sync -H "Authorization: Bearer <SYNC_API_KEY>"`
+- **Cron:** Configure a cron job to POST `/api/sync` periodically for automated sync
+
+---
+
+## Environment Variables
+
+See `/Users/nhn/personal/fos-blog/.env.example` for the full list.
+
+### Required (for basic dev)
+
+```env
+GITHUB_TOKEN=ghp_xxxxx                          # GitHub PAT (for API rate limit lift)
+GITHUB_OWNER=jon890                             # Content repo owner
+GITHUB_REPO=fos-study                           # Content repo name
+```
+
+### Database (for MySQL caching)
+
+```env
+DATABASE_URL=mysql://fos_user:fos_password@localhost:13307/fos_blog
+```
+
+### Sync Protection
+
+```env
+SYNC_API_KEY=your_random_api_key_here          # Protects /api/sync endpoint
+```
+
+### Public/SEO
+
+```env
+NEXT_PUBLIC_SITE_URL=https://your-domain.com            # For canonical URLs & sitemap
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=xxx                # Google Search Console
+NEXT_PUBLIC_GOOGLE_ADSENSE_ID=ca-pub-xxx               # Google AdSense
+```
+
+---
+
+## Database Schema
+
+### Tables
+
+**posts** — Main content table
+
+- `id` (INT): Primary key, auto-increment
+- `title` (VARCHAR 500): Post title (required, indexed)
+- `path` (VARCHAR 500): GitHub file path (required, unique)
+- `slug` (VARCHAR 500): URL slug (required, indexed)
+- `category` (VARCHAR 255): Primary category (indexed)
+- `subcategory` (VARCHAR 255): Secondary category
+- `folders` (JSON): n-depth folder path array (e.g., `["algorithms", "sorting", "quicksort"]`)
+- `content` (TEXT): Full rendered markdown
+- `description` (TEXT): Extracted excerpt
+- `sha` (VARCHAR 64): GitHub file SHA (for change detection)
+- `isActive` (BOOLEAN): Soft delete flag (default: true)
+- `createdAt`, `updatedAt` (TIMESTAMP): Timestamps
+
+**comments** — Per-post comments
+
+- `id` (INT): Primary key
+- `postId` (INT): Foreign key to posts
+- `author` (VARCHAR): Commenter name
+- `email` (VARCHAR): Commenter email
+- `content` (TEXT): Comment text
+- `createdAt` (TIMESTAMP)
+
+**visitStats** — Page view tracking
+
+- `id` (INT): Primary key
+- `postId` (INT): Foreign key to posts
+- `viewCount` (INT): Total views
+- `updatedAt` (TIMESTAMP): Last updated
+
+**syncLogs** — Sync operation history
+
+- `id` (INT): Primary key
+- `commitSha` (VARCHAR): GitHub commit SHA
+- `filesAdded`, `filesUpdated`, `filesDeleted` (INT): Change counts
+- `createdAt` (TIMESTAMP)
+
+**folders** — Category/folder hierarchy (optional)
+
+- `id` (INT): Primary key
+- `name` (VARCHAR): Folder name
+- `path` (VARCHAR): Full path
+- `parentId` (INT): Parent folder (for nesting)
+
+---
+
+## Database Setup
+
+### 1. Start MySQL Container
+
+```bash
+pnpm db:up
+# Waits 10s for health check
+```
+
+### 2. Apply Schema
+
+```bash
+pnpm db:push
+# Or: pnpm db:generate (creates migrations), then pnpm db:migrate
+```
+
+### 3. Verify Connection
+
+```bash
+pnpm db:studio
+# Opens Drizzle Studio at http://local.drizzle.studio
+```
+
+### 4. Populate with GitHub Data
+
+```bash
+curl -X POST http://localhost:3000/api/sync \
+  -H "Authorization: Bearer $SYNC_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+---
+
+## Key Conventions
+
+### File & Naming
+
+- **App routes:** File-system based (Next.js App Router)
+- **Components:** PascalCase (e.g., `MarkdownRenderer.tsx`)
+- **Utils/helpers:** camelCase (e.g., `extractTitle()`, `syncGitHubToDatabase()`)
+- **Constants:** SCREAMING_SNAKE_CASE (e.g., `OWNER`, `REPO`)
+- **Exports:** Named exports preferred; type inference via Drizzle schema
+
+### TypeScript
+
+- **Strict mode:** Enabled (`tsconfig.json`)
+- **Type safety:** Drizzle provides inferred types from schema (e.g., `Post`, `NewPost`)
+- **Path aliases:** `@/*` → project root
+- **Unused vars:** `_` prefix to suppress warnings (ESLint rule)
+
+### Styling
+
+- **Tailwind CSS v4 with `@source` directives**
+  - `app/globals.css` MUST include: `@source "./app"` and `@source "./components"`
+  - New component directories require `@source` updates
+- **Typography plugin:** Used for markdown rendering (`.prose` classes)
+- **Dark mode:** `next-themes` provider + `[data-theme="dark"]` or `dark:` utilities
+
+### Data Flow
+
+1. **GitHub sync:** `POST /api/sync` → `syncGitHubToDatabase()` → fetch files → parse metadata
+2. **Cache:** Files stored in MySQL (posts table)
+3. **Rendering:** App routes query DB → pass to `MarkdownRenderer` → browser
+4. **Updates:** Only synced files update; soft-delete inactive posts
+
+### Testing
+
+- **Test files:** Co-located with source (e.g., `markdown.test.ts` next to `markdown.ts`)
+- **Test runner:** Vitest 4.1.0
+- **Run tests:** `pnpm test`
+
+### Middleware & Hooks
+
+- **proxy.ts:** Next.js middleware — records page visits to DB via `waitUntil()` (fire-and-forget)
+- **Edge Runtime:** Lightweight, fires async without blocking response
+
+### API Routes (next-server)
+
+- **Location:** `app/api/*/route.ts`
+- **Pattern:** Endpoint-per-directory (e.g., `app/api/sync/route.ts`)
+- **Auth:** Bearer token check (SYNC_API_KEY)
+
+---
+
+## Code Structure Patterns
+
+### GitHub Sync
+
+**File:** `/Users/nhn/personal/fos-blog/lib/sync-github.ts`
+
+```typescript
+export function shouldSyncFile(filename: string): boolean;
+export function rewriteImagePaths(content: string, filePath: string): string;
+export async function syncGitHubToDatabase(): Promise<SyncResult>;
+export async function retitleExistingPosts(): Promise<RetitleResult>;
+```
+
+**Flow:**
+
+1. Fetch tree from GitHub API (Octokit)
+2. Walk directory tree, filter `.md` files via `shouldSyncFile()`
+3. Fetch content, rewrite image paths (GitHub raw → blog URLs)
+4. Parse frontmatter + extract title/description
+5. Upsert into posts table (by path, unique key)
+6. Mark inactive posts if deleted from source
+
+### Markdown Processing
+
+**File:** `/Users/nhn/personal/fos-blog/lib/markdown.ts`
+
+```typescript
+export function parseFrontMatter(content: string);
+export function extractTitle(content: string): string | null;
+export function extractDescription(content: string): string | null;
+export function getReadingTime(content: string): number;
+export function generateTableOfContents(content: string): TocItem[];
+```
+
+### Link Resolution
+
+**File:** `/Users/nhn/personal/fos-blog/lib/resolve-markdown-link.ts`
+
+Converts GitHub raw URLs to blog relative URLs for inter-post links.
+
+### Markdown Rendering Component
+
+**File:** `/Users/nhn/personal/fos-blog/components/MarkdownRenderer.tsx`
+
+Uses `react-markdown` + plugins (remark-gfm, rehype-highlight, etc.) to render GFM + code highlighting + mermaid.
+
+---
+
+## Common Tasks
+
+### Add a New Page Route
+
+1. Create file in `app/` (e.g., `app/about/page.tsx`)
+2. Export default React component
+3. Next.js auto-routes via file path
+
+### Modify Tailwind Styles
+
+1. Edit `app/globals.css` or add inline `className=""`
+2. If creating new component directory: update `@source` directives in `globals.css`
+3. Rebuild with `pnpm build` (Turbopack watches `dev`)
+
+### Add a New API Endpoint
+
+1. Create `app/api/myendpoint/route.ts`
+2. Export `GET`, `POST`, etc. functions
+3. Use `NextResponse` for type-safe responses
+
+### Sync Content from GitHub
+
+```bash
+curl -X POST http://localhost:3000/api/sync \
+  -H "Authorization: Bearer ${SYNC_API_KEY}"
+```
+
+### Query Posts from DB
+
+```typescript
+import { db } from "@/db";
+import { posts } from "@/db/schema/posts";
+
+const allPosts = await db.select().from(posts);
+const byCategory = await db
+  .select()
+  .from(posts)
+  .where(eq(posts.category, "AI"));
+```
+
+### Run Tests
+
+```bash
+pnpm test                    # All tests
+pnpm test -- lib/markdown   # Specific file
+```
+
+---
+
+## Performance & Optimization
+
+### ISR (Incremental Static Regeneration)
+
+- Blog posts cached for 1 hour (`revalidate: 3600`)
+- Sync endpoint invalidates cache on success (via Vercel API)
+
+### Image Optimization
+
+- Remote GitHub images: `next/image` with `remotePatterns` config
+- Allowed hostnames: `raw.githubusercontent.com`, `github.com`
+
+### Markdown Rendering
+
+- Syntax highlighting via highlight.js (client-side)
+- Mermaid diagrams supported (lazy-loaded)
+
+### Database Queries
+
+- Indexed columns: `category`, `slug`
+- Soft-delete via `isActive` flag (prevents orphaned data)
+
+---
+
+## Known Limitations & TODOs
+
+- **TODO/FIXME markers:** 165 found in codebase (see `lib/sync-github.test.ts`, etc.)
+- **Image rewriting:** Currently rewrites only GitHub raw URLs; non-GitHub CDNs not handled
+- **Rate limiting:** GitHub API limits at 60 req/hr (unauthenticated) or 5000 req/hr (with token)
+- **Sync idempotency:** Uses GitHub file SHA to detect changes; force-resync requires manual deletion
+
+---
+
+## Vercel Deployment
+
+Recommended production platform.
+
+### Steps
+
+1. Push repo to GitHub
+2. Connect repo in Vercel dashboard
+3. Set environment variables (GITHUB_TOKEN, DATABASE_URL, SYNC_API_KEY, etc.)
+4. Deploy!
+5. Configure cron job: **Vercel Cron** → POST `/api/sync` hourly
+
+---
+
+## Subdirectory Agent Docs
+
+Each major directory has an `AGENTS.md` file for delegation:
+
+- `app/AGENTS.md` — Page routes, API routes, layout
+- `components/AGENTS.md` — UI components
+- `db/AGENTS.md` — Schema, repositories, migrations
+- `lib/AGENTS.md` — Utilities, sync, markdown
+- `docker/AGENTS.md` — MySQL setup, Docker Compose
+
+See these files for detailed agent responsibilities.
+
+---
+
+## Useful Links
+
+- **Repository:** https://github.com/jon890/fos-blog
+- **Content Source:** https://github.com/jon890/fos-study
+- **Live Blog:** https://fosworld.co.kr
+- **Next.js Docs:** https://nextjs.org/docs
+- **Drizzle ORM Docs:** https://orm.drizzle.team
+- **Tailwind CSS Docs:** https://tailwindcss.com/docs
+
+---
+
+## Summary for Claude Code Agents
+
+**This is a Next.js 16 full-stack blog with GitHub sync, MySQL caching, and Markdown rendering.**
+
+- **Primary concern:** Content sync consistency, markdown edge cases, performance
+- **Key files to touch:** `lib/sync-github.ts`, `app/api/sync/route.ts`, `components/MarkdownRenderer.tsx`, `db/schema/posts.ts`
+- **Testing:** Vitest + co-located test files
+- **Deployment:** Vercel + MySQL (external) + GitHub Actions (cron)
+
+**Agents should prioritize:**
+
+1. Maintaining schema integrity (Drizzle types)
+2. Sync idempotency (no duplicate/lost data)
+3. Markdown fidelity (GFM rendering, mermaid, links)
+4. Type safety across API boundaries

--- a/app/api/sync/AGENTS.md
+++ b/app/api/sync/AGENTS.md
@@ -1,16 +1,16 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-17 | Updated: 2026-03-17 -->
+<!-- Generated: 2026-03-17 | Updated: 2026-03-30 -->
 
 # app/api/sync
 
 ## Purpose
-POST/GET endpoint that triggers a full GitHub-to-database sync. Pulls all markdown files from the configured GitHub repository and upserts them into MySQL. Intended for manual calls or cron jobs.
+POST/GET endpoint that triggers a full GitHub-to-database sync. GitHub 저장소에서 마크다운 파일을 가져와 MySQL에 upsert하고, 이미지 상대경로를 GitHub raw URL로 변환하여 저장한다. 수동 호출 또는 cron job 용도.
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
-| `route.ts` | `POST /api/sync` (and `GET` for dev convenience) — validates Bearer token then calls `syncGitHubToDatabase()` |
+| `route.ts` | `POST /api/sync` (and `GET` for dev convenience) — validates Bearer token then calls `syncGitHubToDatabase()` + `retitleExistingPosts()` |
 
 ## For AI Agents
 
@@ -19,6 +19,7 @@ POST/GET endpoint that triggers a full GitHub-to-database sync. Pulls all markdo
 - `GET` is an alias for `POST` for development convenience; keep this in mind when testing
 - Returns sync statistics: `postsAdded`, `postsUpdated`, `postsDeleted`
 - Sync uses SHA-based change detection — unchanged files are skipped
+- **이미지 처리**: sync 과정에서 `rewriteImagePaths()`가 자동 호출되어 `./images/foo.png` 형태의 상대경로가 GitHub raw URL로 변환된 후 DB에 저장됨
 
 ### API Contract
 ```
@@ -38,9 +39,9 @@ Response 500:
 ## Dependencies
 
 ### Internal
-- `@/lib/sync-github` → `syncGitHubToDatabase()`
+- `@/lib/sync-github` → `syncGitHubToDatabase()`, `retitleExistingPosts()`
 
 ### External
-- Requires `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO` env vars (consumed by `lib/github.ts`)
+- Requires `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO` env vars (consumed by `lib/sync-github.ts`)
 
 <!-- MANUAL: -->

--- a/app/components/AGENTS.md
+++ b/app/components/AGENTS.md
@@ -1,0 +1,44 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-03-30 | Updated: 2026-03-30 -->
+
+# app/components
+
+## Purpose
+
+App Router 전용 Server Component 래퍼 디렉토리. DB 데이터를 서버에서 fetch하여 `components/`의 Client Component에 props로 전달하는 역할을 담당한다. "use client"가 필요한 UI 컴포넌트는 `/components`에, 서버 데이터 페칭 로직은 이 디렉토리에 위치한다.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `FolderSidebarWrapper.tsx` | DB에서 폴더 경로와 포스트 목록을 fetch해 `FolderSidebar`에 전달하는 Server Component |
+
+## For AI Agents
+
+### Working In This Directory
+
+- 이 디렉토리의 컴포넌트는 **Server Component**여야 한다 — `"use client"` 추가 금지
+- DB 접근은 `@/db/queries`의 `getDbQueries()`를 통해서만 수행한다
+- UI 렌더링 로직은 포함하지 않는다 — 데이터 fetch 후 `/components/`의 컴포넌트에 위임
+
+### Common Patterns
+
+```tsx
+// Server Component wrapper 패턴
+export async function XxxWrapper() {
+  const dbQueries = getDbQueries();
+  if (!dbQueries) return null;  // DB 미설정 시 graceful null 반환
+
+  const data = await dbQueries.getSomething();
+  return <XxxClientComponent data={data} />;
+}
+```
+
+## Dependencies
+
+### Internal
+- `@/db/queries` — DB 쿼리 함수
+- `@/db/constants` — categoryIcons 등 공유 상수
+- `@/components/` — 실제 렌더링을 담당하는 Client Component
+
+<!-- MANUAL: -->

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-17 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-17 | Updated: 2026-03-30 -->
 
 # components
 
@@ -14,7 +14,7 @@ Reusable React UI components used across the application. All components are **C
 | `PostCard.tsx` | Card for post listings — displays title, category, description |
 | `CategoryCard.tsx` | Card for a single category — icon, name, post count |
 | `CategoryList.tsx` | Responsive grid of `CategoryCard` components |
-| `MarkdownRenderer.tsx` | Converts markdown string → styled React output with syntax highlighting, GFM, raw HTML, and slug-based heading IDs |
+| `MarkdownRenderer.tsx` | Converts markdown string → styled React output with syntax highlighting, GFM, raw HTML, slug-based heading IDs. 이미지는 `next/image`로 렌더링 (WebP 변환, lazy loading 자동 적용) |
 | `TableOfContents.tsx` | Auto-generates a clickable TOC from post heading structure (uses rehype-slug IDs) |
 | `SearchDialog.tsx` | Modal full-text search UI — calls `/api/search?q=` and displays results; requires `"use client"` |
 | `ThemeProvider.tsx` | Wraps children with `next-themes` Provider; `enableSystem=false`, `defaultTheme="dark"` |
@@ -31,6 +31,7 @@ Reusable React UI components used across the application. All components are **C
 - Keep components **pure presentational** — no direct DB calls or fetch inside components
 - `SearchDialog.tsx` and `ThemeToggle.tsx` are Client Components (`"use client"`) — they interact with browser APIs
 - `MarkdownRenderer.tsx` uses a plugin pipeline: `remark-gfm` → `rehype-slug` → `rehype-highlight` → `rehype-raw`; modify the plugin array carefully as order matters
+- **이미지 렌더링**: `img` 컴포넌트는 `next/image`를 사용한다. 외부 이미지 도메인은 `next.config.js`의 `remotePatterns`에 등록해야 한다 (현재 `raw.githubusercontent.com`, `github.com` 허용)
 - **Code block inline detection:** `isInline = !className && !String(children).includes("\n")` — fenced blocks without a language have no className, so newline check prevents them from being styled as inline code
 - `Mermaid.tsx` renders via `dangerouslySetInnerHTML` with `mermaid.render()` — it re-renders on theme change
 - `JsonLd.tsx` structured data affects SEO — update schema types only when the content type changes

--- a/docker/AGENTS.md
+++ b/docker/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-17 | Updated: 2026-03-17 -->
+<!-- Generated: 2026-03-17 | Updated: 2026-03-30 -->
 
 # docker
 
@@ -10,7 +10,7 @@ Docker configuration for local development database. Contains MySQL initializati
 
 | Directory | Purpose |
 |-----------|---------|
-| `mysql/` | MySQL-specific init scripts run on first container startup |
+| `mysql/` | MySQL-specific init scripts run on first container startup (see `mysql/AGENTS.md`) |
 
 ## Key Files
 

--- a/docker/mysql/AGENTS.md
+++ b/docker/mysql/AGENTS.md
@@ -1,0 +1,36 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-03-30 | Updated: 2026-03-30 -->
+
+# docker/mysql
+
+## Purpose
+
+MySQL 컨테이너 초기화 스크립트 디렉토리. Docker Compose 실행 시 컨테이너가 최초 생성될 때 자동으로 실행되어 데이터베이스 문자셋, 타임존, 사용자 권한을 설정한다.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `init.sql` | MySQL 초기화 SQL — utf8mb4 문자셋, KST(+09:00) 타임존, fos_user 권한 설정 |
+
+## For AI Agents
+
+### Working In This Directory
+
+- `init.sql`은 컨테이너 **최초 생성 시에만** 실행된다 — 기존 컨테이너에는 영향 없음
+- 스키마 변경은 이 파일이 아닌 `drizzle/` 마이그레이션으로 관리한다
+- 문자셋(`utf8mb4`)과 타임존(`+09:00`) 설정은 변경하지 않는다
+
+### Testing Requirements
+
+변경 사항 적용은 컨테이너를 재생성해야 한다:
+```bash
+pnpm db:down && pnpm db:up
+```
+
+## Dependencies
+
+### External
+- Docker Compose (`docker-compose.yml`) — 이 디렉토리를 MySQL init volume으로 마운트
+
+<!-- MANUAL: -->

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-17 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-17 | Updated: 2026-03-30 -->
 
 # lib
 
@@ -12,7 +12,8 @@ Shared utility functions and service clients. Contains the GitHub API integratio
 |------|-------------|
 | `github.ts` | Octokit-based GitHub REST API client — fetches repo tree, file contents, folder structures, and derives category/post metadata; also exports `getCategoryIcon()` and `getCategoryColorClass()` |
 | `markdown.ts` | Markdown utilities — `parseFrontMatter()`, `extractTitle()`, `extractDescription()`, `getReadingTime()`, `generateTableOfContents()` (uses `github-slugger` for slug parity with `rehype-slug`) |
-| `sync-github.ts` | Sync orchestration — commit-based incremental sync (compares HEAD SHA to last synced commit); falls back to full sync when >300 files changed or on first run; also updates categories and folder READMEs |
+| `sync-github.ts` | Sync orchestration — commit-based incremental sync (compares HEAD SHA to last synced commit); falls back to full sync when >300 files changed or on first run; also updates categories and folder READMEs. Exports `shouldSyncFile()` and `rewriteImagePaths()` |
+| `sync-github.test.ts` | Vitest 단위 테스트 — `shouldSyncFile`, `rewriteImagePaths` 커버 |
 
 ## For AI Agents
 
@@ -20,6 +21,7 @@ Shared utility functions and service clients. Contains the GitHub API integratio
 - `github.ts` requires `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO` environment variables
 - `github.ts` is a **dual-purpose** file: it serves both as a GitHub API client AND contains legacy direct-fetch helpers (`getPost`, `getCategories`) that were used before the DB layer existed — prefer the DB layer for production reads
 - `sync-github.ts` writes to the database — do not call it directly from page rendering paths
+- **이미지 처리**: `sync-github.ts`의 `rewriteImagePaths(content, filePath)`는 마크다운 내 상대경로 이미지를 GitHub raw URL로 변환한다. content를 DB에 저장하기 전에 반드시 호출해야 한다
 - `generateTableOfContents()` in `markdown.ts` uses `github-slugger` to produce slugs identical to `rehype-slug` — keep them in sync if changing heading ID logic
 - All functions are side-effect-free except `sync-github.ts`
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` 추가: 프로젝트 기술 스택, 디렉토리 구조, 컨벤션, 환경변수 등을 문서화하여 AI 에이전트 협업 효율 향상
- `AGENTS.md` 불릿 스타일 소폭 정리
- `.github/workflows/claude-code-review.yml` 추가: PR 오픈/업데이트 시 자동 코드 리뷰

## GitHub Action 동작 방식

PR이 열리거나 업데이트되면 4개의 병렬 전문 에이전트가 리뷰를 수행합니다:

| 에이전트 | 담당 영역 |
|---------|---------|
| Agent 1 | TypeScript & 타입 안전성 |
| Agent 2 | 프로젝트 컨벤션 (sync 규칙, console.log 등) |
| Agent 3 | 보안 (API 키 노출, 인증 등) |
| Agent 4 | Next.js 아키텍처 패턴 |

리뷰 결과는 Files changed 탭의 인라인 코멘트 + PR 요약 코멘트로 게시됩니다.

## 사전 설정 필요

- GitHub Repository Secrets에 `CLAUDE_CODE_OAUTH_TOKEN` 등록 필요

## Test plan

- [ ] `CLAUDE_CODE_OAUTH_TOKEN` secret 등록 후 PR 오픈 시 Action 동작 확인
- [ ] 인라인 코멘트 및 요약 코멘트 정상 게시 확인
- [ ] 동일 PR 업데이트 시 이전 코멘트 숨김 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)