### PR TITLE
🩹 Fix(mermaid): 노드 내 텍스트 잘림 버그 수정

### DIFF
--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -23,7 +23,8 @@ export function Mermaid({ chart }: MermaidProps) {
       startOnLoad: false,
       theme: mermaidTheme,
       securityLevel: "loose",
-      fontFamily: "inherit",
+      // fontFamily를 지정하지 않아 Mermaid 기본값(trebuchet ms)을 사용한다.
+      // "inherit"으로 설정하면 Noto Sans KR의 글자 크기 계산이 달라 노드 내 텍스트가 잘린다.
     });
 
     const renderChart = async () => {


### PR DESCRIPTION
Closes #28

## Summary

`Mermaid.tsx`에서 `fontFamily: "inherit"` 옵션 제거

## 원인

Mermaid는 SVG 노드 크기를 렌더링 전에 기본 폰트(trebuchet ms)의 metrics 기준으로 계산합니다. `fontFamily: "inherit"`으로 Noto Sans KR을 상속하면 실제 렌더링 시 글자 크기가 달라 텍스트가 노드 박스를 초과하여 잘립니다.

## 변경

```ts
// before
mermaid.initialize({
  startOnLoad: false,
  theme: mermaidTheme,
  securityLevel: "loose",
  fontFamily: "inherit",  // ← 제거
});

// after
mermaid.initialize({
  startOnLoad: false,
  theme: mermaidTheme,
  securityLevel: "loose",
  // Mermaid 기본값(trebuchet ms) 사용
});
```

래퍼의 `overflow-x-auto`는 유지되어 넓은 다이어그램에서 가로 스크롤 제공.

## Test plan

- [ ] `/posts/database/mysql/mysql-architecture.md` 에서 Mermaid 다이어그램 텍스트 잘림 해소 확인
- [x] `pnpm lint` 통과
- [x] `pnpm tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)