### PR TITLE
🔥 Remove: 호출자 없는 POST /api/visit 엔드포인트 제거

### DIFF
--- a/src/app/api/visit/AGENTS.md
+++ b/src/app/api/visit/AGENTS.md
@@ -1,31 +1,27 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-03-20 | Updated: 2026-03-20 -->
+<!-- Generated: 2026-03-20 | Updated: 2026-04-01 -->
 
 # app/api/visit
 
 ## Purpose
-API route for tracking and querying page view counts and visitor statistics. Records visits with IP deduplication (SHA-256 hashed) and provides flexible query modes for single/multiple pages and total counts.
+API route for querying page view counts and visitor statistics.
+방문 기록 자체는 `proxy.ts` 미들웨어에서 처리되므로 이 라우트는 **조회 전용**입니다.
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
-| `route.ts` | `POST` — record a visit; `GET` — query visit counts (single page, multiple pages, or site total) |
+| `route.ts` | `GET` — 조회수 쿼리 (단일 페이지 / 복수 페이지 / 사이트 전체) |
 
 ## For AI Agents
 
 ### Working In This Directory
-- IP addresses are **SHA-256 hashed** before storage — raw IPs are never persisted
-- IP is extracted from `x-visitor-ip` header (set by middleware), then `x-forwarded-for`, then `x-real-ip`
-- `recordVisit()` returns `isNewVisit: boolean` — used by the client to avoid double-counting
-- Uses `getDbQueries()` — returns `null` if DB unavailable → `503`
+- 방문 기록은 **`proxy.ts` 미들웨어**가 담당 (`waitUntil`로 비동기 처리) — 이 라우트에서 기록하지 않음
+- IP 주소는 SHA-256으로 해시 후 저장 — raw IP는 저장하지 않음
+- `getRepositories().visit` 를 통해 `VisitRepository` 접근
 
 ### API Contract
 ```
-POST /api/visit
-  Body: { pagePath: string }
-  → 200: { success: true, isNewVisit: boolean }
-
 GET /api/visit?path=<pagePath>
   → 200: { count: number }
 
@@ -42,6 +38,10 @@ GET /api/visit  (no params)
 ## Dependencies
 
 ### Internal
-- `@/db/queries` → `getDbQueries()`, `recordVisit()`, `getVisitCount()`, `getPostVisitCounts()`, `getTotalVisitCount()`, `getTodayVisitorCount()`
+- `@/infra/db/repositories` → `getRepositories().visit` → `VisitRepository`
+
+### Callers
+- `src/components/PostViewCount.tsx` — 개별 포스트 조회수 표시 (`?path=`)
+- `src/components/VisitorCount.tsx` — 사이트 전체 방문자 수 표시 (`?total=true`)
 
 <!-- MANUAL: -->

--- a/src/app/api/visit/route.ts
+++ b/src/app/api/visit/route.ts
@@ -1,52 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHash } from "crypto";
 import { getRepositories } from "@/infra/db/repositories";
 
-function hashIp(ip: string): string {
-  return createHash("sha256").update(ip).digest("hex");
-}
-
-function getClientIp(request: NextRequest): string {
-  const visitorIp = request.headers.get("x-visitor-ip");
-  if (visitorIp) return visitorIp;
-
-  const forwarded = request.headers.get("x-forwarded-for");
-  if (forwarded) return forwarded.split(",")[0].trim();
-
-  const realIp = request.headers.get("x-real-ip");
-  if (realIp) return realIp;
-
-  return "unknown";
-}
-
-// POST /api/visit - 방문 기록
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { pagePath } = body;
-
-    if (!pagePath || typeof pagePath !== "string") {
-      return NextResponse.json(
-        { error: "pagePath가 필요합니다." },
-        { status: 400 }
-      );
-    }
-
-    const clientIp = getClientIp(request);
-    const ipHash = hashIp(clientIp);
-
-    const { visit } = getRepositories();
-    const isNewVisit = await visit.recordVisit(pagePath, ipHash);
-
-    return NextResponse.json({ success: true, isNewVisit });
-  } catch (error) {
-    console.error("방문 기록 실패:", error);
-    return NextResponse.json(
-      { error: "방문 기록에 실패했습니다." },
-      { status: 500 }
-    );
-  }
-}
+// 방문 기록은 proxy.ts 미들웨어에서 처리됨
 
 // GET /api/visit - 조회수 조회
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
Closes #30

## Summary

- `POST /api/visit` 엔드포인트 제거 — 방문 기록은 `proxy.ts` 미들웨어에서 이미 처리 중
- `GET /api/visit` 는 `PostViewCount`, `VisitorCount` 컴포넌트에서 사용 중이므로 유지

## 배경

`proxy.ts`(Next.js 미들웨어)가 `waitUntil`로 비동기 방문 기록을 처리하고 있어, `POST /api/visit`와 완전히 역할이 중복됨. 클라이언트에서 `POST /api/visit`를 호출하는 코드도 존재하지 않는 dead code였음.

## Test plan

- [x] `pnpm lint` 통과
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm test` 통과 (69 tests)
- [ ] `GET /api/visit` 정상 동작 확인 (PostViewCount, VisitorCount 컴포넌트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)