### PR TITLE
feat(env): @t3-oss/env-nextjs로 환경변수 타입 안전 관리 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_OWNER: jon890
           GITHUB_REPO: fos-study
+          NEXT_PUBLIC_SITE_URL: https://fosworld.co.kr
+          SKIP_ENV_VALIDATION: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,5 @@ jobs:
           GITHUB_OWNER: jon890
           GITHUB_REPO: fos-study
           NEXT_PUBLIC_SITE_URL: https://fosworld.co.kr
+          SYNC_API_KEY: dummy-ci-key
           SKIP_ENV_VALIDATION: "true"

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+import type { NextConfig } from "next";
+import "./src/env"; // 빌드 시 환경변수 검증
+
+const nextConfig: NextConfig = {
   output: 'standalone',
   images: {
     remotePatterns: [
@@ -18,4 +20,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^21.0.0",
+    "@t3-oss/env-nextjs": "^0.13.11",
     "bcryptjs": "^3.0.3",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.1",
@@ -33,7 +34,8 @@
     "rehype-highlight": "^7.0.0",
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@octokit/rest':
         specifier: ^21.0.0
         version: 21.1.1
+      '@t3-oss/env-nextjs':
+        specifier: ^0.13.11
+        version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -65,6 +68,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -1141,6 +1147,40 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@t3-oss/env-core@0.13.11':
+    resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
+  '@t3-oss/env-nextjs@0.13.11':
+    resolution: {integrity: sha512-NC+3j7YWgpzdFu1t5y/8wqibTK0lm5RS4bjXA1n8uwik3wIR4iZM4Fa+U2BaMa5k3Qk8RZiYhoAIX0WogmGkzg==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -4707,6 +4747,18 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@t3-oss/env-core@0.13.11(typescript@5.9.3)(zod@4.3.6)':
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.3.6
+
+  '@t3-oss/env-nextjs@0.13.11(typescript@5.9.3)(zod@4.3.6)':
+    dependencies:
+      '@t3-oss/env-core': 0.13.11(typescript@5.9.3)(zod@4.3.6)
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.3.6
 
   '@tailwindcss/node@4.1.18':
     dependencies:

--- a/src/app/ads.txt/route.ts
+++ b/src/app/ads.txt/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
+import { env } from "@/env";
 
 export async function GET() {
-  const adsenseId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_ID;
+  const adsenseId = env.NEXT_PUBLIC_GOOGLE_ADSENSE_ID;
 
   if (!adsenseId) {
     return new NextResponse("# ads.txt not configured", {

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { syncGitHubToDatabase, retitleExistingPosts } from "@/lib/sync-github";
 import logger from "@/lib/logger";
+import { env } from "@/env";
 
 const log = logger.child({ module: "api/sync" });
 
@@ -9,7 +10,7 @@ const log = logger.child({ module: "api/sync" });
 export async function POST(request: Request) {
   // API 키 검증 (선택사항)
   const authHeader = request.headers.get("authorization");
-  const apiKey = process.env.SYNC_API_KEY;
+  const apiKey = env.SYNC_API_KEY;
 
   if (apiKey && authHeader !== `Bearer ${apiKey}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -2,12 +2,12 @@ import { getRepositories } from "@/infra/db/repositories";
 import type { CategoryData } from "@/infra/db/types";
 import { CategoryList } from "@/components/CategoryList";
 import { Metadata } from "next";
+import { env } from "@/env";
 
 // ISR - 60초마다 페이지 재생성
 export const revalidate = 60;
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || "https://fosworld.co.kr";
+const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
 export const metadata: Metadata = {
   title: "카테고리",

--- a/src/app/category/[...path]/page.tsx
+++ b/src/app/category/[...path]/page.tsx
@@ -8,9 +8,9 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Folder, ChevronRight, Home, BookOpen } from "lucide-react";
 import { Metadata } from "next";
+import { env } from "@/env";
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || "https://fosworld.co.kr";
+const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
 // ISR - 60초마다 페이지 재생성
 export const revalidate = 60;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Noto_Sans_KR, JetBrains_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
+import { env } from "@/env";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Header } from "@/components/Header";
 import { VisitorCount } from "@/components/VisitorCount";
@@ -22,8 +23,7 @@ const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || "https://fosworld.co.kr";
+const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
@@ -82,7 +82,7 @@ export const metadata: Metadata = {
     },
   },
   verification: {
-    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+    google: env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
   },
   alternates: {
     canonical: siteUrl,
@@ -94,7 +94,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const adsenseId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_ID;
+  const adsenseId = env.NEXT_PUBLIC_GOOGLE_ADSENSE_ID;
 
   return (
     <html lang="ko" suppressHydrationWarning>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,13 @@
 import { getRepositories } from "@/infra/db/repositories";
 import type { CategoryData, PostData } from "@/infra/db/types";
+import { env } from "@/env";
 import { CategoryList } from "@/components/CategoryList";
 import { PostCard } from "@/components/PostCard";
 import { WebsiteJsonLd } from "@/components/JsonLd";
 import { ArrowRight, Sparkles, Flame } from "lucide-react";
 import Link from "next/link";
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || "https://fos-blog.vercel.app";
+const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
 // ISR - 60초마다 페이지 재생성
 export const revalidate = 60;

--- a/src/app/posts/[...slug]/page.tsx
+++ b/src/app/posts/[...slug]/page.tsx
@@ -17,9 +17,9 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Calendar, Clock, Folder, Github, Pencil } from "lucide-react";
 import { Metadata } from "next";
+import { env } from "@/env";
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || "https://fosworld.co.kr";
+const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
 // ISR - 60초마다 페이지 재생성
 export const revalidate = 60;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next";
+import { env } from "@/env";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://fos-blog.vercel.app";
+  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   return {
     rules: [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,13 @@
 import type { MetadataRoute } from "next";
 import { getRepositories } from "@/infra/db/repositories";
+import { env } from "@/env";
 import { computeFolderPaths } from "@/lib/path-utils";
 
 // ISR - 60초마다 재생성
 export const revalidate = 60;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://fosworld.co.kr";
+  const baseUrl = env.NEXT_PUBLIC_SITE_URL;
 
   const staticPages: MetadataRoute.Sitemap = [
     {

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,7 +5,7 @@ export const env = createEnv({
   server: {
     // 필수 — 없으면 startup에서 throw
     GITHUB_TOKEN: z.string().min(1),
-    DATABASE_URL: z.string().url(),
+    DATABASE_URL: z.string().url().optional(),
     SYNC_API_KEY: z.string().min(1),
 
     // 선택 (기본값 있음)

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,48 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod";
+
+export const env = createEnv({
+  server: {
+    // 필수 — 없으면 startup에서 throw
+    GITHUB_TOKEN: z.string().min(1),
+    DATABASE_URL: z.string().url(),
+    SYNC_API_KEY: z.string().min(1),
+
+    // 선택 (기본값 있음)
+    GITHUB_OWNER: z.string().default("jon890"),
+    GITHUB_REPO: z.string().default("fos-study"),
+    GITHUB_BRANCH: z.string().default("main"),
+    NODE_ENV: z
+      .enum(["development", "test", "production"])
+      .default("development"),
+
+    // 선택
+    USE_FULLTEXT_SEARCH: z.string().optional(),
+    LOG_LEVEL: z.string().optional(),
+  },
+  client: {
+    // 선택 (기본값 있음)
+    NEXT_PUBLIC_SITE_URL: z.string().url().default("https://fosworld.co.kr"),
+
+    // 선택
+    NEXT_PUBLIC_GOOGLE_ADSENSE_ID: z.string().optional(),
+    NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: z.string().optional(),
+  },
+  runtimeEnv: {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    DATABASE_URL: process.env.DATABASE_URL,
+    SYNC_API_KEY: process.env.SYNC_API_KEY,
+    GITHUB_OWNER: process.env.GITHUB_OWNER,
+    GITHUB_REPO: process.env.GITHUB_REPO,
+    GITHUB_BRANCH: process.env.GITHUB_BRANCH,
+    NODE_ENV: process.env.NODE_ENV,
+    USE_FULLTEXT_SEARCH: process.env.USE_FULLTEXT_SEARCH,
+    LOG_LEVEL: process.env.LOG_LEVEL,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+    NEXT_PUBLIC_GOOGLE_ADSENSE_ID: process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_ID,
+    NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION:
+      process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+  },
+  skipValidation: !!process.env.SKIP_ENV_VALIDATION,
+  emptyStringAsUndefined: true,
+});

--- a/src/infra/db/index.ts
+++ b/src/infra/db/index.ts
@@ -17,8 +17,7 @@ export function tryGetDb(): MySql2Database<typeof schema> | null {
   }
 
   // 런타임에 환경변수 확인
-  // skipValidation 모드(CI 등)에서는 undefined일 수 있음
-  const connectionString = env.DATABASE_URL as string | undefined;
+  const connectionString = env.DATABASE_URL;
   if (!connectionString) {
     console.warn("[DB] DATABASE_URL is not set");
     return null;

--- a/src/infra/db/index.ts
+++ b/src/infra/db/index.ts
@@ -1,6 +1,7 @@
 import { drizzle, MySql2Database } from "drizzle-orm/mysql2";
 import mysql from "mysql2/promise";
 import * as schema from "./schema";
+import { env } from "@/env";
 
 // 캐시된 DB 인스턴스
 let cachedDb: MySql2Database<typeof schema> | null = null;
@@ -16,14 +17,15 @@ export function tryGetDb(): MySql2Database<typeof schema> | null {
   }
 
   // 런타임에 환경변수 확인
-  const connectionString = process.env.DATABASE_URL;
+  // skipValidation 모드(CI 등)에서는 undefined일 수 있음
+  const connectionString = env.DATABASE_URL as string | undefined;
   if (!connectionString) {
     console.warn("[DB] DATABASE_URL is not set");
     return null;
   }
 
   // 개발 환경에서 쿼리 로깅 활성화
-  const enableLogging = process.env.NODE_ENV === "development";
+  const enableLogging = env.NODE_ENV === "development";
 
   const pool = mysql.createPool({
     uri: connectionString,

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -3,6 +3,7 @@ import { NewPost, posts } from "../schema";
 import { UpdatePost } from "../schema/posts";
 import type { PostData } from "../types";
 import { BaseRepository } from "./BaseRepository";
+import { env } from "@/env";
 
 export class PostRepository extends BaseRepository {
   async getPostsByCategory(category: string): Promise<PostData[]> {
@@ -142,7 +143,7 @@ export class PostRepository extends BaseRepository {
     }
 
     const searchQuery = query.trim();
-    const useFulltextSearch = process.env.USE_FULLTEXT_SEARCH !== "false";
+    const useFulltextSearch = env.USE_FULLTEXT_SEARCH !== "false";
 
     // FULLTEXT 검색 시도 (MySQL MATCH AGAINST)
     if (useFulltextSearch) {

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -143,7 +143,7 @@ export class PostRepository extends BaseRepository {
     }
 
     const searchQuery = query.trim();
-    const useFulltextSearch = env.USE_FULLTEXT_SEARCH !== "false";
+    const useFulltextSearch = (env.USE_FULLTEXT_SEARCH ?? "true") !== "false";
 
     // FULLTEXT 검색 시도 (MySQL MATCH AGAINST)
     if (useFulltextSearch) {

--- a/src/infra/github/client.ts
+++ b/src/infra/github/client.ts
@@ -1,9 +1,10 @@
 import { Octokit } from "@octokit/rest";
+import { env } from "@/env";
 
 export const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN,
+  auth: env.GITHUB_TOKEN,
 });
 
-export const OWNER = process.env.GITHUB_OWNER || "jon890";
-export const REPO = process.env.GITHUB_REPO || "fos-study";
-export const BRANCH = process.env.GITHUB_BRANCH || "main";
+export const OWNER = env.GITHUB_OWNER;
+export const REPO = env.GITHUB_REPO;
+export const BRANCH = env.GITHUB_BRANCH;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,13 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "node",
+    env: {
+      SKIP_ENV_VALIDATION: "true",
+      GITHUB_OWNER: "jon890",
+      GITHUB_REPO: "fos-study",
+      GITHUB_BRANCH: "main",
+      NEXT_PUBLIC_SITE_URL: "https://fosworld.co.kr",
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- `@t3-oss/env-nextjs` + `zod` 도입으로 빌드/시작 시점에 환경변수 검증
- `src/env.ts` 생성 — 필수 변수 누락 시 startup에서 즉시 throw
- 13개 파일의 `process.env.*` 직접 접근을 `env.*` 타입 안전 접근으로 교체
- `next.config.js` → `next.config.ts` 전환 및 빌드 시 env 검증 실행
- CI에 `SKIP_ENV_VALIDATION=true` 추가 — DB 없이도 빌드 통과

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `src/env.ts` | 환경변수 스키마 정의 (신규) |
| `next.config.ts` | TypeScript 전환 + env import (next.config.js 대체) |
| `src/infra/github/client.ts` | `GITHUB_TOKEN`, `OWNER`, `REPO`, `BRANCH` |
| `src/infra/db/index.ts` | `DATABASE_URL`, `NODE_ENV` |
| `src/infra/db/repositories/PostRepository.ts` | `USE_FULLTEXT_SEARCH` |
| `src/app/api/sync/route.ts` | `SYNC_API_KEY` |
| `src/app/layout.tsx` 외 6개 | `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_GOOGLE_*` |
| `.github/workflows/ci.yml` | `SKIP_ENV_VALIDATION`, `NEXT_PUBLIC_SITE_URL` 추가 |

## Test plan

- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `SKIP_ENV_VALIDATION=true pnpm build` 통과 (CI 시뮬레이션)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)