### PR TITLE
fix(seo): remove duplicate H1 on post/folder pages

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -245,6 +245,7 @@
 **Follow-ups**:
 - 향후 다른 페이지(검색 결과 등)에서 Markdown 렌더 시에도 동일 전처리 적용 여부 판단
 - 글 본문의 heading 계층이 h2 부터 시작하게 되므로, rehype-slug + TOC 생성 로직 (`generateTableOfContents`) 영향 재확인
+  → **확인됨**: `generateTableOfContents(mainContent)` 에 stripped content 를 전달하므로 H1 제목이 TOC 에서 제거되는 것이 의도된 동작. 페이지 `<h1>` 으로 이미 노출되므로 TOC 중복 없음
 
 ---
 

--- a/src/app/category/[...path]/page.tsx
+++ b/src/app/category/[...path]/page.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft, Folder, ChevronRight, Home, BookOpen } from "lucide-react";
 import { Metadata } from "next";
 import { env } from "@/env";
 import logger from "@/lib/logger";
+import { parseFrontMatter, stripLeadingH1 } from "@/lib/markdown";
 
 const log = logger.child({ module: "app/category/[...path]" });
 const siteUrl = env.NEXT_PUBLIC_SITE_URL;
@@ -195,7 +196,7 @@ export default async function FolderPage({ params }: FolderPageProps) {
               <span>README.md</span>
             </div>
             <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 md:p-8">
-              <MarkdownRenderer content={readme} basePath={`${folderPath}/README`} />
+              <MarkdownRenderer content={stripLeadingH1(parseFrontMatter(readme).content)} basePath={`${folderPath}/README`} />
             </div>
           </section>
         )}

--- a/src/app/posts/[...slug]/page.tsx
+++ b/src/app/posts/[...slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   getReadingTime,
   generateTableOfContents,
   parseFrontMatter,
+  stripLeadingH1,
 } from "@/lib/markdown";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { TableOfContents } from "@/components/TableOfContents";
@@ -111,7 +112,8 @@ export default async function PostPage({ params }: PostPageProps) {
   }
 
   const { content, post: postData } = data;
-  const { content: mainContent } = parseFrontMatter(content);
+  const { content: contentWithoutFrontmatter } = parseFrontMatter(content);
+  const mainContent = stripLeadingH1(contentWithoutFrontmatter);
   const title = extractTitle(content) || postData.title;
   const readingTime = getReadingTime(content);
   const toc = generateTableOfContents(mainContent);

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -5,6 +5,7 @@ import {
   generateTableOfContents,
   getReadingTime,
   parseFrontMatter,
+  stripLeadingH1,
 } from "./markdown";
 
 // ===== parseFrontMatter =====
@@ -208,5 +209,42 @@ describe("generateTableOfContents", () => {
     const toc = generateTableOfContents(content);
     expect(toc).toHaveLength(1);
     expect(toc[0].text).toBe("진짜 헤딩");
+  });
+});
+
+// ===== stripLeadingH1 =====
+describe("stripLeadingH1", () => {
+  it("returns content unchanged when no leading h1", () => {
+    const input = "## Section\n본문...";
+    expect(stripLeadingH1(input)).toBe(input);
+  });
+
+  it("removes leading h1 and following blank lines", () => {
+    const input = "# Title\n\n본문 내용";
+    expect(stripLeadingH1(input)).toBe("본문 내용");
+  });
+
+  it("removes leading blank lines + h1 + trailing blank lines", () => {
+    const input = "\n\n# Title\n\n\n본문";
+    expect(stripLeadingH1(input)).toBe("본문");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripLeadingH1("")).toBe("");
+  });
+
+  it("preserves mid-document h1", () => {
+    const input = "본문 첫 단락\n\n# Mid Heading\n\n본문 이어서";
+    expect(stripLeadingH1(input)).toBe(input);
+  });
+
+  it("does not remove leading h2", () => {
+    const input = "## Only Section\n본문";
+    expect(stripLeadingH1(input)).toBe(input);
+  });
+
+  it("does not remove h1 without space after hash (e.g. #main)", () => {
+    const input = "#main\n본문";
+    expect(stripLeadingH1(input)).toBe(input);
   });
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -113,6 +113,21 @@ export interface TocItem {
   slug: string;
 }
 
+/**
+ * Markdown 본문의 선두 H1 라인 + 뒤이은 공백 라인을 제거한다.
+ * ADR-010 참조.
+ */
+export function stripLeadingH1(content: string): string {
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length && lines[i].trim() === "") i++;
+  if (i >= lines.length) return content;
+  if (!/^#\s+.+$/.test(lines[i])) return content;
+  i++;
+  while (i < lines.length && lines[i].trim() === "") i++;
+  return lines.slice(i).join("\n");
+}
+
 export function generateTableOfContents(content: string): TocItem[] {
   const headingRegex = /^(#{1,6})\s+(.+)$/gm;
   const toc: TocItem[] = [];


### PR DESCRIPTION
## Summary

- 글 상세 페이지와 FolderPage README 에서 페이지 `<h1>{title}</h1>` 과 본문 선두 `# Title` 이 모두 렌더되어 **H1 이 2개** 가 되는 문제를 해결
- Markdown 원본(`jon890/fos-study`) 은 건드리지 않고, 렌더 직전 전처리로 선두 h1 을 제거하는 순수 유틸 `stripLeadingH1` 추가
- FolderPage README 는 frontmatter 가 있어도 안전하게 동작하도록 `stripLeadingH1(parseFrontMatter(readme).content)` 형태 적용

## ADR

- **ADR-010** Markdown 본문 선두 H1 제거 — regex `^#\s+.+$` 로 정확히 h1 만 매치, 중간 h1 은 섹션 마커로 보존
- Follow-ups: `generateTableOfContents(mainContent)` 는 stripped content 를 받아 **TOC 에서 H1 항목 제거가 의도된 동작** (페이지 `<h1>` 으로 이미 노출)

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test -- --run` (15 files, 138 tests — stripLeadingH1 7 케이스 포함)
- [x] `pnpm build`
- [ ] 수동 검증: 임의 글 상세 + 카테고리 README 렌더 시 H1 1개만 보이는지 확인
- [ ] 수동 검증: TOC 에 본문 H1 항목이 없고, h2 부터 표시되는지 확인
- [ ] 수동 검증: 중간 h1 이 있는 글에서 중간 h1 은 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)