### PR TITLE
⚡ Perf: full sync 비활성화 N+1 쿼리 개선

### DIFF
--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -234,6 +234,14 @@ export class PostRepository extends BaseRepository {
     return success;
   }
 
+  async deactivateByIds(ids: number[]): Promise<void> {
+    if (ids.length === 0) return;
+    await this.db
+      .update(posts)
+      .set({ isActive: false })
+      .where(inArray(posts.id, ids));
+  }
+
   async create(newPost: NewPost) {
     await this.db.insert(posts).values(newPost);
   }

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -234,12 +234,13 @@ export class PostRepository extends BaseRepository {
     return success;
   }
 
-  async deactivateByIds(ids: number[]): Promise<void> {
-    if (ids.length === 0) return;
-    await this.db
+  async deactivateByIds(ids: number[]): Promise<number> {
+    if (ids.length === 0) return 0;
+    const result = await this.db
       .update(posts)
       .set({ isActive: false })
       .where(inArray(posts.id, ids));
+    return result[0].affectedRows;
   }
 
   async create(newPost: NewPost) {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -179,12 +179,11 @@ export class SyncService {
       }
     }
 
-    for (const post of existingPosts) {
-      if (!processedPaths.has(post.path) && post.isActive) {
-        await this.postRepo.deactive(post.path);
-        deleted++;
-      }
-    }
+    const idsToDeactivate = existingPosts
+      .filter((p) => !processedPaths.has(p.path) && p.isActive)
+      .map((p) => p.id);
+    await this.postRepo.deactivateByIds(idsToDeactivate);
+    deleted = idsToDeactivate.length;
     if (deleted > 0) console.log(`비활성화 완료: ${deleted}개`);
 
     return { added, updated, deleted };

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -182,8 +182,7 @@ export class SyncService {
     const idsToDeactivate = existingPosts
       .filter((p) => !processedPaths.has(p.path) && p.isActive)
       .map((p) => p.id);
-    await this.postRepo.deactivateByIds(idsToDeactivate);
-    deleted = idsToDeactivate.length;
+    deleted = await this.postRepo.deactivateByIds(idsToDeactivate);
     if (deleted > 0) console.log(`비활성화 완료: ${deleted}개`);
 
     return { added, updated, deleted };


### PR DESCRIPTION
Closes #31

## Summary

Full sync 시 비활성화 대상 포스트를 하나씩 UPDATE하던 N+1 패턴을 단일 쿼리로 개선

## 변경 내용

**Before** — 비활성화할 포스트 수만큼 UPDATE 쿼리 발생:
```ts
for (const post of existingPosts) {
  if (!processedPaths.has(post.path) && post.isActive) {
    await this.postRepo.deactive(post.path);  // N번 쿼리
  }
}
```

**After** — 단일 `WHERE id IN (...)` 쿼리:
```ts
const idsToDeactivate = existingPosts
  .filter((p) => !processedPaths.has(p.path) && p.isActive)
  .map((p) => p.id);
await this.postRepo.deactivateByIds(idsToDeactivate);  // 1번 쿼리
```

`existingPosts`가 이미 메모리에 있어 추가 SELECT 없이 개선 가능.

## 미적용 항목

`PostService.retitleAll()` — 포스트마다 다른 제목이라 단일 쿼리 불가, 수동 스크립트 용도로 현재 규모에서 허용 범위 내 (이슈 내용 참고)

## Test plan

- [x] `pnpm lint` 통과
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm test` 통과 (69 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)