### PR TITLE
docs(pages): 전체 페이지 PRD 초기 작성

### DIFF
--- a/docs/pages/categories.md
+++ b/docs/pages/categories.md
@@ -1,0 +1,54 @@
+# 카테고리 목록 — Page PRD
+
+**Route:** `/categories`  
+**File:** `src/app/categories/page.tsx`  
+**Updated:** 2026-04-02
+
+---
+
+## Purpose
+
+블로그의 모든 카테고리를 그리드 형태로 나열하는 페이지. 각 카테고리별 글 수를 표시하고 해당 카테고리 상세로 이동하는 진입점 역할을 한다.
+
+---
+
+## Data
+
+| Source | Method | Returns |
+|--------|--------|---------|
+| CategoryRepository | `getCategories()` | 카테고리 목록 (slug, name, count) |
+
+**ISR:** `revalidate = 60`  
+**Static params:** 없음
+
+**에러 처리:** DB 에러 시 빈 배열로 폴백 — 빈 카테고리 목록 렌더링
+
+---
+
+## Components
+
+| Component | Role |
+|-----------|------|
+| `CategoryList` | 카테고리 카드 그리드 |
+
+---
+
+## Interactions
+
+- **카테고리 카드 클릭**: `/category/<slug>` 이동 (CategoryList 내부 처리)
+
+---
+
+## SEO
+
+- `export const metadata` (정적): title="카테고리", canonical=`/categories`, og type=website
+- JSON-LD 없음
+
+---
+
+## Related Files
+
+- `src/app/categories/page.tsx`
+- `src/components/CategoryList.tsx`
+- `src/infra/db/repositories/CategoryRepository.ts`
+- `src/infra/db/types.ts` — `CategoryData` 타입

--- a/docs/pages/category-detail.md
+++ b/docs/pages/category-detail.md
@@ -1,0 +1,82 @@
+# 카테고리/폴더 상세 — Page PRD
+
+**Route:** `/category/[...path]`  
+**File:** `src/app/category/[...path]/page.tsx`  
+**Updated:** 2026-04-02
+
+---
+
+## Purpose
+
+특정 카테고리 또는 하위 폴더의 내용을 보여주는 페이지. 하위 폴더 목록, 해당 폴더의 글 목록, README.md(있으면) 를 표시한다. 다단계 중첩 경로를 지원한다.
+
+---
+
+## Data
+
+| Source | Method | Returns |
+|--------|--------|---------|
+| FolderRepository | `getFolderContents(folderPath)` | `{ folders, posts, readme }` |
+| VisitRepository | `getPostVisitCounts(postPaths)` | 글 조회수 맵 |
+
+`folderPath` = `pathSegments.join("/")`  
+`pathSegments` = URL 세그먼트 배열 (decodeURIComponent 처리)
+
+**ISR:** `revalidate = 60`  
+**Static params:** `generateStaticParams()` — `computeFolderPaths(post.getAllPostPaths())` 로 생성
+
+**에러 처리:**
+- DB 에러 시 빈 폴더 컨텐츠로 폴백
+- `folders`, `posts`, `readme` 모두 없으면 `notFound()`
+
+---
+
+## Components
+
+| Component | Role |
+|-----------|------|
+| `PostCard` | 글 목록 카드 (showCategory=false) |
+| `MarkdownRenderer` | README.md 렌더링 (있을 때만) |
+| `BreadcrumbJsonLd` | JSON-LD 브레드크럼 |
+
+---
+
+## Interactions
+
+- **"상위 폴더로" / "카테고리 목록으로"**: 상위 경로 또는 `/categories` 이동
+- **브레드크럼 링크**: 경로 중간 세그먼트로 이동
+- **하위 폴더 카드 클릭**: `/category/<folder.path>` 이동
+- **PostCard 클릭**: `/posts/<post.path>` 이동
+
+---
+
+## SEO
+
+- `generateMetadata()`: title=currentFolder, description, canonical, og type=website
+- `BreadcrumbJsonLd`: 홈 → 카테고리 세그먼트들
+
+---
+
+## Layout
+
+```
+← 상위 폴더로 / ← 카테고리 목록으로
+브레드크럼 네비게이션 (Home > ... > currentFolder)
+헤더 (카테고리 아이콘 + 폴더명 + 폴더/글 수)
+README.md 섹션 (있을 때만)
+하위 폴더 그리드 (있을 때만)
+이 폴더의 글 목록 (있을 때만)
+```
+
+---
+
+## Related Files
+
+- `src/app/category/[...path]/page.tsx`
+- `src/components/PostCard.tsx`
+- `src/components/MarkdownRenderer.tsx`
+- `src/components/JsonLd.tsx`
+- `src/infra/db/repositories/FolderRepository.ts`
+- `src/infra/db/repositories/VisitRepository.ts`
+- `src/infra/db/constants.ts` — `categoryIcons`, `DEFAULT_CATEGORY_ICON`
+- `src/lib/path-utils.ts` — `computeFolderPaths`

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -1,0 +1,77 @@
+# 홈 — Page PRD
+
+**Route:** `/`  
+**File:** `src/app/page.tsx`  
+**Updated:** 2026-04-02
+
+---
+
+## Purpose
+
+블로그의 메인 랜딩 페이지. 카테고리 목록, 인기 글, 최근 글, 통계를 보여주며 방문자가 원하는 콘텐츠로 빠르게 이동하도록 돕는다.
+
+---
+
+## Data
+
+| Source | Method | Returns |
+|--------|--------|---------|
+| CategoryRepository | `getCategories()` | 전체 카테고리 목록 + 글 수 |
+| PostRepository | `getRecentPosts(6)` | 최근 글 6개 |
+| VisitRepository | `getPopularPostPaths(limit*3)` | 인기 글 경로 + 조회수 |
+| PostRepository | `getPostsByPaths(paths)` | 인기 글 상세 데이터 |
+| VisitRepository | `getPostVisitCounts(postPaths)` | 최근 글 조회수 맵 |
+
+**ISR:** `revalidate = 60`  
+**Static params:** 없음
+
+**에러 처리:** DB 에러 시 빈 배열로 폴백 — 빈 화면으로 렌더링됨 (notFound 없음)
+
+---
+
+## Components
+
+| Component | Role |
+|-----------|------|
+| `CategoryList` | 카테고리 그리드 (최대 6개 표시) |
+| `PostCard` | 인기 글 / 최근 글 카드 |
+| `WebsiteJsonLd` | JSON-LD 구조화 데이터 |
+
+---
+
+## Interactions
+
+- **카테고리 카드 클릭**: `/category/<slug>` 이동
+- **"모두 보기" 링크**: `/categories` 이동
+- **PostCard 클릭**: `/posts/<path>` 이동
+
+---
+
+## SEO
+
+- `WebsiteJsonLd`: name="FOS Study", description, url
+- 별도 `generateMetadata` / `export const metadata` 없음 (루트 layout.tsx의 default metadata 사용)
+
+---
+
+## Layout
+
+```
+Hero Section (제목 + 설명)
+Categories Section (최대 6개 → "모두 보기" 링크)
+Popular Posts Section (인기 글, 조회수 있을 때만 표시)
+Recent Posts Section (최근 6개)
+Stats Section (카테고리 수 / 전체 글 수 / "계속 성장 중")
+```
+
+---
+
+## Related Files
+
+- `src/app/page.tsx`
+- `src/components/CategoryList.tsx`
+- `src/components/PostCard.tsx`
+- `src/components/JsonLd.tsx`
+- `src/infra/db/repositories/CategoryRepository.ts`
+- `src/infra/db/repositories/PostRepository.ts`
+- `src/infra/db/repositories/VisitRepository.ts`

--- a/docs/pages/post-detail.md
+++ b/docs/pages/post-detail.md
@@ -36,7 +36,7 @@
 | `MarkdownRenderer` | 마크다운 본문 렌더링 (GFM, mermaid, syntax highlight) |
 | `TableOfContents` | 사이드바 목차 (lg 이상에서만 표시, `hidden lg:block`) |
 | `Comments` | 댓글 섹션 (postSlug 전달) |
-| `PostViewCount` | 조회수 표시 (클라이언트 사이드 카운트 증가 포함) |
+| `PostViewCount` | 조회수 표시 (클라이언트에서 `/api/visit?path=...` GET으로 fetch) |
 | `ArticleJsonLd` | JSON-LD 아티클 구조화 데이터 |
 | `BreadcrumbJsonLd` | JSON-LD 브레드크럼 |
 
@@ -57,7 +57,7 @@
 | State | Component | Description |
 |-------|-----------|-------------|
 | `activeSlug` | `TableOfContents` | IntersectionObserver로 현재 뷰포트 내 헤딩 추적 |
-| `isCollapsed` | `TableOfContents` | 목차 접기/펼치기 상태 (localStorage 유지) — `feat/toc-collapsible` 브랜치에서 추가됨 |
+| `isCollapsed` | `TableOfContents` | 목차 접기/펼치기 상태 (localStorage 유지) |
 
 ---
 
@@ -118,3 +118,4 @@
 - `TableOfContents`는 `toc.length > 0` 일 때만 렌더링
 - GitHub URL은 `jon890/fos-study` 레포 고정
 - 모바일에서 TOC 미노출 — 별도 모바일 TOC 구현 시 이 문서 업데이트 필요
+- **조회수 증가**는 `src/proxy.ts`(Edge middleware)에서 처리 — `PostViewCount`는 표시만 담당

--- a/docs/pages/post-detail.md
+++ b/docs/pages/post-detail.md
@@ -1,0 +1,120 @@
+# 글 상세 — Page PRD
+
+**Route:** `/posts/[...slug]`  
+**File:** `src/app/posts/[...slug]/page.tsx`  
+**Updated:** 2026-04-02
+
+---
+
+## Purpose
+
+마크다운 글의 상세 내용을 렌더링하는 페이지. 본문, 목차(사이드바), 메타 정보(읽기 시간, 작성일, 수정일, 조회수), 댓글을 제공한다.
+
+---
+
+## Data
+
+| Source | Method | Returns |
+|--------|--------|---------|
+| PostRepository | `getPost(slug)` | `{ content: string, post: PostData }` |
+
+`slug` = URL 세그먼트 배열을 `join("/")` (decodeURIComponent 처리)
+
+**ISR:** `revalidate = 60`  
+**Static params:** `generateStaticParams()` — `post.getAllPostPaths()` 로 생성
+
+**에러 처리:**
+- DB 에러 시 `notFound()`
+- `data === null` 시 `notFound()`
+
+---
+
+## Components
+
+| Component | Role |
+|-----------|------|
+| `MarkdownRenderer` | 마크다운 본문 렌더링 (GFM, mermaid, syntax highlight) |
+| `TableOfContents` | 사이드바 목차 (lg 이상에서만 표시, `hidden lg:block`) |
+| `Comments` | 댓글 섹션 (postSlug 전달) |
+| `PostViewCount` | 조회수 표시 (클라이언트 사이드 카운트 증가 포함) |
+| `ArticleJsonLd` | JSON-LD 아티클 구조화 데이터 |
+| `BreadcrumbJsonLd` | JSON-LD 브레드크럼 |
+
+---
+
+## Interactions
+
+- **카테고리 배지 클릭**: `/category/<category>` 이동
+- **목차 항목 클릭**: 해당 헤딩으로 스크롤 (`#slug` 앵커)
+- **"GitHub에서 보기" 링크**: GitHub 원본 파일 새 탭 오픈
+- **"수정 제안하기" 버튼**: GitHub 원본 파일 새 탭 오픈
+- **"카테고리의 다른 글 보기"**: `/category/<category>` 이동
+
+---
+
+## Client State
+
+| State | Component | Description |
+|-------|-----------|-------------|
+| `activeSlug` | `TableOfContents` | IntersectionObserver로 현재 뷰포트 내 헤딩 추적 |
+| `isCollapsed` | `TableOfContents` | 목차 접기/펼치기 상태 (localStorage 유지) — `feat/toc-collapsible` 브랜치에서 추가됨 |
+
+---
+
+## SEO
+
+- `generateMetadata()`: title, description, canonical, og(article), twitter(summary_large_image), publishedTime, modifiedTime
+- `ArticleJsonLd`: url, title, description, datePublished, dateModified, authorName/Url
+- `BreadcrumbJsonLd`: 홈 → 카테고리 → (서브카테고리) → 글 제목
+- Canonical: `${siteUrl}/posts/${slug}`
+
+---
+
+## Layout
+
+```
+← 목록으로 돌아가기
+┌─────────────────────────────┬──────────────┐
+│ <article>                   │ <aside>      │
+│   헤더 (카테고리, 제목,     │ TableOfContents│
+│         메타, 조회수)       │ (lg:block)   │
+│   MarkdownRenderer           │              │
+│   푸터 (카테고리링크, GitHub)│              │
+│   Comments                  │              │
+└─────────────────────────────┴──────────────┘
+```
+
+모바일: aside 숨김 (`hidden lg:block`), TOC 미노출
+
+---
+
+## Server-side Processing
+
+`lib/markdown.ts` 함수들이 서버에서 실행됨:
+- `parseFrontMatter(content)` — frontmatter 제거
+- `extractTitle(content)` — h1 헤딩 추출
+- `extractDescription(content)` — 첫 단락 추출
+- `getReadingTime(content)` — 읽기 시간 계산
+- `generateTableOfContents(mainContent)` — TOC 항목 생성
+
+---
+
+## Related Files
+
+- `src/app/posts/[...slug]/page.tsx`
+- `src/components/MarkdownRenderer.tsx`
+- `src/components/TableOfContents.tsx`
+- `src/components/Comments.tsx`
+- `src/components/PostViewCount.tsx`
+- `src/components/JsonLd.tsx`
+- `src/infra/db/repositories/PostRepository.ts`
+- `src/lib/markdown.ts`
+- `src/infra/db/constants.ts` — `categoryIcons`
+
+---
+
+## Constraints
+
+- `TableOfContents`는 `toc.length > 0` 일 때만 렌더링
+- GitHub URL은 `jon890/fos-study` 레포 고정
+- 모바일에서 TOC 미노출 — 별도 모바일 TOC 구현 시 이 문서 업데이트 필요


### PR DESCRIPTION
## Summary
- `docs/pages/home.md` — 홈 페이지 (카테고리/인기글/최근글/통계 섹션)
- `docs/pages/categories.md` — 카테고리 목록 페이지
- `docs/pages/category-detail.md` — 카테고리/폴더 상세 (중첩 경로, README, static params)
- `docs/pages/post-detail.md` — 글 상세 (마크다운 렌더링, TOC, 댓글, SEO 전체 스펙)

## 목적
- `/page-prd` + `/page-impl` 스킬의 입력 문서로 활용
- 페이지 유지보수 시 컨텍스트 참조
- 신규 페이지 추가 시 기존 패턴 참고 기반

## Test plan
- [ ] 각 PRD 파일 내용이 실제 코드와 일치하는지 확인
- [ ] `/page-impl <page>` 실행 시 PRD를 올바르게 읽는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)