### PR TITLE
chore(skills): page-prd / page-impl 스킬 추가

### DIFF
--- a/.claude/skills/page-impl/SKILL.md
+++ b/.claude/skills/page-impl/SKILL.md
@@ -66,6 +66,7 @@ PRD에서 아래 항목을 파악한다:
 변경 파일:
 1. src/app/<route>/page.tsx — 페이지 메인
 2. src/components/<Name>.tsx — (신규 컴포넌트 필요 시만)
+3. src/services/<Name>Service.ts — (복잡한 비즈니스 로직이 필요 시만)
 
 재사용 컴포넌트: PostCard, CategoryList, ...
 데이터: getRepositories() → post.getXxx()
@@ -73,6 +74,11 @@ PRD에서 아래 항목을 파악한다:
 
 진행할까요?
 ```
+
+**아키텍처 레이어 결정 기준:**
+- **단순 조회** (1~2개 repository 메서드): 페이지에서 `getRepositories()` 직접 호출
+- **복잡한 비즈니스 로직** (여러 repository 조합, 변환 로직): `src/services/` 에 Service 클래스 작성 후 페이지에서 호출
+- 프로젝트 아키텍처: `app/ → services/ → infra/db+github/`
 
 ---
 
@@ -82,13 +88,30 @@ PRD에서 아래 항목을 파악한다:
 
 **기존 컴포넌트 우선**: 신규 작성 전에 `src/components/` 를 확인한다.
 
-**에러 처리 패턴** — 프로젝트 전체 일관성 유지:
+**Server / Client Component 결정 기준:**
+- **Server Component (기본)**: 데이터 페칭, DB 접근, `getRepositories()` 호출 — `"use client"` 없음
+- **Client Component** (`"use client"` 필수): `useState`, `useEffect`, 이벤트 핸들러(`onClick` 등) 사용 시. 반드시 파일 첫 줄에 위치.
+- 원칙: Server Component를 기본으로, 인터랙티브한 부분만 Client Component로 분리한다.
+
+**에러 처리 패턴** — DB 에러 후 fallback을 반드시 명시한다:
 ```typescript
 const log = logger.child({ module: "app/<route>" });
 
+// 패턴 A — 데이터 없으면 404 (단일 리소스 조회)
+let data = null;
+try {
+  const { post } = getRepositories();
+  data = await post.getPost(slug);
+} catch {
+  notFound();
+}
+if (!data) notFound();
+
+// 패턴 B — DB 없어도 빈 화면으로 폴백 (목록 페이지)
+let items: ItemType[] = [];
 try {
   const { xxx } = getRepositories();
-  data = await xxx.getXxx();
+  items = await xxx.getXxx();
 } catch (error) {
   log.warn(
     { err: error instanceof Error ? error : new Error(String(error)) },
@@ -96,6 +119,8 @@ try {
   );
 }
 ```
+
+PRD의 페이지 성격에 따라 패턴 A(상세 페이지) 또는 패턴 B(목록 페이지)를 선택한다.
 
 **필수 적용 항목:**
 - ISR: PRD의 revalidate 값으로 `export const revalidate = N`

--- a/.claude/skills/page-impl/SKILL.md
+++ b/.claude/skills/page-impl/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: page-impl
+description: |
+  docs/pages/ 의 PRD 문서를 기반으로 신규 페이지를 구현하거나 기존 페이지를 PRD에 맞게 수정하는 스킬.
+  다음 상황에서 반드시 이 스킬을 사용한다:
+  - "page-impl", "PRD로 구현해줘", "PRD 기반으로 페이지 만들어줘"
+  - "이 PRD 보고 코드 짜줘", "문서 보고 페이지 구현해줘", "PRD → 코드"
+  - "page-prd 만든 거 이제 구현해줘", "스펙 문서 있으니까 이제 만들어줘"
+  - PRD 문서가 docs/pages/ 에 있고 구현 작업을 시작하는 모든 상황
+  항상 PRD 문서(docs/pages/<name>.md)가 먼저 존재해야 한다.
+  없으면 `/page-prd <name>` 을 먼저 실행하도록 안내한다.
+---
+
+# page-impl — PRD 기반 페이지 구현
+
+## 개요
+
+`docs/pages/<page-name>.md` PRD를 읽고 페이지를 구현한다.
+신규 페이지 생성과 기존 페이지의 PRD 반영 모두 처리한다.
+
+**전제조건**: PRD 파일이 존재해야 한다.
+
+```bash
+ls docs/pages/
+```
+
+없으면 작업 중단 후 안내:
+> "PRD 문서가 없습니다. `/page-prd <name>` 을 먼저 실행해 문서를 작성해주세요."
+
+---
+
+## 파일명 규칙 (page-prd와 동일)
+
+| PRD 파일명 | 페이지 파일 |
+|-----------|------------|
+| `docs/pages/home.md` | `src/app/page.tsx` |
+| `docs/pages/categories.md` | `src/app/categories/page.tsx` |
+| `docs/pages/category-detail.md` | `src/app/category/[...path]/page.tsx` |
+| `docs/pages/post-detail.md` | `src/app/posts/[...slug]/page.tsx` |
+| `docs/pages/search.md` | `src/app/search/page.tsx` |
+
+---
+
+## 1단계: PRD 읽기 및 유사 패턴 파악
+
+PRD에서 아래 항목을 파악한다:
+- **Route** → 파일 경로 결정
+- **Data** → import할 repository 메서드 확인
+- **Components** → 재사용 가능 컴포넌트 vs 신규 작성 필요
+- **Constraints** → ISR, auth, Edge Runtime 제약
+
+**유사 페이지 찾기**: PRD의 데이터 패턴이나 컴포넌트가 기존 페이지와 비슷하면 해당 페이지를 참조 템플릿으로 읽는다.
+기존 페이지 목록은 `src/app/` 디렉토리를 빠르게 확인한다.
+
+---
+
+## 2단계: 구현 계획 제시 및 확인
+
+코드 작성 전에 아래 계획을 사용자에게 보여주고 승인을 받는다:
+
+```
+## 구현 계획 — <Page Name>
+
+파일: src/app/<route>/page.tsx  [신규 생성 / 수정]
+
+변경 파일:
+1. src/app/<route>/page.tsx — 페이지 메인
+2. src/components/<Name>.tsx — (신규 컴포넌트 필요 시만)
+
+재사용 컴포넌트: PostCard, CategoryList, ...
+데이터: getRepositories() → post.getXxx()
+참조 패턴: src/app/posts/[...slug]/page.tsx (유사 구조)
+
+진행할까요?
+```
+
+---
+
+## 3단계: 코드 구현
+
+### 핵심 원칙
+
+**기존 컴포넌트 우선**: 신규 작성 전에 `src/components/` 를 확인한다.
+
+**에러 처리 패턴** — 프로젝트 전체 일관성 유지:
+```typescript
+const log = logger.child({ module: "app/<route>" });
+
+try {
+  const { xxx } = getRepositories();
+  data = await xxx.getXxx();
+} catch (error) {
+  log.warn(
+    { err: error instanceof Error ? error : new Error(String(error)) },
+    "Database not available",
+  );
+}
+```
+
+**필수 적용 항목:**
+- ISR: PRD의 revalidate 값으로 `export const revalidate = N`
+- Metadata: `generateMetadata()` 또는 `export const metadata`
+- 로깅: `logger.child({ module: 'app/<route>' })`, console.log 금지
+- 환경변수: `import { env } from "@/env"`
+- 타입: `@/infra/db/types` 에서 import, strict 준수
+
+**신규 컴포넌트 작성 기준**: `src/components/` 에 없는 것만 작성.
+props 인터페이스를 명확히 정의하고 named export 사용.
+
+---
+
+## 4단계: 검증
+
+```bash
+pnpm lint && pnpm type-check
+```
+
+에러가 있으면 수정 후 재실행. `--no-verify` 절대 금지.
+
+---
+
+## 5단계: PRD 동기화
+
+구현 중 PRD와 다르게 결정한 사항(컴포넌트 변경, 데이터 소스 추가 등)이 있으면
+`docs/pages/<page-name>.md` 의 해당 섹션을 갱신하고 `Updated:` 날짜를 오늘로 변경한다.
+PRD와 코드가 일치하는 상태를 항상 유지한다.
+
+---
+
+## 6단계: 완료 보고
+
+```
+✅ 구현 완료 — <Page Name>
+
+생성/수정 파일:
+- src/app/<route>/page.tsx
+- src/components/<Name>.tsx  (신규인 경우)
+
+PRD 대비 변경사항:
+- <있으면 기재, 없으면 "PRD 그대로 구현">
+
+다음: `/commit-and-push` 로 커밋 및 PR 생성
+```

--- a/.claude/skills/page-prd/SKILL.md
+++ b/.claude/skills/page-prd/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: page-prd
+description: |
+  특정 페이지의 코드를 분석해 AI Agent가 이해할 수 있는 간결한 PRD 문서를 docs/pages/ 에 생성하거나 갱신하는 스킬.
+  다음 상황에서 반드시 이 스킬을 사용한다:
+  - "page-prd", "페이지 문서화", "페이지 PRD 작성", "페이지 스펙 문서 만들어줘"
+  - "이 페이지 분석해서 문서 만들어줘", "페이지 PRD 업데이트해줘", "docs 폴더에 페이지 문서 만들어줘"
+  - 새 페이지를 구현하기 전 PRD를 먼저 작성하자고 할 때
+  - 기존 페이지를 수정하기 전 현재 스펙을 문서화하자고 할 때
+  - "page-impl 전에 PRD 먼저" 같은 흐름에서
+  인수가 없으면 사용자에게 대상 페이지를 확인한다.
+---
+
+# page-prd — 페이지 PRD 자동 문서화
+
+## 개요
+
+페이지 코드를 읽고 AI Agent 친화적인 PRD 문서를 `docs/pages/<page-name>.md` 에 생성한다.
+이 문서는 두 가지 목적으로 사용된다:
+
+1. **유지보수 참조** — 기존 페이지 수정 시 컨텍스트로 활용
+2. **신규 구현 입력** — `/page-impl` 스킬의 입력 문서로 사용 (PRD → 코드 플로우)
+
+---
+
+## 1단계: 대상 페이지 결정
+
+인수가 있으면 그 페이지를, 없으면 사용자에게 확인한다.
+
+```
+/page-prd posts          → src/app/posts/[...slug]/page.tsx
+/page-prd categories     → src/app/categories/page.tsx
+/page-prd home           → src/app/page.tsx
+/page-prd category       → src/app/category/[...path]/page.tsx
+/page-prd search         → src/app/search/page.tsx
+```
+
+**파일 탐색 순서:**
+1. `src/app/<arg>/page.tsx`
+2. `src/app/<arg>/[...slug]/page.tsx`
+3. `src/app/<arg>/[...path]/page.tsx`
+4. `src/app/<arg>/[id]/page.tsx`
+5. 없으면 Glob으로 탐색 후 사용자에게 선택 요청
+
+> **API 라우트 제외**: `src/app/api/` 경로는 이 스킬의 대상이 아니다.
+> API 스펙 문서가 필요하면 사용자에게 별도 스킬이나 직접 작업을 안내한다.
+
+---
+
+## 2단계: 코드 분석
+
+**필요한 파일만 읽는다** — 과도한 탐색은 금지.
+
+### 반드시 읽는 파일
+- 페이지 파일 자체 (`page.tsx`)
+
+### 필요 시 추가로 읽는 파일
+- 페이지가 호출하는 repository 메서드 파일 (반환 타입 확인)
+- 페이지에서 import하는 컴포넌트 파일 (props 인터페이스 확인, 1~2개로 제한)
+
+### 파악 항목
+
+| 항목 | 확인 방법 |
+|------|-----------|
+| 라우트 패턴 | 파일 경로에서 추론 |
+| ISR/캐싱 | `export const revalidate` 값 |
+| 데이터 소스 | `getRepositories()` 호출, fetch |
+| 컴포넌트 | import 문 |
+| 클라이언트 상태 | `"use client"` 여부, useState/useEffect |
+| 인증/권한 | auth 관련 로직 |
+| Metadata | `generateMetadata`, `export const metadata` |
+| 정적 생성 | `generateStaticParams` 여부 |
+
+---
+
+## 3단계: PRD 문서 작성
+
+`docs/pages/` 디렉토리가 없으면 생성한다.
+아래 템플릿으로 `docs/pages/<page-name>.md` 를 작성한다.
+
+**간결하게** — 각 섹션은 필요한 정보만. 해당 없는 섹션은 생략한다.
+
+```markdown
+# <Page Title> — Page PRD
+
+**Route:** `<URL 패턴>`  
+**File:** `<파일 경로>`  
+**Updated:** <오늘 날짜 YYYY-MM-DD>
+
+---
+
+## Purpose
+
+<이 페이지가 하는 일을 1~2문장으로.>
+
+---
+
+## Data
+
+| Source | Method | Returns |
+|--------|--------|---------|
+| PostRepository | `getPost(slug)` | 글 본문 + 메타데이터 |
+
+**ISR:** `revalidate = 60`  
+**Static params:** `generateStaticParams()` 있음/없음
+
+---
+
+## Components
+
+| Component | Role |
+|-----------|------|
+| `MarkdownRenderer` | 마크다운 본문 렌더링 |
+| `TableOfContents` | 사이드바 목차 (lg 이상) |
+
+---
+
+## Interactions
+
+- **<인터랙션>**: <결과>
+
+(Server Component만 있으면 이 섹션 생략)
+
+---
+
+## Client State
+
+| State | Component | Description |
+|-------|-----------|-------------|
+| `activeSlug` | `TableOfContents` | 현재 뷰포트 내 헤딩 |
+
+(없으면 이 섹션 생략)
+
+---
+
+## SEO
+
+- `generateMetadata()`: title, description, og, twitter, canonical
+- JSON-LD: `ArticleJsonLd`, `BreadcrumbJsonLd`
+
+---
+
+## Related Files
+
+- `src/app/posts/[...slug]/page.tsx`
+- `src/components/MarkdownRenderer.tsx`
+- `src/infra/db/repositories/PostRepository.ts`
+
+---
+
+## Constraints
+
+- <이 페이지에만 적용되는 제약 또는 주의사항>
+- 없으면 이 섹션 생략
+
+---
+
+## Known TODOs
+
+- [ ] <있으면 기재, 없으면 이 섹션 생략>
+```
+
+---
+
+## 4단계: 기존 문서 처리
+
+`docs/pages/<page-name>.md` 가 이미 존재하면:
+1. 기존 문서를 읽는다
+2. 코드와 비교해 **변경된 항목만** 갱신한다
+3. **Known TODOs** 섹션은 보존한다 — 기존 항목 삭제 금지
+4. `Updated:` 날짜를 오늘로 갱신한다
+
+---
+
+## 5단계: 완료 보고
+
+```
+✅ docs/pages/<page-name>.md 생성/갱신 완료
+
+- Route: <URL>
+- 데이터 소스: <N>개
+- 컴포넌트: <N>개
+- ISR: revalidate = <값>
+```
+
+이후 사용자 의도에 따라 안내:
+- 기존 페이지 수정이 목적 → "이 문서를 참조해 작업을 시작하겠습니다"
+- 신규 페이지 구현이 목적 → "`/page-impl <page-name>` 으로 구현을 시작할 수 있습니다"
+
+---
+
+## 파일명 규칙
+
+| 페이지 파일 | PRD 파일명 |
+|------------|-----------|
+| `src/app/page.tsx` | `docs/pages/home.md` |
+| `src/app/categories/page.tsx` | `docs/pages/categories.md` |
+| `src/app/category/[...path]/page.tsx` | `docs/pages/category-detail.md` |
+| `src/app/posts/[...slug]/page.tsx` | `docs/pages/post-detail.md` |
+| `src/app/search/page.tsx` | `docs/pages/search.md` |


### PR DESCRIPTION
## Summary
- `page-prd`: 페이지 코드를 분석해 `docs/pages/<name>.md` PRD 문서 자동 생성/갱신
- `page-impl`: PRD 문서를 기반으로 페이지 코드 구현 (신규 / 기존 수정)
- PRD → 코드 플로우 지원: 두 스킬이 파일명 규칙을 공유하여 연속 사용 가능
- `skill-creator` 검토 후 trigger description 강화, 유사 패턴 탐색 명확화, 두 스킬 간 정합성 보완

## Workflow
```
/page-prd <page>   →  docs/pages/<name>.md 생성
/page-impl <page>  →  PRD 기반 코드 구현
/commit-and-push   →  커밋 & PR
```

## Test plan
- [ ] `/page-prd home` 실행 시 `docs/pages/home.md` 생성 확인
- [ ] PRD 없이 `/page-impl` 실행 시 안내 메시지 출력 확인
- [ ] `/page-prd` → `/page-impl` 연속 실행 시 파일명 규칙 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)