### PR TITLE
chore(local): crontab.example 추가 및 AGENTS.md 업데이트

### DIFF
--- a/local/AGENTS.md
+++ b/local/AGENTS.md
@@ -19,6 +19,7 @@
 |------|-------------|
 | `docker-compose.yml` | MySQL 8.4 컨테이너 설정 — 포트 13307, 볼륨 마운트, health check |
 | `mysql/init.sql` | 최초 컨테이너 시작 시 실행되는 초기화 SQL — DB, 사용자, 권한 설정 |
+| `crontab.example` | 콘텐츠 동기화 cron 예시 — 매 시간 `/api/sync` 호출, `crontab` 명령으로 설치 |
 
 ## For AI Agents
 

--- a/local/crontab.example
+++ b/local/crontab.example
@@ -1,0 +1,11 @@
+# fos-blog 콘텐츠 동기화 cron 설정
+# 설치 방법:
+#   crontab local/crontab.example
+#
+# 주의: SYNC_API_KEY는 .env 파일의 값과 동일해야 한다.
+#       YOUR_SYNC_API_KEY를 실제 키로 교체한 후 설치할 것.
+
+# 콘텐츠 동기화: 매 시간 정각 (GitHub → MySQL)
+0 * * * * curl -s -X POST http://localhost:3000/api/sync \
+  -H "Authorization: Bearer YOUR_SYNC_API_KEY" \
+  >> /var/log/fos-blog-sync.log 2>&1


### PR DESCRIPTION
## Summary
- `local/crontab.example` 추가: 매 시간 `/api/sync`를 호출하는 cron 설정 예시
- `local/AGENTS.md` 업데이트: Key Files 섹션에 `crontab.example` 설명 추가

Closes #53

## Test plan
- [ ] `crontab local/crontab.example` 명령으로 설치 가능한지 확인
- [ ] `YOUR_SYNC_API_KEY`를 실제 키로 교체 후 cron 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)