### PR TITLE
refactor(sync): retitleExistingPosts를 SyncService 내부로 이동

### DIFF
--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { syncGitHubToDatabase, retitleExistingPosts } from "@/lib/sync-github";
+import { syncGitHubToDatabase } from "@/lib/sync-github";
 import logger from "@/lib/logger";
 import { env } from "@/env";
 
@@ -18,7 +18,6 @@ export async function POST(request: Request) {
 
   try {
     const syncResult = await syncGitHubToDatabase();
-    const retitleResult = await retitleExistingPosts();
 
     return NextResponse.json({
       success: true,
@@ -29,11 +28,7 @@ export async function POST(request: Request) {
         updated: syncResult.updated,
         deleted: syncResult.deleted,
       },
-      titles: {
-        updated: retitleResult.updated,
-        skipped: retitleResult.skipped,
-        total: retitleResult.total,
-      },
+      titles: syncResult.titles,
     });
   } catch (error) {
     log.error({ err: error instanceof Error ? error : new Error(String(error)) }, "Sync error");

--- a/src/lib/sync-github.ts
+++ b/src/lib/sync-github.ts
@@ -1,5 +1,6 @@
+import type { SyncService } from "@/services";
 import { createSyncService } from "@/services";
 
-export async function syncGitHubToDatabase() {
+export async function syncGitHubToDatabase(): ReturnType<SyncService["sync"]> {
   return createSyncService().sync();
 }

--- a/src/lib/sync-github.ts
+++ b/src/lib/sync-github.ts
@@ -1,9 +1,5 @@
-import { createSyncService, createPostService } from "@/services";
+import { createSyncService } from "@/services";
 
 export async function syncGitHubToDatabase() {
   return createSyncService().sync();
-}
-
-export async function retitleExistingPosts() {
-  return createPostService().retitleAll();
 }

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -13,6 +13,7 @@ import { shouldSyncFile } from "@/infra/github/file-filter";
 import { rewriteImagePaths } from "@/infra/github/image-rewrite";
 import { PostSyncService, parsePath } from "./PostSyncService";
 import { MetadataSyncService } from "./MetadataSyncService";
+import { PostService } from "./PostService";
 import logger from "@/lib/logger";
 
 const log = logger.child({ module: "SyncService" });
@@ -29,6 +30,7 @@ export class SyncService {
   constructor(
     private postSyncService: PostSyncService,
     private metadataSyncService: MetadataSyncService,
+    private postService: PostService,
     private postRepo: PostRepository,
     private syncLogRepo: SyncLogRepository,
     private githubApi: GithubApi,
@@ -40,6 +42,7 @@ export class SyncService {
     deleted: number;
     commitSha: string;
     upToDate?: boolean;
+    titles: { total: number; updated: number; skipped: number };
   }> {
     log.info("GitHub → Database 동기화 시작...");
 
@@ -59,12 +62,14 @@ export class SyncService {
 
       if (lastSyncedSha === headSha) {
         log.info("이미 최신 상태입니다.");
+        const titles = await this.postService.retitleAll();
         return {
           added: 0,
           updated: 0,
           deleted: 0,
           commitSha: headSha,
           upToDate: true,
+          titles,
         };
       }
 
@@ -91,6 +96,7 @@ export class SyncService {
 
       await this.metadataSyncService.updateCategories();
       await this.metadataSyncService.syncFolderReadmes();
+      const titles = await this.postService.retitleAll();
 
       await this.syncLogRepo.create({
         status: "success",
@@ -104,7 +110,7 @@ export class SyncService {
         { added, updated, deleted, commitSha: headSha.slice(0, 7) },
         `동기화 완료: ${added}개 추가, ${updated}개 업데이트, ${deleted}개 삭제 (commit: ${headSha.slice(0, 7)})`,
       );
-      return { added, updated, deleted, commitSha: headSha };
+      return { added, updated, deleted, commitSha: headSha, titles };
     } catch (error) {
       log.error({ err: error instanceof Error ? error : new Error(String(error)) }, "동기화 실패");
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -19,6 +19,7 @@ export function createSyncService(): SyncService {
   return new SyncService(
     new PostSyncService(postRepo, githubApi),
     new MetadataSyncService(categoryRepo, folderRepo, postRepo, githubApi),
+    new PostService(postRepo),
     postRepo,
     syncLogRepo,
     githubApi,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -19,7 +19,7 @@ export function createSyncService(): SyncService {
   return new SyncService(
     new PostSyncService(postRepo, githubApi),
     new MetadataSyncService(categoryRepo, folderRepo, postRepo, githubApi),
-    new PostService(postRepo),
+    new PostService(postRepo), // postRepo 공유 — PostService는 스테이트리스이므로 createPostService()와 인스턴스 분리 무방
     postRepo,
     syncLogRepo,
     githubApi,


### PR DESCRIPTION
## Summary
- `SyncService`에 `PostService` 의존성 추가, `sync()` 내부에서 `retitleAll()` 호출
- `route.ts`에서 `retitleExistingPosts()` 직접 호출 제거 → 단일 `syncGitHubToDatabase()` 호출로 단순화
- `sync-github.ts`에서 `retitleExistingPosts` export 제거
- "sync할 때 retitle도 해야 한다"는 비즈니스 규칙이 API 레이어에서 서비스 레이어로 이동

Closes #51

## Test plan
- [x] `pnpm lint && pnpm type-check` — 이상 없음
- [x] `pnpm test` — 86개 테스트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)