### PR TITLE
test(SyncService): SyncService 및 PostSyncService.upsert 단위 테스트 추가

### DIFF
--- a/src/services/PostSyncService.test.ts
+++ b/src/services/PostSyncService.test.ts
@@ -87,7 +87,7 @@ describe("PostSyncService.upsert", () => {
 
   it("기존 포스트가 없으면 postRepo.create를 호출하고 'added'를 반환한다", async () => {
     const { postRepo, githubApi } = makeMocks();
-    vi.mocked(githubApi.getFileContent).mockResolvedValue({ content: "# Hello", sha: "sha123" } as never);
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({ content: "# Hello", sha: "sha123" });
     vi.mocked(postRepo.getPostId).mockResolvedValue(null);
 
     const service = new PostSyncService(postRepo, githubApi);
@@ -100,7 +100,7 @@ describe("PostSyncService.upsert", () => {
 
   it("기존 포스트가 있으면 postRepo.update를 호출하고 'updated'를 반환한다", async () => {
     const { postRepo, githubApi } = makeMocks();
-    vi.mocked(githubApi.getFileContent).mockResolvedValue({ content: "# Hello", sha: "sha456" } as never);
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({ content: "# Hello", sha: "sha456" });
     vi.mocked(postRepo.getPostId).mockResolvedValue(42);
 
     const service = new PostSyncService(postRepo, githubApi);

--- a/src/services/PostSyncService.test.ts
+++ b/src/services/PostSyncService.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { parsePath } from "./PostSyncService";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { parsePath, PostSyncService } from "./PostSyncService";
+import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+import type { getFileContent, getFileCommitDates } from "@/infra/github/api";
 
 describe("parsePath", () => {
   it("루트 경로 파일 — category는 확장자 포함 파일명, title은 확장자 제거", () => {
@@ -48,5 +50,64 @@ describe("parsePath", () => {
     const result = parsePath("");
     expect(result.category).toBe("uncategorized");
     expect(result.foldersList).toEqual([]);
+  });
+});
+
+describe("PostSyncService.upsert", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeMocks() {
+    const postRepo = {
+      getPostId: vi.fn(),
+      create: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PostRepository;
+
+    const githubApi = {
+      getFileContent: vi.fn(),
+      getFileCommitDates: vi.fn().mockResolvedValue(null),
+    } as unknown as { getFileContent: typeof getFileContent; getFileCommitDates: typeof getFileCommitDates };
+
+    return { postRepo, githubApi };
+  }
+
+  it("getFileContent가 null을 반환하면 'skipped'를 반환한다", async () => {
+    const { postRepo, githubApi } = makeMocks();
+    vi.mocked(githubApi.getFileContent).mockResolvedValue(null);
+
+    const service = new PostSyncService(postRepo, githubApi);
+    const result = await service.upsert("AI/intro.md");
+
+    expect(result).toBe("skipped");
+    expect(postRepo.create).not.toHaveBeenCalled();
+    expect(postRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("기존 포스트가 없으면 postRepo.create를 호출하고 'added'를 반환한다", async () => {
+    const { postRepo, githubApi } = makeMocks();
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({ content: "# Hello", sha: "sha123" } as never);
+    vi.mocked(postRepo.getPostId).mockResolvedValue(null);
+
+    const service = new PostSyncService(postRepo, githubApi);
+    const result = await service.upsert("AI/intro.md");
+
+    expect(result).toBe("added");
+    expect(postRepo.create).toHaveBeenCalledOnce();
+    expect(postRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("기존 포스트가 있으면 postRepo.update를 호출하고 'updated'를 반환한다", async () => {
+    const { postRepo, githubApi } = makeMocks();
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({ content: "# Hello", sha: "sha456" } as never);
+    vi.mocked(postRepo.getPostId).mockResolvedValue(42);
+
+    const service = new PostSyncService(postRepo, githubApi);
+    const result = await service.upsert("AI/intro.md");
+
+    expect(result).toBe("updated");
+    expect(postRepo.update).toHaveBeenCalledWith(42, expect.objectContaining({ sha: "sha456" }));
+    expect(postRepo.create).not.toHaveBeenCalled();
   });
 });

--- a/src/services/SyncService.test.ts
+++ b/src/services/SyncService.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { SyncService } from "./SyncService";
+import type { SyncLog } from "@/infra/db/schema/syncLogs";
 import type { PostSyncService } from "./PostSyncService";
 import type { MetadataSyncService } from "./MetadataSyncService";
 import type { PostRepository } from "@/infra/db/repositories/PostRepository";
@@ -61,7 +62,7 @@ describe("SyncService.sync", () => {
     const sha = "abc1234";
 
     vi.mocked(githubApi.getCurrentHeadSha).mockResolvedValue(sha);
-    vi.mocked(syncLogRepo.getLatest).mockResolvedValue({ commitSha: sha } as never);
+    vi.mocked(syncLogRepo.getLatest).mockResolvedValue({ commitSha: sha } as SyncLog);
 
     const service = new SyncService(postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi);
     const result = await service.sync();
@@ -95,7 +96,7 @@ describe("SyncService.sync", () => {
     const lastSha = "oldsha";
 
     vi.mocked(githubApi.getCurrentHeadSha).mockResolvedValue(headSha);
-    vi.mocked(syncLogRepo.getLatest).mockResolvedValue({ commitSha: lastSha } as never);
+    vi.mocked(syncLogRepo.getLatest).mockResolvedValue({ commitSha: lastSha } as SyncLog);
     vi.mocked(githubApi.getChangedFilesSince).mockResolvedValue(null);
 
     const service = new SyncService(postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi);

--- a/src/services/SyncService.test.ts
+++ b/src/services/SyncService.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { SyncService } from "./SyncService";
+import type { PostSyncService } from "./PostSyncService";
+import type { MetadataSyncService } from "./MetadataSyncService";
+import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+import type { SyncLogRepository } from "@/infra/db/repositories/SyncLogRepository";
+import type {
+  getChangedFilesSince,
+  getCurrentHeadSha,
+  getDirectoryContents,
+  getFileCommitDates,
+  getFileContent,
+} from "@/infra/github/api";
+
+type GithubApi = {
+  getCurrentHeadSha: typeof getCurrentHeadSha;
+  getChangedFilesSince: typeof getChangedFilesSince;
+  getDirectoryContents: typeof getDirectoryContents;
+  getFileContent: typeof getFileContent;
+  getFileCommitDates: typeof getFileCommitDates;
+};
+
+function makeMocks() {
+  const postSyncService = {
+    upsert: vi.fn(),
+  } as unknown as PostSyncService;
+
+  const metadataSyncService = {
+    updateCategories: vi.fn().mockResolvedValue(undefined),
+    syncFolderReadmes: vi.fn().mockResolvedValue(undefined),
+  } as unknown as MetadataSyncService;
+
+  const postRepo = {
+    getAllForSync: vi.fn().mockResolvedValue([]),
+    deactivateByIds: vi.fn().mockResolvedValue(0),
+  } as unknown as PostRepository;
+
+  const syncLogRepo = {
+    getLatest: vi.fn(),
+    create: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SyncLogRepository;
+
+  const githubApi = {
+    getCurrentHeadSha: vi.fn(),
+    getChangedFilesSince: vi.fn(),
+    getDirectoryContents: vi.fn().mockResolvedValue([]),
+    getFileContent: vi.fn(),
+    getFileCommitDates: vi.fn(),
+  } as unknown as GithubApi;
+
+  return { postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi };
+}
+
+describe("SyncService.sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lastSyncedSha === headSha 이면 upToDate: true를 반환한다", async () => {
+    const { postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi } = makeMocks();
+    const sha = "abc1234";
+
+    vi.mocked(githubApi.getCurrentHeadSha).mockResolvedValue(sha);
+    vi.mocked(syncLogRepo.getLatest).mockResolvedValue({ commitSha: sha } as never);
+
+    const service = new SyncService(postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi);
+    const result = await service.sync();
+
+    expect(result.upToDate).toBe(true);
+    expect(result.commitSha).toBe(sha);
+    expect(syncLogRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("lastSyncedSha가 없으면 performFullSync를 호출한다", async () => {
+    const { postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi } = makeMocks();
+    const headSha = "def5678";
+
+    vi.mocked(githubApi.getCurrentHeadSha).mockResolvedValue(headSha);
+    vi.mocked(syncLogRepo.getLatest).mockResolvedValue(null);
+
+    const service = new SyncService(postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi);
+    const result = await service.sync();
+
+    // getDirectoryContents가 호출됐으면 performFullSync가 실행된 것
+    expect(githubApi.getDirectoryContents).toHaveBeenCalled();
+    expect(result.commitSha).toBe(headSha);
+    expect(syncLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "success", commitSha: headSha }),
+    );
+  });
+
+  it("getChangedFilesSince가 null을 반환하면 performFullSync로 폴백한다", async () => {
+    const { postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi } = makeMocks();
+    const headSha = "ghi9012";
+    const lastSha = "oldsha";
+
+    vi.mocked(githubApi.getCurrentHeadSha).mockResolvedValue(headSha);
+    vi.mocked(syncLogRepo.getLatest).mockResolvedValue({ commitSha: lastSha } as never);
+    vi.mocked(githubApi.getChangedFilesSince).mockResolvedValue(null);
+
+    const service = new SyncService(postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi);
+    await service.sync();
+
+    // getDirectoryContents가 호출됐으면 performFullSync 폴백이 실행된 것
+    expect(githubApi.getDirectoryContents).toHaveBeenCalled();
+    expect(syncLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "success" }),
+    );
+  });
+
+  it("에러 발생 시 syncLogRepo.create({ status: 'failed' })를 호출하고 에러를 다시 던진다", async () => {
+    const { postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi } = makeMocks();
+    const error = new Error("GitHub API 오류");
+
+    vi.mocked(githubApi.getCurrentHeadSha).mockRejectedValue(error);
+
+    const service = new SyncService(postSyncService, metadataSyncService, postRepo, syncLogRepo, githubApi);
+
+    await expect(service.sync()).rejects.toThrow("GitHub API 오류");
+    expect(syncLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed", error: "GitHub API 오류" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `SyncService.test.ts` 신규 생성: 핵심 sync 흐름 4개 케이스 검증
  - `lastSyncedSha === headSha` → `upToDate: true` 반환
  - `lastSyncedSha` 없음 → `performFullSync` 호출
  - `getChangedFilesSince` null → `performFullSync` 폴백
  - 에러 발생 시 `syncLogRepo.create({ status: "failed" })` 호출
- `PostSyncService.test.ts` 확장: `upsert()` 메서드 3개 케이스 추가
  - `getFileContent` null → `"skipped"` 반환
  - 신규 파일 → `postRepo.create` 호출 후 `"added"` 반환
  - 기존 파일 → `postRepo.update` 호출 후 `"updated"` 반환

Closes #49

## Test plan
- [x] `pnpm test` — 93개 테스트 전부 통과
- [x] `pnpm lint && pnpm type-check` — 이상 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)