### PR TITLE
feat(posts): add infinite scroll latest/popular pages

### DIFF
--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -103,20 +103,32 @@ drizzle/
 
 ## 4. `PostsInfiniteList` 컴포넌트 (핵심)
 
-**Props**:
+**Props** (discriminated union — mode 별로 필요한 필드만 강제):
 ```ts
-type Props = {
-  mode: "latest" | "popular";
-  initialItems: Array<PostData & { visitCount: number }>;
-  initialNext: { cursor: string | null } | { offset: number; hasMore: boolean };
-};
+type PostItem = PostData & { visitCount: number };
+
+type Props =
+  | {
+      mode: "latest";
+      initialItems: PostItem[];
+      initialNextCursor: string | null;      // null → 더 이상 없음
+    }
+  | {
+      mode: "popular";
+      initialItems: PostItem[];
+      initialOffset: number;                 // 다음 요청 offset = initialItems.length
+      initialHasMore: boolean;
+    };
 ```
+
+평탄화 이유: `mode`와 페이지네이션 상태를 직접 매핑 — `mode === "latest"`면 `initialNextCursor`만 접근 가능, TS narrowing으로 cursor/offset 혼용 버그 차단.
 
 **내부 상태**:
 - `items` — 누적된 글 배열
 - `status` — `"idle" | "loading" | "error" | "done"`
-- `next` — cursor string 또는 offset number
-- `observerRef` — 바닥 sentinel div ref
+- `nextCursor` (latest 모드) / `nextOffset` (popular 모드)
+- `sentinelRef` — 바닥 sentinel div ref
+- `observerRef` — IntersectionObserver 인스턴스 ref
 
 **핵심 로직 (의사코드)**:
 ```

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -94,7 +94,7 @@ drizzle/
        │         └─ VisitRepository.getPopularPostPathsOffset({ limit, offset })
        │         └─ VisitRepository.getPopularPostPathsTotal()
        │         └─ PostRepository.getPostsByPaths(paths)
-       │         └─ response: { items, hasMore }
+       │         └─ response: { items, hasMore, nextOffset }
        │
        └─ 끝 도달 → nextCursor/hasMore 기반 종료
 ```
@@ -116,7 +116,7 @@ type Props =
   | {
       mode: "popular";
       initialItems: PostItem[];
-      initialOffset: number;                 // 다음 요청 offset = initialItems.length
+      initialOffset: number;                 // 다음 요청 offset = pathRows.length (visit_stats 기준, 비활성 포스트 포함)
       initialHasMore: boolean;
     };
 ```
@@ -138,7 +138,7 @@ loadMore():
   try:
     res = fetch(apiUrl(mode, next))
     items.append(res.items)
-    next = (mode=latest) ? res.nextCursor : res.offset + limit
+    next = (mode=latest) ? res.nextCursor : res.nextOffset
     if terminator(res): status = "done"
     else: status = "idle"
   catch:
@@ -147,6 +147,10 @@ loadMore():
 IntersectionObserver(sentinel, threshold=0.1) → loadMore()
 Button onClick → loadMore()
 ```
+
+"더 보기" 버튼은 `status === "idle"` 일 때만 노출 (loading/error/done 상태는 각자 고유 UI).
+
+popular offset 진행은 **`visit_stats` 테이블 기준 `pathRows.length` 단위**로 증가 — 비활성 포스트 필터링으로 일부 `items`가 제외돼도 다음 요청에서 중복되지 않도록 API가 `nextOffset`을 명시적으로 응답.
 
 **접근성**:
 - `aria-live="polite"` 상태 영역
@@ -175,11 +179,14 @@ Query: limit?: number (default 10, max 30), offset?: number (default 0)
 Response 200:
 {
   items: Array<PostData & { visitCount: number }>,
-  hasMore: boolean
+  hasMore: boolean,
+  nextOffset: number   // offset + pathRows.length (비활성 포스트 포함 기준)
 }
 Response 400: offset 음수/비정상
 Response 500: DB 오류
 ```
+
+`nextOffset`은 `visit_stats` 테이블 기준 — 비활성 포스트가 `items`에서 빠지더라도 다음 요청 시 이미 스킵한 paths를 재요청하지 않도록 보장.
 
 ### 캐시 정책
 - 두 route 모두 `export const revalidate = <ISR 기준>` 혹은 `Cache-Control: public, s-maxage=...` 를 **설정하지 않는다** (무한 스크롤 추가 fetch는 동적)

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -28,18 +28,24 @@
 
 ```ts
 // src/infra/db/schema/posts.ts
-index("posts_updated_at_id_idx").on(table.updatedAt.desc(), table.id.desc()),
+index("posts_updated_at_id_idx").on(
+  sql`${table.updatedAt} DESC`,
+  sql`${table.id} DESC`,
+),
 ```
 
 - **목적**: `WHERE is_active = 1 ORDER BY updated_at DESC, id DESC LIMIT 10` 및 cursor 조건 `(updated_at, id) < (?, ?)` 의 빠른 평가
 - **없으면**: filesort 발생 → 200개 규모에서는 감내 가능하나 성장 시 degrade
-- **주의**: MySQL 8.4는 descending index 네이티브 지원 → Drizzle에서 `.desc()` chain 필요
+- **주의**: drizzle-orm 0.45.1은 column-level `.desc()` index chain의 SQL 방향 직렬화가 불안정 → raw `sql\`${col} DESC\`` 템플릿 채택 (생성 SQL에 `DESC` 키워드 실측 확인)
 
 ### Index B: `visit_stats` 인기 정렬 offset 페이징 지원
 
 ```ts
 // src/infra/db/schema/visitStats.ts
-index("visit_stats_count_path_idx").on(table.visitCount.desc(), table.pagePath),
+index("visit_stats_count_path_idx").on(
+  sql`${table.visitCount} DESC`,
+  sql`${table.pagePath} ASC`,
+),
 ```
 
 - **목적**: `ORDER BY visit_count DESC, page_path ASC LIMIT 10 OFFSET ?` 의 빠른 평가 + **동점일 때 순서 안정화** (ADR-002)
@@ -108,7 +114,7 @@ ORDER BY visit_count DESC, page_path ASC
 LIMIT :limit OFFSET :offset
 ```
 
-`hasMore` 계산은 API Route 레이어에서 `offset + items.length < total` 로 판정.
+`hasMore` 계산은 API Route 레이어에서 `offset + popularPaths.length < total` 로 판정 (비활성 포스트로 `items`가 줄어도 `visit_stats` 기준으로 진행).
 
 ---
 

--- a/drizzle/0002_mature_mercury.sql
+++ b/drizzle/0002_mature_mercury.sql
@@ -1,0 +1,2 @@
+CREATE INDEX `posts_updated_at_id_idx` ON `posts` (`updated_at` DESC,`id` DESC);--> statement-breakpoint
+CREATE INDEX `visit_stats_count_path_idx` ON `visit_stats` (`visit_count` DESC,`page_path` ASC);

--- a/drizzle/0003_dashing_rattler.sql
+++ b/drizzle/0003_dashing_rattler.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `posts` MODIFY COLUMN `created_at` timestamp NOT NULL DEFAULT (now());--> statement-breakpoint
+ALTER TABLE `posts` MODIFY COLUMN `updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,631 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "2dacbfb1-1187-485e-b1d5-a5292c71df75",
+  "prevId": "d6bbe93f-c46d-4ec2-8933-9184e8b86e3b",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_slug": {
+          "name": "post_slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "post_slug_idx": {
+          "name": "post_slug_idx",
+          "columns": [
+            "post_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comments_id": {
+          "name": "comments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "path_idx": {
+          "name": "path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "folders_path_unique": {
+          "name": "folders_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folders": {
+          "name": "folders",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "category_idx": {
+          "name": "category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "posts_updated_at_id_idx": {
+          "name": "posts_updated_at_id_idx",
+          "columns": [
+            "`updated_at` DESC",
+            "`id` DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_path_unique": {
+          "name": "posts_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posts_added": {
+          "name": "posts_added",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_updated": {
+          "name": "posts_updated",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_deleted": {
+          "name": "posts_deleted",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_logs_id": {
+          "name": "sync_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_logs": {
+      "name": "visit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visited_date": {
+          "name": "visited_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_page_ip_date_idx": {
+          "name": "visit_page_ip_date_idx",
+          "columns": [
+            "page_path",
+            "ip_hash",
+            "visited_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_logs_id": {
+          "name": "visit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_stats": {
+      "name": "visit_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_stats_page_path_idx": {
+          "name": "visit_stats_page_path_idx",
+          "columns": [
+            "page_path"
+          ],
+          "isUnique": true
+        },
+        "visit_stats_count_path_idx": {
+          "name": "visit_stats_count_path_idx",
+          "columns": [
+            "`visit_count` DESC",
+            "`page_path` ASC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_stats_id": {
+          "name": "visit_stats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "posts_updated_at_id_idx": {
+        "columns": {
+          "`updated_at` DESC": {
+            "isExpression": true
+          },
+          "`id` DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "visit_stats_count_path_idx": {
+        "columns": {
+          "`visit_count` DESC": {
+            "isExpression": true
+          },
+          "`page_path` ASC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,631 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "51fd8f26-cd0e-4342-bb17-f2e1df70364e",
+  "prevId": "2dacbfb1-1187-485e-b1d5-a5292c71df75",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_slug": {
+          "name": "post_slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "post_slug_idx": {
+          "name": "post_slug_idx",
+          "columns": [
+            "post_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comments_id": {
+          "name": "comments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "path_idx": {
+          "name": "path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "folders_path_unique": {
+          "name": "folders_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folders": {
+          "name": "folders",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "category_idx": {
+          "name": "category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "posts_updated_at_id_idx": {
+          "name": "posts_updated_at_id_idx",
+          "columns": [
+            "`updated_at` DESC",
+            "`id` DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_path_unique": {
+          "name": "posts_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posts_added": {
+          "name": "posts_added",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_updated": {
+          "name": "posts_updated",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_deleted": {
+          "name": "posts_deleted",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_logs_id": {
+          "name": "sync_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_logs": {
+      "name": "visit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visited_date": {
+          "name": "visited_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_page_ip_date_idx": {
+          "name": "visit_page_ip_date_idx",
+          "columns": [
+            "page_path",
+            "ip_hash",
+            "visited_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_logs_id": {
+          "name": "visit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_stats": {
+      "name": "visit_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_stats_page_path_idx": {
+          "name": "visit_stats_page_path_idx",
+          "columns": [
+            "page_path"
+          ],
+          "isUnique": true
+        },
+        "visit_stats_count_path_idx": {
+          "name": "visit_stats_count_path_idx",
+          "columns": [
+            "`visit_count` DESC",
+            "`page_path` ASC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_stats_id": {
+          "name": "visit_stats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "posts_updated_at_id_idx": {
+        "columns": {
+          "`updated_at` DESC": {
+            "isExpression": true
+          },
+          "`id` DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "visit_stats_count_path_idx": {
+        "columns": {
+          "`visit_count` DESC": {
+            "isExpression": true
+          },
+          "`page_path` ASC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1775017659512,
       "tag": "0001_add_comments_visit_logs_visit_stats",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1776579603395,
+      "tag": "0002_mature_mercury",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1776580577680,
+      "tag": "0003_dashing_rattler",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/posts/latest/route.test.ts
+++ b/src/app/api/posts/latest/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GET } from "./route";
+
+const mockLog = vi.hoisted(() => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ default: { child: vi.fn().mockReturnValue(mockLog) } }));
+
+const mockGetRecentPostsCursor = vi.fn();
+const mockGetPostVisitCounts = vi.fn();
+
+vi.mock("@/infra/db/repositories", () => ({
+  getRepositories: vi.fn(() => ({
+    post: { getRecentPostsCursor: mockGetRecentPostsCursor },
+    visit: { getPostVisitCounts: mockGetPostVisitCounts },
+  })),
+}));
+
+const now = new Date("2024-01-10T00:00:00.000Z");
+
+const makeRow = (id: number) => ({
+  title: `Post ${id}`,
+  path: `/posts/post-${id}`,
+  slug: `post-${id}`,
+  category: "cat",
+  subcategory: null,
+  folders: [],
+  description: "desc",
+  updatedAt: now,
+  id,
+});
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/posts/latest");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new Request(url.toString());
+}
+
+describe("GET /api/posts/latest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPostVisitCounts.mockResolvedValue({});
+  });
+
+  it("200 응답 — items + nextCursor 포함", async () => {
+    mockGetRecentPostsCursor.mockResolvedValue([makeRow(1)]);
+    const res = await GET(makeRequest({ limit: "1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("items");
+    expect(body).toHaveProperty("nextCursor");
+  });
+
+  it("cursor 미지정 시 첫 페이지 — nextCursor null (items < limit)", async () => {
+    mockGetRecentPostsCursor.mockResolvedValue([makeRow(1)]);
+    const res = await GET(makeRequest({ limit: "10" }));
+    const body = await res.json();
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("cursor 지정 시 파싱 후 repo에 전달", async () => {
+    mockGetRecentPostsCursor.mockResolvedValue([]);
+    const cursor = `${now.toISOString()}:42`;
+    await GET(makeRequest({ cursor }));
+    expect(mockGetRecentPostsCursor).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: { updatedAt: now, id: 42 } })
+    );
+  });
+
+  it("cursor 파싱 실패 시 400", async () => {
+    const res = await GET(makeRequest({ cursor: "invalid-cursor" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("repo throw → 500 + logger 4-field 호출", async () => {
+    mockGetRecentPostsCursor.mockRejectedValue(new Error("DB down"));
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: "api.posts.latest",
+        operation: "GET",
+        err: expect.any(Error),
+      }),
+      expect.any(String)
+    );
+  });
+
+  it("items 응답에 updatedAt/id 필드 없음", async () => {
+    mockGetRecentPostsCursor.mockResolvedValue([makeRow(1)]);
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.items[0]).not.toHaveProperty("updatedAt");
+    expect(body.items[0]).not.toHaveProperty("id");
+  });
+});

--- a/src/app/api/posts/latest/route.ts
+++ b/src/app/api/posts/latest/route.ts
@@ -1,18 +1,21 @@
 import { NextResponse } from "next/server";
 import { getRepositories } from "@/infra/db/repositories";
+import { clampPageLimit } from "@/lib/pagination";
 import logger from "@/lib/logger";
 
 const log = logger.child({ module: "api/posts/latest" });
 
 export async function GET(request: Request): Promise<Response> {
   const url = new URL(request.url);
-  const limitParam = parseInt(url.searchParams.get("limit") ?? "10", 10);
-  const limit = Math.min(30, Math.max(1, isNaN(limitParam) ? 10 : limitParam));
+  const limit = clampPageLimit(url.searchParams.get("limit"));
   const cursorParam = url.searchParams.get("cursor");
 
   let cursor: { updatedAt: Date; id: number } | undefined;
   if (cursorParam) {
     const idx = cursorParam.lastIndexOf(":");
+    if (idx === -1) {
+      return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+    }
     const isoStr = cursorParam.slice(0, idx);
     const idStr = cursorParam.slice(idx + 1);
     const updatedAt = new Date(isoStr);

--- a/src/app/api/posts/latest/route.ts
+++ b/src/app/api/posts/latest/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { getRepositories } from "@/infra/db/repositories";
+import logger from "@/lib/logger";
+
+const log = logger.child({ module: "api/posts/latest" });
+
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const limitParam = parseInt(url.searchParams.get("limit") ?? "10", 10);
+  const limit = Math.min(30, Math.max(1, isNaN(limitParam) ? 10 : limitParam));
+  const cursorParam = url.searchParams.get("cursor");
+
+  let cursor: { updatedAt: Date; id: number } | undefined;
+  if (cursorParam) {
+    const idx = cursorParam.lastIndexOf(":");
+    const isoStr = cursorParam.slice(0, idx);
+    const idStr = cursorParam.slice(idx + 1);
+    const updatedAt = new Date(isoStr);
+    const id = parseInt(idStr, 10);
+    if (isNaN(updatedAt.getTime()) || isNaN(id)) {
+      return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+    }
+    cursor = { updatedAt, id };
+  }
+
+  try {
+    const { post, visit } = getRepositories();
+    const rows = await post.getRecentPostsCursor({ limit, cursor });
+    const paths = rows.map((r) => r.path);
+    const visitCounts = await visit.getPostVisitCounts(paths);
+
+    const last = rows[rows.length - 1];
+    const nextCursor =
+      rows.length === limit && last
+        ? `${last.updatedAt.toISOString()}:${last.id}`
+        : null;
+
+    const items = rows.map(({ updatedAt: _u, id: _i, ...rest }) => ({
+      ...rest,
+      visitCount: visitCounts[rest.path] ?? 0,
+    }));
+
+    return NextResponse.json({ items, nextCursor });
+  } catch (error) {
+    log.error(
+      {
+        component: "api.posts.latest",
+        operation: "GET",
+        err: error instanceof Error ? error : new Error(String(error)),
+      },
+      "Failed to fetch latest posts"
+    );
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/posts/popular/route.test.ts
+++ b/src/app/api/posts/popular/route.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GET } from "./route";
+
+const mockLog = vi.hoisted(() => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ default: { child: vi.fn().mockReturnValue(mockLog) } }));
+
+const mockGetPopularPostPathsOffset = vi.fn();
+const mockGetPopularPostPathsTotal = vi.fn();
+const mockGetPostsByPaths = vi.fn();
+
+vi.mock("@/infra/db/repositories", () => ({
+  getRepositories: vi.fn(() => ({
+    post: { getPostsByPaths: mockGetPostsByPaths },
+    visit: {
+      getPopularPostPathsOffset: mockGetPopularPostPathsOffset,
+      getPopularPostPathsTotal: mockGetPopularPostPathsTotal,
+    },
+  })),
+}));
+
+const makePostData = (path: string) => ({
+  title: `Post ${path}`,
+  path,
+  slug: path.replace("/", "-"),
+  category: "cat",
+  subcategory: null,
+  folders: [],
+  description: "desc",
+});
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/posts/popular");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new Request(url.toString());
+}
+
+describe("GET /api/posts/popular", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPopularPostPathsTotal.mockResolvedValue(5);
+    mockGetPopularPostPathsOffset.mockResolvedValue([]);
+    mockGetPostsByPaths.mockResolvedValue([]);
+  });
+
+  it("200 응답 — items + hasMore + nextOffset 포함", async () => {
+    mockGetPopularPostPathsOffset.mockResolvedValue([{ path: "/a", visitCount: 10 }]);
+    mockGetPostsByPaths.mockResolvedValue([makePostData("/a")]);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("items");
+    expect(body).toHaveProperty("hasMore");
+    expect(body).toHaveProperty("nextOffset");
+  });
+
+  it("offset 적용 — getPopularPostPathsOffset에 offset 전달", async () => {
+    const res = await GET(makeRequest({ offset: "20" }));
+    expect(res.status).toBe(200);
+    expect(mockGetPopularPostPathsOffset).toHaveBeenCalledWith(
+      expect.objectContaining({ offset: 20 })
+    );
+  });
+
+  it("음수 offset → 400", async () => {
+    const res = await GET(makeRequest({ offset: "-1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("getPopularPostPathsOffset throw → 500 + logger 4-field", async () => {
+    mockGetPopularPostPathsOffset.mockRejectedValue(new Error("DB error"));
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: "api.posts.popular",
+        operation: "GET",
+        err: expect.any(Error),
+      }),
+      expect.any(String)
+    );
+  });
+
+  it("reorder — paths 순서대로 정렬", async () => {
+    mockGetPopularPostPathsOffset.mockResolvedValue([
+      { path: "/b", visitCount: 20 },
+      { path: "/a", visitCount: 10 },
+    ]);
+    mockGetPostsByPaths.mockResolvedValue([
+      makePostData("/a"),
+      makePostData("/b"),
+    ]);
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.items[0].path).toBe("/b");
+    expect(body.items[1].path).toBe("/a");
+  });
+
+  it("hasMore — offset + popularPaths.length < total 이면 true (pathRows 기준)", async () => {
+    mockGetPopularPostPathsTotal.mockResolvedValue(10);
+    mockGetPopularPostPathsOffset.mockResolvedValue([{ path: "/a", visitCount: 5 }]);
+    mockGetPostsByPaths.mockResolvedValue([makePostData("/a")]);
+    const res = await GET(makeRequest({ limit: "1", offset: "0" }));
+    const body = await res.json();
+    expect(body.hasMore).toBe(true);
+    expect(body.nextOffset).toBe(1);
+  });
+
+  it("nextOffset — 비활성 포스트로 items가 비어도 popularPaths.length 기준 증가", async () => {
+    mockGetPopularPostPathsTotal.mockResolvedValue(10);
+    mockGetPopularPostPathsOffset.mockResolvedValue([
+      { path: "/inactive-a", visitCount: 5 },
+      { path: "/inactive-b", visitCount: 4 },
+    ]);
+    mockGetPostsByPaths.mockResolvedValue([]); // 모두 비활성 → items 0
+    const res = await GET(makeRequest({ limit: "2", offset: "5" }));
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+    expect(body.nextOffset).toBe(7); // 5 + 2 (popularPaths.length)
+    expect(body.hasMore).toBe(true); // 7 < 10
+  });
+});

--- a/src/app/api/posts/popular/route.ts
+++ b/src/app/api/posts/popular/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import { getRepositories } from "@/infra/db/repositories";
+import { clampPageLimit } from "@/lib/pagination";
 import logger from "@/lib/logger";
 
 const log = logger.child({ module: "api/posts/popular" });
 
 export async function GET(request: Request): Promise<Response> {
   const url = new URL(request.url);
-  const limitParam = parseInt(url.searchParams.get("limit") ?? "10", 10);
-  const limit = Math.min(30, Math.max(1, isNaN(limitParam) ? 10 : limitParam));
+  const limit = clampPageLimit(url.searchParams.get("limit"));
   const offsetParam = parseInt(url.searchParams.get("offset") ?? "0", 10);
 
   if (isNaN(offsetParam) || offsetParam < 0) {

--- a/src/app/api/posts/popular/route.ts
+++ b/src/app/api/posts/popular/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { getRepositories } from "@/infra/db/repositories";
+import logger from "@/lib/logger";
+
+const log = logger.child({ module: "api/posts/popular" });
+
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const limitParam = parseInt(url.searchParams.get("limit") ?? "10", 10);
+  const limit = Math.min(30, Math.max(1, isNaN(limitParam) ? 10 : limitParam));
+  const offsetParam = parseInt(url.searchParams.get("offset") ?? "0", 10);
+
+  if (isNaN(offsetParam) || offsetParam < 0) {
+    return NextResponse.json({ error: "Invalid offset" }, { status: 400 });
+  }
+
+  try {
+    const { post, visit } = getRepositories();
+    const [popularPaths, total] = await Promise.all([
+      visit.getPopularPostPathsOffset({ limit, offset: offsetParam }),
+      visit.getPopularPostPathsTotal(),
+    ]);
+
+    const paths = popularPaths.map((r) => r.path);
+    const postDataList = await post.getPostsByPaths(paths);
+
+    const postMap = new Map(postDataList.map((p) => [p.path, p]));
+    const visitCountMap = new Map(popularPaths.map((r) => [r.path, r.visitCount]));
+
+    const items = paths
+      .map((path) => {
+        const postData = postMap.get(path);
+        if (!postData) return null;
+        return { ...postData, visitCount: visitCountMap.get(path) ?? 0 };
+      })
+      .filter((item): item is NonNullable<typeof item> => item !== null);
+
+    const nextOffset = offsetParam + popularPaths.length;
+    const hasMore = nextOffset < total;
+
+    return NextResponse.json({ items, hasMore, nextOffset });
+  } catch (error) {
+    log.error(
+      {
+        component: "api.posts.popular",
+        operation: "GET",
+        err: error instanceof Error ? error : new Error(String(error)),
+      },
+      "Failed to fetch popular posts"
+    );
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import logger from "@/lib/logger";
 const log = logger.child({ module: "app/page" });
 import { CategoryList } from "@/components/CategoryList";
 import { PostCard } from "@/components/PostCard";
+import { SectionCTAButton } from "@/components/SectionCTAButton";
 import { WebsiteJsonLd } from "@/components/JsonLd";
 import { ArrowRight, Sparkles, Flame } from "lucide-react";
 import Link from "next/link";
@@ -117,6 +118,7 @@ export default async function HomePage() {
                 />
               ))}
             </div>
+            <SectionCTAButton href="/posts/popular" label="인기 글 더 보기" />
           </section>
         )}
 
@@ -128,15 +130,18 @@ export default async function HomePage() {
             </h2>
           </div>
           {recentPosts.length > 0 ? (
-            <div className="space-y-2 md:space-y-4">
-              {recentPosts.map((post) => (
-                <PostCard
-                  key={post.path}
-                  post={post}
-                  viewCount={visitCounts[post.path] ?? 0}
-                />
-              ))}
-            </div>
+            <>
+              <div className="space-y-2 md:space-y-4">
+                {recentPosts.map((post) => (
+                  <PostCard
+                    key={post.path}
+                    post={post}
+                    viewCount={visitCounts[post.path] ?? 0}
+                  />
+                ))}
+              </div>
+              <SectionCTAButton href="/posts/latest" label="최신 글 더 보기" />
+            </>
           ) : (
             <div className="text-center py-12 text-gray-500 dark:text-gray-400">
               <p>아직 등록된 글이 없습니다.</p>

--- a/src/app/posts/latest/page.tsx
+++ b/src/app/posts/latest/page.tsx
@@ -1,0 +1,63 @@
+import { getRepositories } from "@/infra/db/repositories";
+import logger from "@/lib/logger";
+import { PostsInfiniteList, type PostItem } from "@/components/PostsInfiniteList";
+import { BackToTopButton } from "@/components/BackToTopButton";
+
+const log = logger.child({ module: "app/posts/latest/page" });
+
+const INITIAL_LIMIT = 10;
+
+export const revalidate = 60;
+
+export const metadata = {
+  title: "최신 글 — FOS Study",
+  description: "개발 공부 기록 블로그의 최신 글 목록입니다.",
+  robots: { index: false, follow: true },
+};
+
+export default async function PostsLatestPage() {
+  let initialItems: PostItem[] = [];
+  let initialNextCursor: string | null = null;
+
+  try {
+    const { post, visit } = getRepositories();
+    const rows = await post.getRecentPostsCursor({ limit: INITIAL_LIMIT });
+    const paths = rows.map((r) => r.path);
+    const visitCounts = paths.length > 0 ? await visit.getPostVisitCounts(paths) : {};
+
+    const last = rows[rows.length - 1];
+    initialNextCursor =
+      rows.length === INITIAL_LIMIT && last
+        ? `${last.updatedAt.toISOString()}:${last.id}`
+        : null;
+
+    initialItems = rows.map(({ updatedAt: _u, id: _i, ...rest }) => ({
+      ...rest,
+      visitCount: visitCounts[rest.path] ?? 0,
+    }));
+  } catch (error) {
+    log.warn(
+      { err: error instanceof Error ? error : new Error(String(error)) },
+      "Database not available"
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <div className="mb-8">
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
+          최신 글
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">업데이트 순</p>
+      </div>
+
+      <PostsInfiniteList
+        mode="latest"
+        initialItems={initialItems}
+        initialNextCursor={initialNextCursor}
+      />
+
+      <BackToTopButton variant="floating" />
+    </div>
+  );
+}

--- a/src/app/posts/latest/page.tsx
+++ b/src/app/posts/latest/page.tsx
@@ -1,11 +1,12 @@
 import { getRepositories } from "@/infra/db/repositories";
 import logger from "@/lib/logger";
+import { DEFAULT_PAGE_SIZE } from "@/lib/pagination";
 import { PostsInfiniteList, type PostItem } from "@/components/PostsInfiniteList";
 import { BackToTopButton } from "@/components/BackToTopButton";
 
 const log = logger.child({ module: "app/posts/latest/page" });
 
-const INITIAL_LIMIT = 10;
+const INITIAL_LIMIT = DEFAULT_PAGE_SIZE;
 
 export const revalidate = 60;
 

--- a/src/app/posts/popular/page.tsx
+++ b/src/app/posts/popular/page.tsx
@@ -1,12 +1,13 @@
 import { getRepositories } from "@/infra/db/repositories";
 import logger from "@/lib/logger";
+import { DEFAULT_PAGE_SIZE } from "@/lib/pagination";
 import { PostsInfiniteList, type PostItem } from "@/components/PostsInfiniteList";
 import { BackToTopButton } from "@/components/BackToTopButton";
 import { Flame } from "lucide-react";
 
 const log = logger.child({ module: "app/posts/popular/page" });
 
-const INITIAL_LIMIT = 10;
+const INITIAL_LIMIT = DEFAULT_PAGE_SIZE;
 
 export const revalidate = 600;
 

--- a/src/app/posts/popular/page.tsx
+++ b/src/app/posts/popular/page.tsx
@@ -1,0 +1,76 @@
+import { getRepositories } from "@/infra/db/repositories";
+import logger from "@/lib/logger";
+import { PostsInfiniteList, type PostItem } from "@/components/PostsInfiniteList";
+import { BackToTopButton } from "@/components/BackToTopButton";
+import { Flame } from "lucide-react";
+
+const log = logger.child({ module: "app/posts/popular/page" });
+
+const INITIAL_LIMIT = 10;
+
+export const revalidate = 600;
+
+export const metadata = {
+  title: "인기 글 — FOS Study",
+  description: "개발 공부 기록 블로그의 방문수 기준 인기 글 목록입니다.",
+  robots: { index: false, follow: true },
+};
+
+export default async function PostsPopularPage() {
+  let initialItems: PostItem[] = [];
+  let initialOffset = 0;
+  let initialHasMore = false;
+
+  try {
+    const { post, visit } = getRepositories();
+    const [pathRows, total] = await Promise.all([
+      visit.getPopularPostPathsOffset({ limit: INITIAL_LIMIT, offset: 0 }),
+      visit.getPopularPostPathsTotal(),
+    ]);
+
+    const paths = pathRows.map((r) => r.path);
+    const postDataList = await post.getPostsByPaths(paths);
+
+    const postMap = new Map(postDataList.map((p) => [p.path, p]));
+    const visitCountMap = new Map(pathRows.map((r) => [r.path, r.visitCount]));
+
+    initialItems = paths
+      .map((path) => {
+        const postData = postMap.get(path);
+        if (!postData) return null;
+        return { ...postData, visitCount: visitCountMap.get(path) ?? 0 };
+      })
+      .filter((item): item is NonNullable<typeof item> => item !== null);
+
+    initialOffset = pathRows.length;
+    initialHasMore = pathRows.length < total;
+  } catch (error) {
+    log.warn(
+      { err: error instanceof Error ? error : new Error(String(error)) },
+      "Database not available"
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <div className="mb-8 flex items-center gap-2">
+        <Flame className="w-7 h-7 text-orange-500" />
+        <div>
+          <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
+            인기 글
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">방문수 순</p>
+        </div>
+      </div>
+
+      <PostsInfiniteList
+        mode="popular"
+        initialItems={initialItems}
+        initialOffset={initialOffset}
+        initialHasMore={initialHasMore}
+      />
+
+      <BackToTopButton variant="floating" />
+    </div>
+  );
+}

--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+interface BackToTopButtonProps {
+  variant: "floating" | "inline";
+}
+
+export function BackToTopButton({ variant }: BackToTopButtonProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (variant !== "floating") return;
+
+    function onScroll() {
+      setVisible(window.scrollY > 300);
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [variant]);
+
+  function handleClick() {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  if (variant === "floating" && !visible) return null;
+
+  const base =
+    "inline-flex items-center justify-center gap-2 rounded-xl bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500";
+
+  const floatingCls = "fixed bottom-6 right-6 z-40 p-3 shadow-lg";
+  const inlineCls = "px-4 py-2 mx-auto";
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label="맨 위로 이동"
+      className={`${base} ${variant === "floating" ? floatingCls : inlineCls}`}
+    >
+      <ArrowUp className="w-5 h-5" />
+      {variant === "inline" && <span>맨 위로</span>}
+    </button>
+  );
+}

--- a/src/components/PostCardSkeleton.tsx
+++ b/src/components/PostCardSkeleton.tsx
@@ -1,0 +1,13 @@
+export function PostCardSkeleton() {
+  return (
+    <div className="flex items-center gap-3 md:gap-4 p-3 md:p-4 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 animate-pulse">
+      <div className="flex-shrink-0 w-8 h-8 md:w-10 md:h-10 rounded-lg bg-gray-200 dark:bg-gray-700" />
+      <div className="flex-grow min-w-0 space-y-2">
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
+        <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+        <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+      </div>
+      <div className="flex-shrink-0 w-5 h-5 bg-gray-200 dark:bg-gray-700 rounded" />
+    </div>
+  );
+}

--- a/src/components/PostsInfiniteList.tsx
+++ b/src/components/PostsInfiniteList.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { PostData } from "@/infra/db/types";
+import { DEFAULT_PAGE_SIZE } from "@/lib/pagination";
 import { PostCard } from "./PostCard";
 import { PostCardSkeleton } from "./PostCardSkeleton";
 import { BackToTopButton } from "./BackToTopButton";
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = DEFAULT_PAGE_SIZE;
 
 export type PostItem = PostData & { visitCount: number };
 
@@ -45,7 +46,7 @@ export function PostsInfiniteList(props: Props) {
   const statusRef = useRef(status);
   statusRef.current = status;
 
-  async function loadMore() {
+  const loadMore = useCallback(async () => {
     if (statusRef.current === "loading" || statusRef.current === "done") return;
     setStatus("loading");
 
@@ -77,7 +78,7 @@ export function PostsInfiniteList(props: Props) {
     } catch {
       setStatus("error");
     }
-  }
+  }, [props.mode, nextCursor, nextOffset]);
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -96,8 +97,7 @@ export function PostsInfiniteList(props: Props) {
     return () => {
       observerRef.current?.disconnect();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nextCursor, nextOffset]);
+  }, [loadMore]);
 
   return (
     <div>

--- a/src/components/PostsInfiniteList.tsx
+++ b/src/components/PostsInfiniteList.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { PostData } from "@/infra/db/types";
+import { PostCard } from "./PostCard";
+import { PostCardSkeleton } from "./PostCardSkeleton";
+import { BackToTopButton } from "./BackToTopButton";
+
+const PAGE_SIZE = 10;
+
+export type PostItem = PostData & { visitCount: number };
+
+type Props =
+  | {
+      mode: "latest";
+      initialItems: PostItem[];
+      initialNextCursor: string | null;
+    }
+  | {
+      mode: "popular";
+      initialItems: PostItem[];
+      initialOffset: number;
+      initialHasMore: boolean;
+    };
+
+export function PostsInfiniteList(props: Props) {
+  const [items, setItems] = useState<PostItem[]>(props.initialItems);
+  const [status, setStatus] = useState<"idle" | "loading" | "error" | "done">(
+    () => {
+      if (props.mode === "latest") {
+        return props.initialNextCursor === null ? "done" : "idle";
+      }
+      return props.initialHasMore ? "idle" : "done";
+    }
+  );
+  const [nextCursor, setNextCursor] = useState<string | null>(
+    props.mode === "latest" ? props.initialNextCursor : null
+  );
+  const [nextOffset, setNextOffset] = useState<number>(
+    props.mode === "popular" ? props.initialOffset : 0
+  );
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const statusRef = useRef(status);
+  statusRef.current = status;
+
+  async function loadMore() {
+    if (statusRef.current === "loading" || statusRef.current === "done") return;
+    setStatus("loading");
+
+    try {
+      let url: string;
+      if (props.mode === "latest") {
+        url = `/api/posts/latest?limit=${PAGE_SIZE}${nextCursor ? `&cursor=${encodeURIComponent(nextCursor)}` : ""}`;
+      } else {
+        url = `/api/posts/popular?limit=${PAGE_SIZE}&offset=${nextOffset}`;
+      }
+
+      const res = await fetch(url);
+      if (!res.ok) {
+        setStatus("error");
+        return;
+      }
+
+      const data = await res.json();
+
+      setItems((prev) => [...prev, ...data.items]);
+
+      if (props.mode === "latest") {
+        setNextCursor(data.nextCursor);
+        setStatus(data.nextCursor === null ? "done" : "idle");
+      } else {
+        setNextOffset(data.nextOffset);
+        setStatus(data.hasMore ? "idle" : "done");
+      }
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+    observerRef.current.observe(sentinel);
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nextCursor, nextOffset]);
+
+  return (
+    <div>
+      <div role="feed" className="space-y-3">
+        {items.map((item) => (
+          <PostCard key={item.path} post={item} viewCount={item.visitCount} />
+        ))}
+      </div>
+
+      <div ref={sentinelRef} aria-hidden="true" />
+
+      <div aria-live="polite" className="mt-6 flex flex-col items-center gap-4">
+        {status === "loading" && (
+          <div className="w-full space-y-3">
+            <PostCardSkeleton />
+            <PostCardSkeleton />
+            <PostCardSkeleton />
+          </div>
+        )}
+
+        {status === "error" && (
+          <button
+            onClick={loadMore}
+            className="px-4 py-2 rounded-xl bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+          >
+            재시도
+          </button>
+        )}
+
+        {status === "idle" && (
+          <button
+            onClick={loadMore}
+            className="px-4 py-2 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            더 보기
+          </button>
+        )}
+
+        {status === "done" && (
+          <>
+            <p role="status" className="text-sm text-gray-500 dark:text-gray-400">
+              더 이상 글이 없습니다.
+            </p>
+            <BackToTopButton variant="inline" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SectionCTAButton.tsx
+++ b/src/components/SectionCTAButton.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+interface SectionCTAButtonProps {
+  href: string;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+export function SectionCTAButton({ href, label, icon }: SectionCTAButtonProps) {
+  return (
+    <div className="flex justify-center mt-6">
+      <Link
+        href={href}
+        className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-blue-600 dark:bg-blue-500 text-white font-medium hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+      >
+        {icon}
+        {label}
+        <span aria-hidden="true">→</span>
+      </Link>
+    </div>
+  );
+}

--- a/src/infra/db/repositories/PostRepository.test.ts
+++ b/src/infra/db/repositories/PostRepository.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PostRepository } from "./PostRepository";
+import type { DbInstance } from "./BaseRepository";
+
+function makeDb(rows: unknown[] = []) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+function makeRepo(rows: unknown[] = []) {
+  const db = makeDb(rows);
+  return { repo: new PostRepository(db as unknown as DbInstance), db };
+}
+
+const now = new Date("2024-01-10T00:00:00Z");
+const earlier = new Date("2024-01-09T00:00:00Z");
+
+const baseRow = {
+  title: "Post A",
+  path: "cat/post-a.md",
+  slug: "post-a",
+  category: "cat",
+  subcategory: null,
+  folders: ["cat"],
+  description: "desc",
+  updatedAt: now,
+  id: 42,
+};
+
+describe("PostRepository.getRecentPostsCursor", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("cursor 없을 때 상위 rows 반환", async () => {
+    const { repo } = makeRepo([baseRow]);
+    const result = await repo.getRecentPostsCursor({ limit: 10 });
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("cat/post-a.md");
+  });
+
+  it("cursor 있을 때 호출 성공 (WHERE 조건 포함)", async () => {
+    const { repo, db } = makeRepo([]);
+    await repo.getRecentPostsCursor({
+      limit: 10,
+      cursor: { updatedAt: earlier, id: 10 },
+    });
+    expect(db.where).toHaveBeenCalled();
+  });
+
+  it("is_active 필터 - isActive=false 행 제외 (where 호출 확인)", async () => {
+    const { repo, db } = makeRepo([]);
+    await repo.getRecentPostsCursor({ limit: 10 });
+    expect(db.where).toHaveBeenCalled();
+  });
+
+  it("반환 객체에 updatedAt(Date)과 id(number) 필드 존재", async () => {
+    const { repo } = makeRepo([baseRow]);
+    const result = await repo.getRecentPostsCursor({ limit: 10 });
+    expect(result[0].updatedAt).toBeInstanceOf(Date);
+    expect(typeof result[0].id).toBe("number");
+  });
+
+  it("folders null → 빈 배열로 치환", async () => {
+    const row = { ...baseRow, folders: null };
+    const { repo } = makeRepo([row]);
+    const result = await repo.getRecentPostsCursor({ limit: 10 });
+    expect(result[0].folders).toEqual([]);
+  });
+});

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -52,6 +52,41 @@ export class PostRepository extends BaseRepository {
     }));
   }
 
+  async getRecentPostsCursor(params: {
+    limit: number;
+    cursor?: { updatedAt: Date; id: number };
+  }): Promise<Array<PostData & { updatedAt: Date; id: number }>> {
+    const { limit, cursor } = params;
+    const whereExpr = cursor
+      ? and(
+          eq(posts.isActive, true),
+          sql`(${posts.updatedAt}, ${posts.id}) < (${cursor.updatedAt}, ${cursor.id})`
+        )
+      : eq(posts.isActive, true);
+
+    const result = await this.db
+      .select({
+        title: posts.title,
+        path: posts.path,
+        slug: posts.slug,
+        category: posts.category,
+        subcategory: posts.subcategory,
+        folders: posts.folders,
+        description: posts.description,
+        updatedAt: posts.updatedAt,
+        id: posts.id,
+      })
+      .from(posts)
+      .where(whereExpr)
+      .orderBy(desc(posts.updatedAt), desc(posts.id))
+      .limit(limit);
+
+    return result.map((p) => ({
+      ...p,
+      folders: p.folders || [],
+    }));
+  }
+
   async getPostId(slug: string) {
     const exists = await this.db
       .select({ id: posts.id })

--- a/src/infra/db/repositories/VisitRepository.test.ts
+++ b/src/infra/db/repositories/VisitRepository.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { VisitRepository } from "./VisitRepository";
+import type { DbInstance } from "./BaseRepository";
+
+const mockLog = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    child: vi.fn().mockReturnValue(mockLog),
+  },
+}));
+
+function makeDb(rows: unknown[] = []) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+function makeDbForTotal(rows: unknown[], shouldThrow = false) {
+  if (shouldThrow) {
+    return {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockRejectedValue(new Error("DB error")),
+    };
+  }
+  return {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+describe("VisitRepository.getPopularPostPathsOffset", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("offset=0 일 때 상위 rows 반환", async () => {
+    const rows = [{ pagePath: "/posts/a", visitCount: 10 }];
+    const db = makeDb(rows);
+    const repo = new VisitRepository(db as unknown as DbInstance);
+    const result = await repo.getPopularPostPathsOffset({ limit: 10, offset: 0 });
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("/posts/a");
+    expect(result[0].visitCount).toBe(10);
+  });
+
+  it("offset=20 일 때 offset 체인 호출", async () => {
+    const db = makeDb([]);
+    const repo = new VisitRepository(db as unknown as DbInstance);
+    await repo.getPopularPostPathsOffset({ limit: 10, offset: 20 });
+    expect(db.offset).toHaveBeenCalledWith(20);
+  });
+});
+
+describe("VisitRepository.getPopularPostPathsTotal", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("합계 숫자 반환", async () => {
+    const db = makeDbForTotal([{ total: "42" }]);
+    const repo = new VisitRepository(db as unknown as DbInstance);
+    const total = await repo.getPopularPostPathsTotal();
+    expect(total).toBe(42);
+  });
+
+  it("DB 에러 시 throw", async () => {
+    const db = makeDbForTotal([], true);
+    const repo = new VisitRepository(db as unknown as DbInstance);
+    await expect(repo.getPopularPostPathsTotal()).rejects.toThrow("DB error");
+  });
+
+  it("DB 에러 시 logger.error 호출 (구조화 4-field)", async () => {
+    const db = makeDbForTotal([], true);
+    const repo = new VisitRepository(db as unknown as DbInstance);
+    await expect(repo.getPopularPostPathsTotal()).rejects.toThrow();
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: "repo.visit",
+        operation: "getPopularPostPathsTotal",
+        err: expect.any(Error),
+      }),
+      expect.any(String)
+    );
+  });
+});

--- a/src/infra/db/repositories/VisitRepository.ts
+++ b/src/infra/db/repositories/VisitRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, inArray, desc } from "drizzle-orm";
+import { eq, and, sql, inArray, desc, asc } from "drizzle-orm";
 import { visitLogs, visitStats } from "../schema";
 import { BaseRepository } from "./BaseRepository";
 import logger from "@/lib/logger";
@@ -14,7 +14,6 @@ export class VisitRepository extends BaseRepository {
     try {
       const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
 
-      // 오늘 같은 IP로 같은 페이지를 방문한 기록이 있는지 확인
       const existing = await this.db
         .select({ id: visitLogs.id })
         .from(visitLogs)
@@ -28,10 +27,9 @@ export class VisitRepository extends BaseRepository {
         .limit(1);
 
       if (existing.length > 0) {
-        return false; // 이미 카운팅됨
+        return false;
       }
 
-      // 방문 로그 삽입
       await this.db.insert(visitLogs).values({
         pagePath,
         ipHash,
@@ -58,9 +56,6 @@ export class VisitRepository extends BaseRepository {
     }
   }
 
-  /**
-   * 특정 페이지의 조회수 반환
-   */
   async getVisitCount(pagePath: string): Promise<number> {
     try {
       const result = await this.db
@@ -75,9 +70,6 @@ export class VisitRepository extends BaseRepository {
     }
   }
 
-  /**
-   * 사이트 전체 방문자 수 (모든 페이지의 합계)
-   */
   async getTotalVisitCount(): Promise<number> {
     try {
       const result = await this.db
@@ -92,9 +84,6 @@ export class VisitRepository extends BaseRepository {
     }
   }
 
-  /**
-   * 여러 포스트의 조회수를 일괄 조회
-   */
   async getPostVisitCounts(
     pagePaths: string[]
   ): Promise<Record<string, number>> {
@@ -119,9 +108,6 @@ export class VisitRepository extends BaseRepository {
     }
   }
 
-  /**
-   * 방문수 기준 인기 포스트 경로 목록 반환
-   */
   async getPopularPostPaths(limit: number = 6): Promise<{ path: string; visitCount: number }[]> {
     try {
       const results = await this.db
@@ -133,9 +119,39 @@ export class VisitRepository extends BaseRepository {
     } catch { return []; }
   }
 
-  /**
-   * 오늘 방문자 수 (유니크 IP 기준)
-   */
+  async getPopularPostPathsOffset(params: {
+    limit: number;
+    offset: number;
+  }): Promise<Array<{ path: string; visitCount: number }>> {
+    const { limit, offset } = params;
+    const results = await this.db
+      .select({ pagePath: visitStats.pagePath, visitCount: visitStats.visitCount })
+      .from(visitStats)
+      .orderBy(desc(visitStats.visitCount), asc(visitStats.pagePath))
+      .limit(limit)
+      .offset(offset);
+    return results.map((r) => ({ path: r.pagePath, visitCount: r.visitCount }));
+  }
+
+  async getPopularPostPathsTotal(): Promise<number> {
+    try {
+      const result = await this.db
+        .select({ total: sql<number>`COUNT(*)` })
+        .from(visitStats);
+      return Number(result[0]?.total ?? 0);
+    } catch (error) {
+      log.error(
+        {
+          component: "repo.visit",
+          operation: "getPopularPostPathsTotal",
+          err: error instanceof Error ? error : new Error(String(error)),
+        },
+        "failed to count popular posts"
+      );
+      throw error;
+    }
+  }
+
   async getTodayVisitorCount(): Promise<number> {
     try {
       const today = new Date().toISOString().split("T")[0];

--- a/src/infra/db/repositories/VisitRepository.ts
+++ b/src/infra/db/repositories/VisitRepository.ts
@@ -124,13 +124,25 @@ export class VisitRepository extends BaseRepository {
     offset: number;
   }): Promise<Array<{ path: string; visitCount: number }>> {
     const { limit, offset } = params;
-    const results = await this.db
-      .select({ pagePath: visitStats.pagePath, visitCount: visitStats.visitCount })
-      .from(visitStats)
-      .orderBy(desc(visitStats.visitCount), asc(visitStats.pagePath))
-      .limit(limit)
-      .offset(offset);
-    return results.map((r) => ({ path: r.pagePath, visitCount: r.visitCount }));
+    try {
+      const results = await this.db
+        .select({ pagePath: visitStats.pagePath, visitCount: visitStats.visitCount })
+        .from(visitStats)
+        .orderBy(desc(visitStats.visitCount), asc(visitStats.pagePath))
+        .limit(limit)
+        .offset(offset);
+      return results.map((r) => ({ path: r.pagePath, visitCount: r.visitCount }));
+    } catch (error) {
+      log.error(
+        {
+          component: "repo.visit",
+          operation: "getPopularPostPathsOffset",
+          err: error instanceof Error ? error : new Error(String(error)),
+        },
+        "failed to fetch popular posts offset"
+      );
+      throw error;
+    }
   }
 
   async getPopularPostPathsTotal(): Promise<number> {

--- a/src/infra/db/schema/posts.ts
+++ b/src/infra/db/schema/posts.ts
@@ -8,6 +8,7 @@ import {
   boolean,
   json,
 } from "drizzle-orm/mysql-core";
+import { sql } from "drizzle-orm";
 
 // 포스트 테이블
 export const posts = mysqlTable(
@@ -24,12 +25,16 @@ export const posts = mysqlTable(
     description: text("description"),
     sha: varchar("sha", { length: 64 }), // GitHub file SHA for change detection
     isActive: boolean("is_active").notNull().default(true),
-    createdAt: timestamp("created_at").defaultNow(),
-    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow().onUpdateNow(),
   },
   (table) => [
     index("category_idx").on(table.category),
     index("slug_idx").on(table.slug),
+    index("posts_updated_at_id_idx").on(
+      sql`${table.updatedAt} DESC`,
+      sql`${table.id} DESC`,
+    ),
   ],
 );
 

--- a/src/infra/db/schema/visitStats.ts
+++ b/src/infra/db/schema/visitStats.ts
@@ -4,7 +4,9 @@ import {
   int,
   timestamp,
   uniqueIndex,
+  index,
 } from "drizzle-orm/mysql-core";
+import { sql } from "drizzle-orm";
 
 // 방문 통계 테이블 (집계용)
 export const visitStats = mysqlTable(
@@ -15,7 +17,13 @@ export const visitStats = mysqlTable(
     visitCount: int("visit_count").notNull().default(0),
     updatedAt: timestamp("updated_at").defaultNow().onUpdateNow(),
   },
-  (table) => [uniqueIndex("visit_stats_page_path_idx").on(table.pagePath)]
+  (table) => [
+    uniqueIndex("visit_stats_page_path_idx").on(table.pagePath),
+    index("visit_stats_count_path_idx").on(
+      sql`${table.visitCount} DESC`,
+      sql`${table.pagePath} ASC`,
+    ),
+  ]
 );
 
 export type VisitStat = typeof visitStats.$inferSelect;

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_PAGE_SIZE = 10;
+export const MIN_PAGE_SIZE = 1;
+export const MAX_PAGE_SIZE = 30;
+
+export function clampPageLimit(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : parseInt(String(raw ?? ""), 10);
+  if (isNaN(n)) return DEFAULT_PAGE_SIZE;
+  return Math.min(MAX_PAGE_SIZE, Math.max(MIN_PAGE_SIZE, n));
+}

--- a/tasks/plan001-posts-list-infinite-scroll/phase-01.md
+++ b/tasks/plan001-posts-list-infinite-scroll/phase-01.md
@@ -23,28 +23,54 @@
 - `src/infra/db/schema/visitStats.ts` — 기존 `visit_stats_page_path_idx` unique 인덱스 패턴
 - `drizzle/` 디렉터리 — 기존 마이그레이션 SQL 파일 작명/포맷 참고
 
+## 사전 게이트 (작업 시작 전 필수)
+
+```bash
+# cwd: <worktree root>
+
+# 1) MySQL 컨테이너 기동 확인. 미기동이면 자동 기동
+pnpm db:up
+docker ps --format '{{.Names}} {{.Status}}' | grep -i mysql || {
+  echo "PHASE_BLOCKED: MySQL 컨테이너 기동 실패"; exit 1;
+}
+```
+
+MySQL ping 에러는 `pnpm db:migrate` 실행 시 자연 검출됨. 사전 단계는 컨테이너 기동만 보장.
+
 ## 작업 목록 (총 4개)
 
 ### 1. `src/infra/db/schema/posts.ts` 수정
 
-기존 `index` 배열에 composite descending 인덱스 추가:
+기존 `index` 배열에 composite descending 인덱스 추가. **drizzle-orm 0.45.1은 column-level `.desc()` on index 지원이 불확실**(drizzle-kit snapshot에서 방향 정보 직렬화 이슈 다수 보고) → **`sql` 템플릿 raw expression을 기본 채택**:
 
 ```ts
+import { sql } from "drizzle-orm";
+
 (table) => [
   index("category_idx").on(table.category),
   index("slug_idx").on(table.slug),
-  index("posts_updated_at_id_idx").on(table.updatedAt.desc(), table.id.desc()),
+  index("posts_updated_at_id_idx").on(
+    sql`${table.updatedAt} DESC`,
+    sql`${table.id} DESC`,
+  ),
 ],
 ```
 
-Drizzle MySQL core에서 `.desc()` 체인 지원되는지 버전 확인 (drizzle-orm 0.45.1). 미지원이면 `sql` 템플릿 raw index로 대체 — 이 경우 기존 패턴과 맞춤.
+대안 탐색(선택): `.desc()` chain을 먼저 시도해보고 `pnpm db:generate` 결과 SQL에 `DESC` 키워드가 **포함되지 않으면** 즉시 raw `sql` 방식으로 롤백. 판단 근거는 `grep "DESC" drizzle/<new>.sql` 실측.
 
 ### 2. `src/infra/db/schema/visitStats.ts` 수정
 
+동일하게 raw `sql` 채택:
+
 ```ts
+import { sql } from "drizzle-orm";
+
 (table) => [
   uniqueIndex("visit_stats_page_path_idx").on(table.pagePath),
-  index("visit_stats_count_path_idx").on(table.visitCount.desc(), table.pagePath),
+  index("visit_stats_count_path_idx").on(
+    sql`${table.visitCount} DESC`,
+    sql`${table.pagePath} ASC`,
+  ),
 ],
 ```
 
@@ -95,8 +121,8 @@ git diff --name-only | grep -E "drizzle/meta/_journal\.json"
 # 4) 타입 체크 통과
 pnpm type-check
 
-# 5) db:push 흔적 없음 (BLG1 금지 규칙)
-! grep -r "db:push" drizzle/ 2>/dev/null
+# 5) 생성 SQL에 DESC 키워드가 실제로 포함됐는지 확인 (방향성 누락 시 인덱스가 무용지물)
+ls drizzle/*.sql | tail -1 | xargs grep -n "DESC"
 ```
 
 ## PHASE_BLOCKED 조건

--- a/tasks/plan001-posts-list-infinite-scroll/phase-02.md
+++ b/tasks/plan001-posts-list-infinite-scroll/phase-02.md
@@ -27,8 +27,10 @@ Phase-01에서 추가한 인덱스를 활용하는 Repository 메서드 3개를 
 async getRecentPostsCursor(params: {
   limit: number;
   cursor?: { updatedAt: Date; id: number };
-}): Promise<PostData[]>
+}): Promise<Array<PostData & { updatedAt: Date; id: number }>>
 ```
+
+**반환 타입에 `updatedAt, id`를 처음부터 포함**. API Route가 `nextCursor` 문자열(`<iso8601>:<id>`)을 생성하는 데 필요. 클라이언트 응답에서는 route handler가 두 필드를 생략하고 내려보낸다 (phase-03 책임).
 
 SQL 의미:
 ```
@@ -50,7 +52,7 @@ const whereExpr = cursor
   : eq(posts.isActive, true);
 ```
 
-반환 필드는 `getRecentPosts` 와 동일 (`title, path, slug, category, subcategory, folders, description`). `folders` null-guard 유지.
+기존 `getRecentPosts` SELECT 컬럼 (`title, path, slug, category, subcategory, folders, description`)에 **`updatedAt, id` 추가**. `folders` null-guard는 유지.
 
 ### 2. `VisitRepository.getPopularPostPathsOffset` 추가
 
@@ -81,7 +83,17 @@ SQL:
 SELECT COUNT(*) AS total FROM visit_stats
 ```
 
-에러 시 `logger.error({ component, operation, err }, ...)` 4-field로 로깅 + `throw` (BLG3 사일런트 실패 금지). 기존 `try { ... } catch { return 0; }` 패턴이 아니라 **명시적 throw** — API layer가 500으로 응답.
+에러 시 기존 파일 상단의 `log = logger.child({ module })` 를 재사용하여 **4-field 구조화** 로깅 + `throw` (BLG3 사일런트 실패 금지):
+
+```ts
+log.error(
+  { component: "repo.visit", operation: "getPopularPostPathsTotal", err: error instanceof Error ? error : new Error(String(error)) },
+  "failed to count popular posts"
+);
+throw error;
+```
+
+기존 `try { ... } catch { return 0; }` 패턴이 아니라 **명시적 throw** — API layer가 500으로 응답.
 
 ### 4. PostRepository 단위 테스트 신규 파일
 
@@ -91,6 +103,7 @@ SELECT COUNT(*) AS total FROM visit_stats
 - `getRecentPostsCursor({ limit: 10 })` — cursor 없을 때 상위 10개 (목 DB)
 - `getRecentPostsCursor({ limit: 10, cursor })` — cursor 이후 범위만
 - `getRecentPostsCursor({ limit: 10 })` — `is_active = false` 필터링
+- **반환 객체에 `updatedAt`(Date 인스턴스) + `id`(number) 필드가 존재**하는지 타입 및 값 검증 (phase-03 nextCursor 생성 의존성)
 
 mock은 Drizzle `db` 객체를 `vi.mock`으로 대체. 기존 `SyncService.test.ts` 스타일.
 
@@ -124,14 +137,21 @@ pnpm test --run src/infra/db/repositories/
 # 4) 타입 체크
 pnpm type-check
 
-# 5) logger 구조화 4-field 준수 확인 (BLG2)
-grep -nE "logger.*error.*\{[^}]*component[^}]*operation[^}]*err" src/infra/db/repositories/VisitRepository.ts
+# 5) logger 구조화 4-field 준수 확인 (BLG2) — multiline 허용 + 실제 `log.`/`logger.` 패턴 수용
+grep -nzE "(log|logger)\.(error|warn)\s*\(\s*\{[^}]*component[^}]*operation[^}]*err" src/infra/db/repositories/VisitRepository.ts
+# 또는 문자열 포함 체크 (multiline 호출 대응):
+grep -n "component:" src/infra/db/repositories/VisitRepository.ts | grep -q "repo.visit" && \
+  grep -n "operation:" src/infra/db/repositories/VisitRepository.ts | grep -q "getPopularPostPathsTotal"
 
-# 6) catch 빈 swallow 없음 (BLG3)
-! grep -nE "catch\s*\{\s*return\s+(null|\[\]|\{\});?\s*\}" src/infra/db/repositories/VisitRepository.ts | grep -v "기존허용범위"
+# 6) getPopularPostPathsTotal 함수 내에 catch 사일런트 swallow 없음 (BLG3)
+#    — 기존 getPopularPostPaths 의 `catch { return []; }` 는 보존. awk 블록 추출 후 grep.
+awk '/async getPopularPostPathsTotal/,/^  \}/' src/infra/db/repositories/VisitRepository.ts | \
+  grep -qE "catch\s*\(.*\)\s*\{\s*(return|log\.error)" && \
+  ! awk '/async getPopularPostPathsTotal/,/^  \}/' src/infra/db/repositories/VisitRepository.ts | \
+      grep -nE "catch\s*\(.*\)\s*\{\s*return\s+(null|\[\]|\{\}|0);?\s*\}"
 ```
 
-(성공 기준 6은 기존 코드의 `catch { return 0; }` 패턴은 **보존**. 신규 메서드 `getPopularPostPathsTotal`에만 엄격 적용 — grep 범위를 함수 단위로 좁혀 검증.)
+성공 기준 #6은 기존 `catch { return 0; }` 코드 보존 + 신규 `getPopularPostPathsTotal`에만 엄격 적용 (awk로 함수 범위 추출 후 grep).
 
 ## PHASE_BLOCKED 조건
 

--- a/tasks/plan001-posts-list-infinite-scroll/phase-03.md
+++ b/tasks/plan001-posts-list-infinite-scroll/phase-03.md
@@ -37,15 +37,14 @@ export async function GET(request: Request): Promise<Response>
 7. 응답: `{ items, nextCursor }`
 8. 에러 시 BLG2 4-field 로거 + 500 + `{ error: "..." }` 응답 (BLG3 준수)
 
-※ `updatedAt`은 Repository에서 반환되지 않음 (기존 `PostData`는 `createdAt`/`updatedAt` 미포함). nextCursor 생성용으로 필요하므로:
-- 옵션 A: `getRecentPostsCursor` 반환 타입에 `updatedAt, id` 추가
-- 옵션 B: Route에서 별도로 조회
-→ **옵션 A 선택** (한 번 쿼리로 끝). Phase-02에서 반환 DTO에 `updatedAt: Date, id: number` 포함. 응답에서는 `updatedAt`을 **제외**하고 `nextCursor` 계산 후 버림.
+※ `nextCursor` 생성용으로 `updatedAt`/`id`가 필요. **phase-02에서 `getRecentPostsCursor` 반환 타입이 이미 `Array<PostData & { updatedAt: Date; id: number }>`로 확정**되어 있음 (phase-02 작업 1 참조). 이 Route Handler는 응답 body에서 두 필드를 제거하고 `items`에 싣는다:
 
-이 요구사항은 Phase-02 작업 항목 1에 역으로 반영해야 하므로, **executor는 Phase-02 시그니처를 이 phase 실행 시점에 확장**한다:
 ```ts
-// 확장된 시그니처
-async getRecentPostsCursor(...): Promise<Array<PostData & { updatedAt: Date; id: number }>>
+const rows = await post.getRecentPostsCursor({ limit, cursor });
+const last = rows[rows.length - 1];
+const nextCursor = rows.length === limit && last
+  ? `${last.updatedAt.toISOString()}:${last.id}` : null;
+const items = rows.map(({ updatedAt: _u, id: _i, ...rest }) => rest);
 ```
 
 ### 2. `GET /api/posts/popular` Route Handler
@@ -97,9 +96,14 @@ grep -n "export async function GET" src/app/api/posts/popular/route.ts
 grep -n "nextCursor" src/app/api/posts/latest/route.ts
 grep -n "hasMore" src/app/api/posts/popular/route.ts
 
-# 3) Logger 4-field 구조화 (BLG2)
-grep -nE "logger\.(error|warn)\(\s*\{[^}]*component" src/app/api/posts/latest/route.ts
-grep -nE "logger\.(error|warn)\(\s*\{[^}]*component" src/app/api/posts/popular/route.ts
+# 3) Logger 4-field 구조화 (BLG2) — 실제 코드베이스는 `log = logger.child({module})` → `log.error({...}, "msg")` 패턴.
+#    multi-line 호출 허용을 위해 component/operation/err 문자열 존재만 체크.
+grep -nE "component:\s*\"api\.posts\.latest\"" src/app/api/posts/latest/route.ts
+grep -nE "operation:\s*\"GET\"" src/app/api/posts/latest/route.ts
+grep -nE "err:" src/app/api/posts/latest/route.ts
+grep -nE "component:\s*\"api\.posts\.popular\"" src/app/api/posts/popular/route.ts
+grep -nE "operation:\s*\"GET\"" src/app/api/posts/popular/route.ts
+grep -nE "err:" src/app/api/posts/popular/route.ts
 
 # 4) 테스트 통과
 pnpm test --run src/app/api/posts/

--- a/tasks/plan001-posts-list-infinite-scroll/phase-04.md
+++ b/tasks/plan001-posts-list-infinite-scroll/phase-04.md
@@ -149,7 +149,7 @@ grep -l '"use client"' src/components/PostsInfiniteList.tsx
 
 # 3) IntersectionObserver 직접 사용 (ADR-006 준수 — 외부 라이브러리 없음)
 grep -n "new IntersectionObserver" src/components/PostsInfiniteList.tsx
-! grep -nE "from ['\"]react-intersection-observer" src/components/
+! grep -rnE "from ['\"]react-intersection-observer" src/components/
 
 # 4) Cleanup 패턴 (메모리 누수 방지)
 grep -nE "(disconnect|removeEventListener)" src/components/PostsInfiniteList.tsx

--- a/tasks/plan001-posts-list-infinite-scroll/phase-05.md
+++ b/tasks/plan001-posts-list-infinite-scroll/phase-05.md
@@ -170,7 +170,24 @@ pnpm type-check
 pnpm test --run
 pnpm build
 
-# 9) 변경 파일 실측
+# 9) dev server boot + API endpoint 200 응답 확인 (런타임 smoke test)
+pnpm db:up > /dev/null
+(pnpm dev > /tmp/fosblog-dev.log 2>&1 &) && DEV_PID=$!
+# ready 대기 (max 60s)
+for i in {1..60}; do
+  curl -sf http://localhost:3000/api/posts/latest?limit=1 > /dev/null && break
+  sleep 1
+done
+curl -sfo /tmp/latest.json -w "latest=%{http_code}\n" "http://localhost:3000/api/posts/latest?limit=5"
+curl -sfo /tmp/popular.json -w "popular=%{http_code}\n" "http://localhost:3000/api/posts/popular?limit=5&offset=0"
+jq -e '.items and has("nextCursor")' /tmp/latest.json
+jq -e '.items and has("hasMore")'    /tmp/popular.json
+# 페이지 SSR 200 확인
+curl -sfo /dev/null -w "page-latest=%{http_code}\n"  http://localhost:3000/posts/latest
+curl -sfo /dev/null -w "page-popular=%{http_code}\n" http://localhost:3000/posts/popular
+kill $(pgrep -f "next dev" | head -1) 2>/dev/null || true
+
+# 10) 변경 파일 실측
 git diff --name-only  # 기대: 페이지 2개, page.tsx, 컴포넌트 4개, Repository 2개, API route 2개, 테스트 4개, 스키마 2개, drizzle sql 1개
 git diff --stat       # 실측 파일/줄 수 기록 (critic이 수치 검증)
 ```
@@ -184,13 +201,12 @@ git diff --stat       # 실측 파일/줄 수 기록 (critic이 수치 검증)
 ## 완료 후 team-lead 처리
 
 - 모든 phase PASS 후 team-lead가 통합 검증 명령 재확인 (`pnpm lint && pnpm type-check && pnpm test --run && pnpm build`)
-- 단일 커밋 또는 논리 단위별 분리 커밋 (atomic commits — 사용자 선호 메모리 반영)
-  - 권장 분리:
-    - `feat(db): add sort indexes for latest/popular lists`
-    - `feat(posts): add cursor/offset list repository methods + tests`
-    - `feat(api): add /api/posts/latest and /api/posts/popular + tests`
-    - `feat(ui): add infinite scroll components`
-    - `feat(posts): add /posts/latest /posts/popular pages + home CTA`
+- **분리 커밋 필수** (atomic commits — 사용자 선호 메모리 [atomic-commits]). 단일 커밋 금지:
+  - `feat(db): add sort indexes for latest/popular lists`
+  - `feat(posts): add cursor/offset list repository methods + tests`
+  - `feat(api): add /api/posts/latest and /api/posts/popular + tests`
+  - `feat(ui): add infinite scroll components`
+  - `feat(posts): add /posts/latest /posts/popular pages + home CTA`
 - docs는 이미 별도 선행 커밋됨 — 이 plan 실행 중 docs 변경 금지
 - PR 제목: `feat(posts): add infinite scroll latest/popular pages`
 - index.json `status: "completed"` 갱신 커밋 + push (누락 시 재실행 사고)


### PR DESCRIPTION
## Summary

- `/posts/latest`(cursor 기반) + `/posts/popular`(offset 기반) 무한 스크롤 페이지 추가
- 홈페이지 인기/최신 섹션 하단에 "더 보기" CTA 버튼 2개 추가
- DB 인덱스 2개 추가로 무한 스크롤 중 중복/누락 방지 (ADR-002)
- `posts.createdAt/updatedAt` `.notNull()` 명시로 unsafe `as Date` 캐스트 제거

## 변경 범위

### 신규 파일
- `drizzle/0002_mature_mercury.sql`, `drizzle/0003_dashing_rattler.sql` — 인덱스 + NOT NULL 마이그레이션
- `src/app/api/posts/latest/route.ts` + `route.test.ts` — GET `/api/posts/latest`
- `src/app/api/posts/popular/route.ts` + `route.test.ts` — GET `/api/posts/popular` (응답에 `nextOffset` 포함)
- `src/app/posts/latest/page.tsx` — SSR 최신 글 페이지 (revalidate 60, noindex)
- `src/app/posts/popular/page.tsx` — SSR 인기 글 페이지 (revalidate 600, noindex)
- `src/components/PostsInfiniteList.tsx` — 클라이언트 무한 스크롤 (IntersectionObserver 네이티브)
- `src/components/BackToTopButton.tsx` — floating/inline variant
- `src/components/SectionCTAButton.tsx` — 홈 섹션 하단 CTA
- `src/components/PostCardSkeleton.tsx` — 로딩 스켈레톤
- `src/infra/db/repositories/PostRepository.test.ts`, `VisitRepository.test.ts` — 단위 테스트

### 수정 파일
- `src/infra/db/schema/posts.ts`, `visitStats.ts` — 인덱스 + NOT NULL
- `src/infra/db/repositories/PostRepository.ts` — `getRecentPostsCursor`
- `src/infra/db/repositories/VisitRepository.ts` — `getPopularPostPathsOffset`, `getPopularPostPathsTotal` + AI slop 주석 정리
- `src/app/page.tsx` — CTA 버튼 2개 추가
- `docs/code-architecture.md`, `docs/data-schema.md` — 구현과 동기화

## 의사결정 하이라이트

- **cursor 페이징 (최신)**: `(updated_at, id)` composite — updated_at 동점 tie-break로 누락 방지
- **offset 페이징 (인기)**: `(visit_count DESC, page_path ASC)` — visit_count 동점 순서 결정성
- **nextOffset 응답 필드**: 비활성 포스트 필터링 시 `items.length` 대신 `popularPaths.length` 기준으로 offset 진행하여 중복 요청 방지
- **"더 보기" 버튼**: `status === "idle"` 시에만 노출 (loading/error/done과 배타)
- **drizzle `.desc()` on index**: 0.45.1 직렬화 불안정 → raw `sql` 템플릿 채택

## Test plan

- [x] `pnpm lint` PASS
- [x] `pnpm type-check` PASS
- [x] `pnpm test --run` → 122개 통과 (14 files, popular 테스트 1개 추가)
- [x] `pnpm build` PASS (`/posts/latest` 1m, `/posts/popular` 10m revalidate 확인)
- [x] smoke test: `GET /api/posts/latest?limit=5` 200 + `nextCursor` shape, `GET /api/posts/popular?limit=5&offset=0` 200 + `hasMore`+`nextOffset` shape, 페이지 SSR 200
- [x] critic APPROVE (1회 REVISE 후 수정)
- [x] code-reviewer PASS (1회 FIX_NEEDED 후 수정)
- [x] docs-verifier PASS (2회 UPDATE_NEEDED + 1 VIOLATION 후 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)