### PR TITLE
✅ Test: Service 레이어 단위 테스트 추가

### DIFF
--- a/src/services/MetadataSyncService.test.ts
+++ b/src/services/MetadataSyncService.test.ts
@@ -3,6 +3,7 @@ import { MetadataSyncService } from "./MetadataSyncService";
 import type { CategoryRepository } from "@/infra/db/repositories/CategoryRepository";
 import type { FolderRepository } from "@/infra/db/repositories/FolderRepository";
 import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+import type { getFileContent } from "@/infra/github/api";
 
 function makeMocks() {
   const postRepo = {
@@ -15,14 +16,14 @@ function makeMocks() {
   } as unknown as CategoryRepository;
 
   const folderRepo = {
-    getAll: vi.fn(),
+    getAll: vi.fn().mockResolvedValue(new Map()),
     upsert: vi.fn().mockResolvedValue(undefined),
     ensureFolder: vi.fn().mockResolvedValue(undefined),
   } as unknown as FolderRepository;
 
   const githubApi = {
     getFileContent: vi.fn(),
-  };
+  } as unknown as { getFileContent: typeof getFileContent };
 
   return { postRepo, categoryRepo, folderRepo, githubApi };
 }

--- a/src/services/MetadataSyncService.test.ts
+++ b/src/services/MetadataSyncService.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MetadataSyncService } from "./MetadataSyncService";
+import type { CategoryRepository } from "@/infra/db/repositories/CategoryRepository";
+import type { FolderRepository } from "@/infra/db/repositories/FolderRepository";
+import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+
+function makeMocks() {
+  const postRepo = {
+    getCategoryStats: vi.fn(),
+    getAllPostPaths: vi.fn(),
+  } as unknown as PostRepository;
+
+  const categoryRepo = {
+    replaceAll: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CategoryRepository;
+
+  const folderRepo = {
+    getAll: vi.fn(),
+    upsert: vi.fn().mockResolvedValue(undefined),
+    ensureFolder: vi.fn().mockResolvedValue(undefined),
+  } as unknown as FolderRepository;
+
+  const githubApi = {
+    getFileContent: vi.fn(),
+  };
+
+  return { postRepo, categoryRepo, folderRepo, githubApi };
+}
+
+describe("MetadataSyncService.updateCategories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getCategoryStats 결과를 replaceAll에 올바르게 매핑한다", async () => {
+    const { postRepo, categoryRepo, folderRepo, githubApi } = makeMocks();
+
+    vi.mocked(postRepo.getCategoryStats).mockResolvedValue([
+      { category: "AI", count: 5 },
+      { category: "database", count: 3 },
+    ]);
+
+    const service = new MetadataSyncService(categoryRepo, folderRepo, postRepo, githubApi);
+    await service.updateCategories();
+
+    expect(postRepo.getCategoryStats).toHaveBeenCalledOnce();
+    expect(categoryRepo.replaceAll).toHaveBeenCalledWith([
+      { name: "AI", slug: "AI", icon: "🤖", postCount: 5 },
+      { name: "database", slug: "database", icon: "🗄️", postCount: 3 },
+    ]);
+  });
+
+  it("categoryIcons에 없는 카테고리는 기본 아이콘(📁)을 사용한다", async () => {
+    const { postRepo, categoryRepo, folderRepo, githubApi } = makeMocks();
+
+    vi.mocked(postRepo.getCategoryStats).mockResolvedValue([
+      { category: "unknown-topic", count: 2 },
+    ]);
+
+    const service = new MetadataSyncService(categoryRepo, folderRepo, postRepo, githubApi);
+    await service.updateCategories();
+
+    expect(categoryRepo.replaceAll).toHaveBeenCalledWith([
+      { name: "unknown-topic", slug: "unknown-topic", icon: "📁", postCount: 2 },
+    ]);
+  });
+
+  it("카테고리가 없으면 빈 배열로 replaceAll을 호출한다", async () => {
+    const { postRepo, categoryRepo, folderRepo, githubApi } = makeMocks();
+
+    vi.mocked(postRepo.getCategoryStats).mockResolvedValue([]);
+
+    const service = new MetadataSyncService(categoryRepo, folderRepo, postRepo, githubApi);
+    await service.updateCategories();
+
+    expect(categoryRepo.replaceAll).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/services/PostService.test.ts
+++ b/src/services/PostService.test.ts
@@ -4,11 +4,25 @@ import type { PostRepository } from "@/infra/db/repositories/PostRepository";
 
 function makePostRepo(
   posts: Array<{ id: number; path: string; title: string; content: string | null }>,
-): Pick<PostRepository, "getAllWithContent" | "update"> {
+): PostRepository {
   return {
-    getAllWithContent: vi.fn().mockResolvedValue(posts),
+    getPostsByCategory: vi.fn(),
+    getRecentPosts: vi.fn(),
+    getPostId: vi.fn(),
+    getPost: vi.fn(),
+    getAllPostPaths: vi.fn(),
+    getAllPostsForSitemap: vi.fn(),
+    getPostsByPaths: vi.fn(),
+    getAllPostsForSidebar: vi.fn(),
+    searchPosts: vi.fn(),
+    deactive: vi.fn(),
+    deactivateByIds: vi.fn(),
+    create: vi.fn(),
     update: vi.fn().mockResolvedValue(undefined),
-  };
+    getAllForSync: vi.fn(),
+    getAllWithContent: vi.fn().mockResolvedValue(posts),
+    getCategoryStats: vi.fn(),
+  } as unknown as PostRepository;
 }
 
 describe("PostService.retitleAll", () => {
@@ -20,7 +34,7 @@ describe("PostService.retitleAll", () => {
     const repo = makePostRepo([
       { id: 1, path: "AI/intro.md", title: "intro", content: null },
     ]);
-    const service = new PostService(repo as unknown as PostRepository);
+    const service = new PostService(repo);
 
     const result = await service.retitleAll();
 
@@ -37,7 +51,7 @@ describe("PostService.retitleAll", () => {
         content: "# 같은 제목\n\n본문",
       },
     ]);
-    const service = new PostService(repo as unknown as PostRepository);
+    const service = new PostService(repo);
 
     const result = await service.retitleAll();
 
@@ -54,7 +68,7 @@ describe("PostService.retitleAll", () => {
         content: "# 새로운 제목\n\n본문",
       },
     ]);
-    const service = new PostService(repo as unknown as PostRepository);
+    const service = new PostService(repo);
 
     const result = await service.retitleAll();
 
@@ -68,7 +82,7 @@ describe("PostService.retitleAll", () => {
       { id: 2, path: "b.md", title: "구 제목", content: "# 새 제목\n본문" }, // 변경 → update
       { id: 3, path: "c.md", title: "없음", content: null },                 // null → skip
     ]);
-    const service = new PostService(repo as unknown as PostRepository);
+    const service = new PostService(repo);
 
     const result = await service.retitleAll();
 

--- a/src/services/PostService.test.ts
+++ b/src/services/PostService.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PostService } from "./PostService";
+import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+
+function makePostRepo(
+  posts: Array<{ id: number; path: string; title: string; content: string | null }>,
+): Pick<PostRepository, "getAllWithContent" | "update"> {
+  return {
+    getAllWithContent: vi.fn().mockResolvedValue(posts),
+    update: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("PostService.retitleAll", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("content가 없는 포스트는 스킵한다", async () => {
+    const repo = makePostRepo([
+      { id: 1, path: "AI/intro.md", title: "intro", content: null },
+    ]);
+    const service = new PostService(repo as unknown as PostRepository);
+
+    const result = await service.retitleAll();
+
+    expect(result).toEqual({ total: 1, updated: 0, skipped: 1 });
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  it("추출한 제목이 현재 제목과 같으면 스킵한다", async () => {
+    const repo = makePostRepo([
+      {
+        id: 1,
+        path: "AI/intro.md",
+        title: "같은 제목",
+        content: "# 같은 제목\n\n본문",
+      },
+    ]);
+    const service = new PostService(repo as unknown as PostRepository);
+
+    const result = await service.retitleAll();
+
+    expect(result).toEqual({ total: 1, updated: 0, skipped: 1 });
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  it("추출한 제목이 다르면 update를 호출한다", async () => {
+    const repo = makePostRepo([
+      {
+        id: 1,
+        path: "AI/intro.md",
+        title: "구 제목",
+        content: "# 새로운 제목\n\n본문",
+      },
+    ]);
+    const service = new PostService(repo as unknown as PostRepository);
+
+    const result = await service.retitleAll();
+
+    expect(result).toEqual({ total: 1, updated: 1, skipped: 0 });
+    expect(repo.update).toHaveBeenCalledWith(1, { title: "새로운 제목" });
+  });
+
+  it("여러 포스트를 올바르게 집계한다", async () => {
+    const repo = makePostRepo([
+      { id: 1, path: "a.md", title: "새 제목", content: "# 새 제목\n본문" }, // 동일 → skip
+      { id: 2, path: "b.md", title: "구 제목", content: "# 새 제목\n본문" }, // 변경 → update
+      { id: 3, path: "c.md", title: "없음", content: null },                 // null → skip
+    ]);
+    const service = new PostService(repo as unknown as PostRepository);
+
+    const result = await service.retitleAll();
+
+    expect(result).toEqual({ total: 3, updated: 1, skipped: 2 });
+    expect(repo.update).toHaveBeenCalledTimes(1);
+    expect(repo.update).toHaveBeenCalledWith(2, { title: "새 제목" });
+  });
+});

--- a/src/services/PostSyncService.test.ts
+++ b/src/services/PostSyncService.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { parsePath } from "./PostSyncService";
+
+describe("parsePath", () => {
+  it("루트 경로 파일 — category는 확장자 포함 파일명, title은 확장자 제거", () => {
+    const result = parsePath("intro.md");
+    expect(result.category).toBe("intro.md"); // category: pathParts[0], 확장자 미제거
+    expect(result.foldersList).toEqual([]);
+    expect(result.subcategory).toBeUndefined();
+    expect(result.title).toBe("intro"); // title: pathParts[last], 확장자 제거
+  });
+
+  it("1단계 경로 — category와 파일명 분리", () => {
+    const result = parsePath("AI/intro.md");
+    expect(result.category).toBe("AI");
+    expect(result.foldersList).toEqual([]);
+    expect(result.subcategory).toBeUndefined();
+    expect(result.title).toBe("intro");
+  });
+
+  it("2단계 경로 — subcategory는 첫 번째 폴더", () => {
+    const result = parsePath("AI/RAG/intro.md");
+    expect(result.category).toBe("AI");
+    expect(result.foldersList).toEqual(["RAG"]);
+    expect(result.subcategory).toBe("RAG");
+    expect(result.title).toBe("intro");
+  });
+
+  it("3단계 이상 경로 — foldersList에 중간 폴더 모두 포함", () => {
+    const result = parsePath("AI/RAG/deep/intro.md");
+    expect(result.category).toBe("AI");
+    expect(result.foldersList).toEqual(["RAG", "deep"]);
+    expect(result.subcategory).toBe("RAG");
+    expect(result.title).toBe("intro");
+  });
+
+  it("파일명의 언더스코어를 공백으로 변환한다", () => {
+    const result = parsePath("AI/hello_world_guide.md");
+    expect(result.title).toBe("hello world guide");
+  });
+
+  it(".mdx 확장자도 제거한다", () => {
+    const result = parsePath("AI/intro.mdx");
+    expect(result.title).toBe("intro");
+  });
+
+  it("빈 문자열 — category는 uncategorized", () => {
+    const result = parsePath("");
+    expect(result.category).toBe("uncategorized");
+    expect(result.foldersList).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #37

## Summary

Service 레이어 3개 파일에 총 14개 단위 테스트 추가

| 파일 | 대상 | 테스트 수 |
|------|------|-----------|
| `PostSyncService.test.ts` | `parsePath()` 순수 함수 | 7개 |
| `PostService.test.ts` | `retitleAll()` | 4개 |
| `MetadataSyncService.test.ts` | `updateCategories()` | 3개 |

## 테스트 케이스

**parsePath()**: 루트/1단계/2단계/3단계 경로, 언더스코어 변환, .mdx 확장자, 빈 문자열

**retitleAll()**: content null → skip, 동일 제목 → skip, 변경된 제목 → update 호출, 다중 포스트 집계

**updateCategories()**: categoryIcons 매핑, 알 수 없는 카테고리 기본 아이콘(📁), 빈 통계 처리

## Test plan

- [x] `pnpm test` 통과 (83 tests, 7 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)