### PR TITLE
feat(middleware): visit tracking 경로 유효성 + middleware 파일 분리 (ADR-015)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ fos-blog/
 │   │   ├── db/       # Drizzle ORM — schema, repositories, connection
 │   │   └── github/   # GitHub API client (Octokit)
 │   ├── lib/          # Shared utilities (markdown, logger, path-utils)
-│   └── proxy.ts      # Next.js middleware — visit count recording
+│   ├── middleware/   # Per-concern middleware modules (visit.ts, rateLimit.ts)
+│   └── proxy.ts      # Thin middleware orchestrator — composes middleware/* (Node Runtime)
 ├── local/            # Local dev environment (Docker Compose, MySQL init)
 ├── drizzle/          # Drizzle migration artifacts (auto-generated)
 ├── public/           # Static assets
@@ -144,7 +145,8 @@ Browser (Markdown + GFM + Mermaid + 문법 강조)
 | Directory / File    | Purpose                                                                                                |
 | ------------------- | ------------------------------------------------------------------------------------------------------ |
 | `CLAUDE.md`         | AI 에이전트용 프로젝트 컨텍스트 문서 — 기술 스택, 디렉토리 구조, 컨벤션, 환경변수 상세 정리            |
-| `src/proxy.ts`      | Next.js middleware — records page visits to DB via `waitUntil` (fire-and-forget); runs on Edge Runtime |
+| `src/proxy.ts`      | Thin middleware orchestrator — delegates to `middleware/visit.ts` + `middleware/rateLimit.ts` (Node Runtime) |
+| `src/middleware/`   | Per-concern middleware modules — visit tracking (`visit.ts`), rate limiting (`rateLimit.ts`, plan007) |
 | `src/app/`          | Next.js pages and API routes (see `src/app/AGENTS.md`)                                                 |
 | `src/components/`   | Reusable React UI components (see `src/components/AGENTS.md`)                                          |
 | `src/services/`     | Business logic layer — SyncService, PostService (see `src/services/AGENTS.md`)                         |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ fos-blog/
 │   │   ├── db/           # Drizzle ORM — schema/, repositories/
 │   │   └── github/       # Octokit client, API, file-filter, image-rewrite
 │   ├── lib/              # Shared utils — markdown.ts, logger.ts, path-utils.ts
-│   └── proxy.ts          # Middleware — visit count via waitUntil() (Edge Runtime)
+│   ├── middleware/       # Per-concern middleware — visit.ts (visit tracking), rateLimit.ts (placeholder)
+│   └── proxy.ts          # Thin middleware orchestrator — composes middleware/* (Node Runtime)
 ├── local/                # Docker Compose + MySQL init.sql
 ├── drizzle/              # Migration artifacts (auto-generated, do not edit)
 ├── Dockerfile            # Multi-stage build (output: standalone)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ fos-blog/
 │   │   ├── db/           # Drizzle 스키마 + 레포지토리
 │   │   └── github/       # GitHub API 클라이언트
 │   ├── lib/              # 공유 유틸 (markdown, logger)
-│   └── proxy.ts          # 미들웨어 (방문자 통계)
+│   ├── middleware/       # 방문 기록 (visit.ts), rate limit (rateLimit.ts)
+│   └── proxy.ts          # 미들웨어 thin orchestrator
 ├── local/                # Docker Compose + MySQL 초기화
 ├── drizzle/              # 마이그레이션 파일 (자동 생성)
 └── Dockerfile            # 홈서버 배포용

--- a/docs/pages/post-detail.md
+++ b/docs/pages/post-detail.md
@@ -118,4 +118,4 @@
 - `TableOfContents`는 `toc.length > 0` 일 때만 렌더링
 - GitHub URL은 `jon890/fos-study` 레포 고정
 - 모바일에서 TOC 미노출 — 별도 모바일 TOC 구현 시 이 문서 업데이트 필요
-- **조회수 증가**는 `src/proxy.ts`(Edge middleware)에서 처리 — `PostViewCount`는 표시만 담당
+- **조회수 증가**는 `src/proxy.ts` Node Runtime middleware (실 동작은 `src/middleware/visit.ts`로 위임)에서 처리 — `PostViewCount`는 표시만 담당

--- a/drizzle/0004_cleanup_stale_visits.sql
+++ b/drizzle/0004_cleanup_stale_visits.sql
@@ -1,0 +1,11 @@
+-- ADR-015: visit_logs / visit_stats 에 누적된 비유효 path row cleanup.
+-- 활성/비활성 무관 posts.path 에 매치되는 row 는 보존 (비활성 글 visit 도 보존).
+-- 홈 ('/') 도 보존.
+
+DELETE FROM visit_logs
+WHERE page_path <> '/'
+  AND page_path NOT IN (SELECT path FROM posts);
+--> statement-breakpoint
+DELETE FROM visit_stats
+WHERE page_path <> '/'
+  AND page_path NOT IN (SELECT path FROM posts);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,631 @@
+{
+  "id": "a03c3cdc-48e6-4b1b-8870-6d23dc4899b3",
+  "prevId": "51fd8f26-cd0e-4342-bb17-f2e1df70364e",
+  "version": "5",
+  "dialect": "mysql",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_slug": {
+          "name": "post_slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "post_slug_idx": {
+          "name": "post_slug_idx",
+          "columns": [
+            "post_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comments_id": {
+          "name": "comments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "path_idx": {
+          "name": "path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "folders_path_unique": {
+          "name": "folders_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folders": {
+          "name": "folders",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "category_idx": {
+          "name": "category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "posts_updated_at_id_idx": {
+          "name": "posts_updated_at_id_idx",
+          "columns": [
+            "`updated_at` DESC",
+            "`id` DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_path_unique": {
+          "name": "posts_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posts_added": {
+          "name": "posts_added",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_updated": {
+          "name": "posts_updated",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_deleted": {
+          "name": "posts_deleted",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_logs_id": {
+          "name": "sync_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_logs": {
+      "name": "visit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visited_date": {
+          "name": "visited_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_page_ip_date_idx": {
+          "name": "visit_page_ip_date_idx",
+          "columns": [
+            "page_path",
+            "ip_hash",
+            "visited_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_logs_id": {
+          "name": "visit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_stats": {
+      "name": "visit_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "visit_stats_page_path_idx": {
+          "name": "visit_stats_page_path_idx",
+          "columns": [
+            "page_path"
+          ],
+          "isUnique": true
+        },
+        "visit_stats_count_path_idx": {
+          "name": "visit_stats_count_path_idx",
+          "columns": [
+            "`visit_count` DESC",
+            "`page_path` ASC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_stats_id": {
+          "name": "visit_stats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "posts_updated_at_id_idx": {
+        "columns": {
+          "`updated_at` DESC": {
+            "isExpression": true
+          },
+          "`id` DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "visit_stats_count_path_idx": {
+        "columns": {
+          "`visit_count` DESC": {
+            "isExpression": true
+          },
+          "`page_path` ASC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776580577680,
       "tag": "0003_dashing_rattler",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1777094090262,
+      "tag": "0004_cleanup_stale_visits",
+      "breakpoints": true
     }
   ]
 }

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -9,19 +9,20 @@
 
 ## Subdirectories
 
-| Directory     | Purpose                                                               |
-| ------------- | --------------------------------------------------------------------- |
-| `app/`        | Next.js 라우팅 — 페이지, API 라우트, 레이아웃 (see `app/AGENTS.md`)   |
-| `components/` | 재사용 가능한 React UI 컴포넌트 (see `components/AGENTS.md`)          |
-| `services/`   | 비즈니스 로직 레이어 — 동기화, 포스트 조회 (see `services/AGENTS.md`) |
-| `infra/`      | 외부 시스템 통합 — DB, GitHub API (see `infra/AGENTS.md`)             |
-| `lib/`        | 공유 유틸리티 — markdown, logger, path-utils (see `lib/AGENTS.md`)    |
+| Directory     | Purpose                                                                  |
+| ------------- | ------------------------------------------------------------------------ |
+| `app/`        | Next.js 라우팅 — 페이지, API 라우트, 레이아웃 (see `app/AGENTS.md`)      |
+| `components/` | 재사용 가능한 React UI 컴포넌트 (see `components/AGENTS.md`)             |
+| `services/`   | 비즈니스 로직 레이어 — 동기화, 포스트 조회 (see `services/AGENTS.md`)    |
+| `infra/`      | 외부 시스템 통합 — DB, GitHub API (see `infra/AGENTS.md`)                |
+| `lib/`        | 공유 유틸리티 — markdown, logger, path-utils (see `lib/AGENTS.md`)       |
+| `middleware/` | 미들웨어 책임별 모듈 — `visit.ts` (방문 기록), `rateLimit.ts` (예정)     |
 
 ## Key Files
 
-| File       | Description                                                                   |
-| ---------- | ----------------------------------------------------------------------------- |
-| `proxy.ts` | Next.js 미들웨어 — 포스트 조회수를 `waitUntil()`로 비동기 기록 (Edge Runtime) |
+| File       | Description                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| `proxy.ts` | Next.js 미들웨어 thin orchestrator — `middleware/visit.ts` + `middleware/rateLimit.ts` 조합 (Node Runtime) |
 
 ## Architecture
 

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Rate limiting placeholder. 실제 구현은 plan007 에서.
+ * 현재는 모든 요청 통과 (no-op).
+ */
+export function rateLimit(_request: NextRequest): NextResponse | null {
+  return null; // null = 통과, NextResponse = 차단
+}

--- a/src/middleware/visit.test.ts
+++ b/src/middleware/visit.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { NextRequest, NextFetchEvent } from "next/server";
+
+// ── 호이스팅 모크 ────────────────────────────────────────────────────────────
+const mockGetPostId = vi.hoisted(() => vi.fn());
+const mockRecordVisit = vi.hoisted(() => vi.fn().mockResolvedValue(true));
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    child: vi.fn().mockReturnValue({
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@/infra/db", () => ({
+  getDb: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@/infra/db/repositories/PostRepository", () => ({
+  PostRepository: class {
+    getPostId = mockGetPostId;
+  },
+}));
+
+vi.mock("@/infra/db/repositories/VisitRepository", () => ({
+  VisitRepository: class {
+    recordVisit = mockRecordVisit;
+  },
+}));
+
+// ── import (mock 등록 이후) ──────────────────────────────────────────────────
+import { trackVisit } from "./visit";
+
+// ── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+function makeRequest(pathname: string, ip?: string): NextRequest {
+  return {
+    nextUrl: { pathname },
+    headers: {
+      get: (key: string) => {
+        if (key === "x-forwarded-for") return ip ?? "127.0.0.1";
+        return null;
+      },
+    },
+  } as unknown as NextRequest;
+}
+
+/** event.waitUntil 에 전달된 promise 를 캡처 */
+function makeEvent(): {
+  event: NextFetchEvent;
+  getPromise: () => Promise<unknown>;
+} {
+  let captured: Promise<unknown> | null = null;
+  const event = {
+    waitUntil: (p: Promise<unknown>) => {
+      captured = p;
+    },
+  } as unknown as NextFetchEvent;
+  return {
+    event,
+    getPromise: () => captured ?? Promise.resolve(),
+  };
+}
+
+// ── 테스트 ───────────────────────────────────────────────────────────────────
+
+describe("trackVisit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks 가 resolvedValue 구현을 지우므로 재설정
+    mockRecordVisit.mockResolvedValue(true);
+  });
+
+  it("/posts/latest → recordVisit 호출되지 않음 (SKIP_PATHS)", async () => {
+    const { event, getPromise } = makeEvent();
+    trackVisit(makeRequest("/posts/latest"), event);
+    await getPromise();
+    expect(mockRecordVisit).not.toHaveBeenCalled();
+  });
+
+  it("/posts/popular → recordVisit 호출되지 않음 (SKIP_PATHS)", async () => {
+    const { event, getPromise } = makeEvent();
+    trackVisit(makeRequest("/posts/popular"), event);
+    await getPromise();
+    expect(mockRecordVisit).not.toHaveBeenCalled();
+  });
+
+  it("pathname.length > 300 → waitUntil 호출 안 됨 (길이 가드)", async () => {
+    const longPath = "/" + "a".repeat(301);
+    const { event, getPromise } = makeEvent();
+    trackVisit(makeRequest(longPath), event);
+    await getPromise();
+    expect(mockRecordVisit).not.toHaveBeenCalled();
+  });
+
+  it("/ → recordVisit('/', ipHash) 호출", async () => {
+    const { event, getPromise } = makeEvent();
+    trackVisit(makeRequest("/", "10.0.0.1"), event);
+    await getPromise();
+    expect(mockRecordVisit).toHaveBeenCalledOnce();
+    const [calledPath] = mockRecordVisit.mock.calls[0];
+    expect(calledPath).toBe("/");
+  });
+
+  it("/posts/abc.md + getPostId returns null → recordVisit 호출되지 않음", async () => {
+    mockGetPostId.mockResolvedValueOnce(null);
+    const { event, getPromise } = makeEvent();
+    trackVisit(makeRequest("/posts/abc.md"), event);
+    await getPromise();
+    expect(mockGetPostId).toHaveBeenCalledWith("abc.md");
+    expect(mockRecordVisit).not.toHaveBeenCalled();
+  });
+
+  it("/posts/abc.md + getPostId returns number → recordVisit('abc.md', ipHash) 호출", async () => {
+    mockGetPostId.mockResolvedValueOnce(42);
+    const { event, getPromise } = makeEvent();
+    trackVisit(makeRequest("/posts/abc.md", "192.168.0.1"), event);
+    await getPromise();
+    expect(mockGetPostId).toHaveBeenCalledWith("abc.md");
+    expect(mockRecordVisit).toHaveBeenCalledOnce();
+    const [calledPath, calledHash] = mockRecordVisit.mock.calls[0];
+    expect(calledPath).toBe("abc.md");
+    expect(typeof calledHash).toBe("string");
+    expect(calledHash).toHaveLength(64); // sha256 hex
+  });
+
+  it("/foo (matcher 외 경로) → recordVisit 호출되지 않음", async () => {
+    const { event, getPromise } = makeEvent();
+    trackVisit(makeRequest("/foo"), event);
+    await getPromise();
+    expect(mockRecordVisit).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/visit.ts
+++ b/src/middleware/visit.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextFetchEvent } from "next/server";
+import { createHash } from "crypto";
+import { getDb } from "@/infra/db";
+import { VisitRepository } from "@/infra/db/repositories/VisitRepository";
+import { PostRepository } from "@/infra/db/repositories/PostRepository";
+import logger from "@/lib/logger";
+
+const log = logger.child({ module: "middleware/visit" });
+
+const SKIP_PATHS = new Set(["/posts/latest", "/posts/popular"]);
+const MAX_PATH_LENGTH = 300;
+
+/**
+ * 응답 차단 없이 방문 기록을 비동기로 처리한다.
+ * - `/`: 항상 기록 (`/` 자체)
+ * - `/posts/...`: pathname → posts.path 변환 후 DB 존재 시에만 기록
+ * - `/posts/latest|popular`: noindex 목록 페이지 — early return
+ * - 길이 > 300 path: 가드 차단 (공격 페이로드 무시)
+ */
+export function trackVisit(request: NextRequest, event: NextFetchEvent): void {
+  const pathname = request.nextUrl.pathname;
+
+  if (pathname.length > MAX_PATH_LENGTH) return;
+  if (SKIP_PATHS.has(pathname)) return;
+
+  const clientIp =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown";
+
+  const visitPromise = (async () => {
+    try {
+      const db = getDb();
+      let pagePath: string | null = null;
+
+      if (pathname === "/") {
+        pagePath = "/";
+      } else if (pathname.startsWith("/posts/")) {
+        const postPath = decodeURIComponent(pathname.replace("/posts/", ""));
+        const postRepo = new PostRepository(db);
+        const exists = await postRepo.getPostId(postPath);
+        if (!exists) return;
+        pagePath = postPath;
+      } else {
+        return;
+      }
+
+      const visitRepo = new VisitRepository(db);
+      const ipHash = createHash("sha256").update(clientIp).digest("hex");
+      await visitRepo.recordVisit(pagePath, ipHash);
+    } catch (error) {
+      log.error(
+        {
+          component: "middleware.visit",
+          operation: "recordVisit",
+          pathname,
+          err: error instanceof Error ? error : new Error(String(error)),
+        },
+        "visit record failed"
+      );
+    }
+  })();
+
+  event.waitUntil(visitPromise);
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,44 +1,16 @@
-import { NextResponse, NextRequest, NextFetchEvent } from "next/server";
-import { createHash } from "crypto";
-import { getDb } from "@/infra/db";
-import { VisitRepository } from "@/infra/db/repositories";
+import { NextRequest, NextFetchEvent, NextResponse } from "next/server";
+import { trackVisit } from "@/middleware/visit";
+import { rateLimit } from "@/middleware/rateLimit";
 
-/**
- * 페이지 방문 시 직접 DB에 방문 기록을 남기는 프록시
- * waitUntil을 사용하여 응답을 지연시키지 않고 비동기로 처리
- */
 export function proxy(request: NextRequest, event: NextFetchEvent) {
-  const pathname = request.nextUrl.pathname;
+  const limitResponse = rateLimit(request);
+  if (limitResponse) return limitResponse;
 
-  const clientIp =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "unknown";
-
-  let pagePath = pathname;
-  if (pathname.startsWith("/posts/")) {
-    pagePath = decodeURIComponent(pathname.replace("/posts/", ""));
-  }
-
-  const visitPromise = (async () => {
-    try {
-      const db = getDb();
-      const visitRepo = new VisitRepository(db);
-      const ipHash = createHash("sha256").update(clientIp).digest("hex");
-      await visitRepo.recordVisit(pagePath, ipHash);
-    } catch (error) {
-      console.error("[proxy] 방문 기록 실패:", error);
-    }
-  })();
-
-  event.waitUntil(visitPromise);
+  trackVisit(request, event);
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: [
-    "/",
-    "/posts/:path*",
-  ],
+  matcher: ["/", "/posts/:path*"],
 };

--- a/tasks/plan006-visit-tracking-validation/phase-01.md
+++ b/tasks/plan006-visit-tracking-validation/phase-01.md
@@ -25,10 +25,10 @@
 ```bash
 # cwd: <worktree root>
 
-# 1) MySQL 컨테이너 기동 (마이그레이션 검증용)
-pnpm db:up
-docker ps --format '{{.Names}} {{.Status}}' | grep -i mysql || {
-  echo "PHASE_BLOCKED: MySQL 컨테이너 기동 실패"; exit 1;
+# 1) MySQL 컨테이너 가동 확인 (마이그레이션 검증용)
+#    container 이름: fos-blog-mysql. 미가동 시 'docker compose -f local/docker-compose.yml up -d' 로 기동
+docker ps --format '{{.Names}} {{.Status}}' | grep -E "^fos-blog-mysql " || {
+  echo "PHASE_BLOCKED: fos-blog-mysql 컨테이너 미가동"; exit 1;
 }
 
 # 2) drizzle-kit custom 마이그레이션 지원 확인


### PR DESCRIPTION
## Summary

ADR-015 구현 — visit tracking 경로 유효성 검증 + middleware 파일 분리 + 기존 쓰레기 데이터 cleanup.

- `src/proxy.ts` 가 모든 요청을 무조건 기록하던 구조 → `posts.path` DB 존재 검증 + 길이 가드 + 목록 페이지 early return 적용
- middleware 책임을 `src/middleware/visit.ts` + `src/middleware/rateLimit.ts` (placeholder, plan007) 로 분리. `src/proxy.ts` 는 thin orchestrator
- 기존 SQL injection 페이로드 등 누적된 비유효 path row 를 일회성 cleanup 마이그레이션 (`drizzle/0004_cleanup_stale_visits.sql`) 으로 정리
- docs 부패 정정 (middleware/ 디렉터리 신설 및 Node Runtime 명기)

## Commits

1. `chore(tasks)`: phase 사전 게이트가 미존재 스크립트 호출 → 컨테이너 직접 확인으로 교체
2. `refactor(middleware)`: proxy → visit + rateLimit 분리 + path validation
3. `chore(db)`: cleanup_stale_visits 마이그레이션
4. `docs`: middleware/ 신설 반영 docs 정합성

## Test plan

- [x] `pnpm test` (145 passed, 16 files — visit.test.ts 7 케이스 포함)
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm build` (Next.js standalone)
- [x] `pnpm db:migrate` (0004_cleanup_stale_visits 적용 성공)
- [x] critic APPROVE
- [x] code-reviewer PASS
- [x] docs-verifier PASS (잔여 README.md 1건은 직접 수정 후 통합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)