### PR TITLE
feat(article): plan011 article page redesign (Hero + 3-col grid + TOC + Header progress + prose tokens)

### DIFF
--- a/docs/pages/post-detail.md
+++ b/docs/pages/post-detail.md
@@ -2,13 +2,13 @@
 
 **Route:** `/posts/[...slug]`  
 **File:** `src/app/posts/[...slug]/page.tsx`  
-**Updated:** 2026-04-02
+**Updated:** 2026-04-27
 
 ---
 
 ## Purpose
 
-마크다운 글의 상세 내용을 렌더링하는 페이지. 본문, 목차(사이드바), 메타 정보(읽기 시간, 작성일, 수정일, 조회수), 댓글을 제공한다.
+마크다운 글의 상세 내용을 렌더링하는 페이지. Round 2 mockup (plan011) 기반의 ArticleHero (mesh + breadcrumb + 카테고리 art-tag + 제목 + 리드 + 메타) + 3-col body grid + sticky TOC + Header 통합 reading progress + mockup 톤 prose 로 구성.
 
 ---
 
@@ -17,15 +17,18 @@
 | Source | Method | Returns |
 |--------|--------|---------|
 | PostRepository | `getPost(slug)` | `{ content: string, post: PostData }` |
+| VisitRepository | `getVisitCount(post.path)` | `number` (조회수 — server-side) |
 
 `slug` = URL 세그먼트 배열을 `join("/")` (decodeURIComponent 처리)
 
 **ISR:** `revalidate = 60`  
-**Static params:** `generateStaticParams()` — `post.getAllPostPaths()` 로 생성
+**Static params:** `generateStaticParams()` — `post.getAllPostPaths()` 로 생성  
+**Repositories accessor:** `getRepositories()` (React `cache(...)` wrapper) — 동일 요청 내 재사용
 
 **에러 처리:**
 - DB 에러 시 `notFound()`
 - `data === null` 시 `notFound()`
+- `getVisitCount` 는 `VisitRepository` 내부 try/catch 로 0 fallback (page 레이어 오염 없음)
 
 ---
 
@@ -33,22 +36,25 @@
 
 | Component | Role |
 |-----------|------|
-| `MarkdownRenderer` | 마크다운 본문 렌더링 (GFM, mermaid, syntax highlight) |
-| `TableOfContents` | 사이드바 목차 (lg 이상에서만 표시, `hidden lg:block`) |
-| `Comments` | 댓글 섹션 (postSlug 전달) |
-| `PostViewCount` | 조회수 표시 (클라이언트에서 `/api/visit?path=...` GET으로 fetch) |
+| `ArticleHero` | Hero 영역 — mesh 그라디언트 (카테고리 hue 변형 + plan009 토큰) + breadcrumb + 카테고리 art-tag + 제목 + 리드 + meta row (date · readtime · views) |
+| `MarkdownRenderer` | 마크다운 본문 렌더링 (GFM, mermaid, syntax highlight). 외부 wrapper 는 `<div>` (글 페이지에서 article 중첩 회피) |
+| `TableOfContents` | 사이드바 목차. mono 톤 + 번호 prefix (`01`/`02`) + brand 좌측 라인 + active highlight + sticky top-20. **H2 만 표시** (page.tsx 에서 `level === 2` filter) |
+| `ArticleFooter` | `frontmatter.tags` 가 있는 경우만 렌더되는 태그 칩 영역 (graceful fallback) |
+| `Comments` | 댓글 섹션 (postPath 전달) |
 | `ArticleJsonLd` | JSON-LD 아티클 구조화 데이터 |
 | `BreadcrumbJsonLd` | JSON-LD 브레드크럼 |
+
+> Header (`src/components/Header.tsx`) 는 글 페이지 컴포넌트는 아니지만, `/posts/*` pathname 한정으로 하단 1px 라인을 reading progress fill 로 변환 (plan011).
 
 ---
 
 ## Interactions
 
-- **카테고리 배지 클릭**: `/category/<category>` 이동
+- **breadcrumb 항목 클릭**: `/` (홈), `/category/<category>` (카테고리)
+- **카테고리 art-tag 자체는 표시용** (현재 링크 아님 — 후속 PR 에서 결정)
 - **목차 항목 클릭**: 해당 헤딩으로 스크롤 (`#slug` 앵커)
-- **"GitHub에서 보기" 링크**: GitHub 원본 파일 새 탭 오픈
-- **"수정 제안하기" 버튼**: GitHub 원본 파일 새 탭 오픈
-- **"카테고리의 다른 글 보기"**: `/category/<category>` 이동
+- **태그 칩**: 표시용 (라우팅은 issue #72 에서 결정 예정)
+- **스크롤**: Header 하단 reading progress fill 이 `/posts/*` 에서만 동작
 
 ---
 
@@ -56,8 +62,10 @@
 
 | State | Component | Description |
 |-------|-----------|-------------|
-| `activeSlug` | `TableOfContents` | IntersectionObserver로 현재 뷰포트 내 헤딩 추적 |
-| `isCollapsed` | `TableOfContents` | 목차 접기/펼치기 상태 (localStorage 유지) |
+| `activeSlug` | `TableOfContents` | IntersectionObserver 로 현재 뷰포트 내 헤딩 추적 (ADR-006) |
+| `progress` | `Header` | `/posts/*` 한정 scroll position → 0~1 ratio. passive listener, `isArticle === false` 일 때 등록 안 함 |
+
+> TOC 의 collapse toggle (`isCollapsed`) 은 plan011 에서 제거됨 — H2 만 필터링해 항목 수가 적고 sticky 사이드바에 항상 노출되어 collapse 가 불필요.
 
 ---
 
@@ -73,49 +81,62 @@
 ## Layout
 
 ```
-← 목록으로 돌아가기
-┌─────────────────────────────┬──────────────┐
-│ <article>                   │ <aside>      │
-│   헤더 (카테고리, 제목,     │ TableOfContents│
-│         메타, 조회수)       │ (lg:block)   │
-│   MarkdownRenderer           │              │
-│   푸터 (카테고리링크, GitHub)│              │
-│   Comments                  │              │
-└─────────────────────────────┴──────────────┘
+┌────────────────────────────────────────────────────────┐
+│ <ArticleHero> (full-width, header semantic)            │
+│   mesh + breadcrumb + art-tag + title + lead + meta    │
+└────────────────────────────────────────────────────────┘
+┌──────────┬────────────────────────────┬───────────────┐
+│ (gutter) │ <div class="prose">        │ <aside>       │
+│  1fr     │   MarkdownRenderer (div)   │ TableOfContents│
+│          │   minmax(0, 820px)         │ 240px sticky  │
+└──────────┴────────────────────────────┴───────────────┘
+┌────────────────────────────────────────────────────────┐
+│ <ArticleFooter> (tags 있을 때만)                        │
+└────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────┐
+│ <Comments>                                              │
+└────────────────────────────────────────────────────────┘
 ```
 
-모바일: aside 숨김 (`hidden lg:block`), TOC 미노출
+- 데스크톱 grid: `1fr | minmax(0, 820px) | 240px` (Q16 — 한글 가독성)
+- 모바일 (`md:` 미만): 단일 컬럼 + TOC 숨김 + Hero 단순화 (Q14)
 
 ---
 
 ## Server-side Processing
 
 `lib/markdown.ts` 함수들이 서버에서 실행됨:
-- `parseFrontMatter(content)` — frontmatter 제거
+- `parseFrontMatter(content)` — frontmatter 제거 + `frontMatter.tags` 추출
+- `stripLeadingH1(mainContent)` — 본문 첫 H1 제거 (ADR-010, 제목 중복 방지)
 - `extractTitle(content)` — h1 헤딩 추출
-- `extractDescription(content)` — 첫 단락 추출
-- `getReadingTime(content)` — 읽기 시간 계산
-- `generateTableOfContents(mainContent)` — TOC 항목 생성
+- `extractDescription(content)` — 첫 단락 추출 → ArticleHero `lead`
+- `getReadingTime(content)` — 읽기 시간 계산 → ArticleHero meta row
+- `generateTableOfContents(stripped)` — TOC 항목 생성. page.tsx 에서 `filter((i) => i.level === 2)` 로 H2 만 추림
 
 ---
 
 ## Related Files
 
 - `src/app/posts/[...slug]/page.tsx`
+- `src/components/ArticleHero.tsx`
+- `src/components/ArticleFooter.tsx`
 - `src/components/MarkdownRenderer.tsx`
 - `src/components/TableOfContents.tsx`
+- `src/components/Header.tsx` — `/posts/*` reading progress
 - `src/components/Comments.tsx`
-- `src/components/PostViewCount.tsx`
 - `src/components/JsonLd.tsx`
 - `src/infra/db/repositories/PostRepository.ts`
+- `src/infra/db/repositories/VisitRepository.ts` — `getVisitCount(pagePath)`
 - `src/lib/markdown.ts`
-- `src/infra/db/constants.ts` — `categoryIcons`
+- `src/lib/category-meta.ts` — `getCategoryColor` / `getCategoryHue` / `toCanonicalCategory` (plan010)
+- `src/app/globals.css` — plan009 토큰 + plan011 prose 확장 (H2 counter / blockquote QUOTE / inline code / mermaid 격리)
 
 ---
 
 ## Constraints
 
-- `TableOfContents`는 `toc.length > 0` 일 때만 렌더링
-- GitHub URL은 `jon890/fos-study` 레포 고정
+- `TableOfContents` 는 `tocItems.length > 0` 일 때만 렌더 (level===2 filter 후 0이면 사이드바 빈 칸 회피)
+- GitHub 원본 링크는 plan011 단계에서 글 페이지에서 제거 (Hero 가 메타 흡수). 후속 PR 에서 footer 또는 별도 메뉴로 복원 검토
 - 모바일에서 TOC 미노출 — 별도 모바일 TOC 구현 시 이 문서 업데이트 필요
-- **조회수 증가**는 `src/proxy.ts` Node Runtime middleware (실 동작은 `src/middleware/visit.ts`로 위임)에서 처리 — `PostViewCount`는 표시만 담당
+- **조회수 증가**는 `src/proxy.ts` Node Runtime middleware (실 동작은 `src/middleware/visit.ts`) 에서 upsert. **표시**는 page.tsx 가 server-side `getVisitCount(post.path)` 로 fetch 하여 `<ArticleHero viewCount={…}/>` 에 전달 (plan011 이전의 client `<PostViewCount>` 패턴은 폐기)
+- prose 의 H2 CSS counter 는 `.prose` 단일 셀렉터에서 reset 되므로, 페이지 내 prose 컨테이너는 1개로 유지해야 번호가 어긋나지 않음

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -181,6 +181,66 @@ code, kbd, samp, pre {
   @apply scroll-mt-20;
 }
 
+/* mockup 톤 prose 확장 */
+.prose {
+  counter-reset: prose-h2;
+}
+.prose h2 {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 56px 0 16px;
+  color: var(--color-fg-primary);
+  scroll-margin-top: 80px;
+  counter-increment: prose-h2;
+}
+.prose h2::before {
+  content: counter(prose-h2, decimal-leading-zero);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  margin-right: 12px;
+  letter-spacing: 0.04em;
+}
+.prose blockquote {
+  border-left: 2px solid var(--color-brand-400);
+  padding: 4px 0 4px 20px;
+  margin: 24px 0;
+  font-size: 16px;
+  color: var(--color-fg-primary);
+  font-style: normal;
+}
+.prose blockquote::before {
+  content: "QUOTE";
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--color-brand-400);
+  margin-bottom: 8px;
+}
+.prose :not(pre) > code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+  background: var(--color-bg-subtle);
+  color: var(--color-brand-400);
+}
+.prose ul li::marker {
+  content: "— ";
+  color: var(--color-fg-faint);
+}
+
+/* mermaid 격리 — prose pre 룰의 영향 차단 */
+.prose pre.mermaid,
+.prose pre:has(> code.language-mermaid) {
+  background: transparent !important;
+  border: none !important;
+  padding: 0;
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 8px;

--- a/src/app/posts/[...slug]/page.tsx
+++ b/src/app/posts/[...slug]/page.tsx
@@ -179,9 +179,9 @@ export default async function PostPage({ params }: PostPageProps) {
 
       <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-8 px-6 py-12 md:grid-cols-[1fr_minmax(0,820px)_240px] md:gap-12 md:py-16">
         <div className="hidden md:block" aria-hidden />
-        <div className="min-w-0">
+        <article className="min-w-0">
           <MarkdownRenderer content={stripped} basePath={slug} />
-        </div>
+        </article>
         <aside className="hidden md:block">
           <TableOfContents toc={tocItems} />
         </aside>

--- a/src/app/posts/[...slug]/page.tsx
+++ b/src/app/posts/[...slug]/page.tsx
@@ -1,5 +1,4 @@
 import { getRepositories } from "@/infra/db/repositories";
-import { categoryIcons, DEFAULT_CATEGORY_ICON } from "@/infra/db/constants";
 import type { PostData } from "@/infra/db/types";
 import {
   extractTitle,
@@ -13,10 +12,9 @@ import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 import { TableOfContents } from "@/components/TableOfContents";
 import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import { Comments } from "@/components/Comments";
-import { PostViewCount } from "@/components/PostViewCount";
+import { ArticleHero } from "@/components/ArticleHero";
+import { ArticleFooter } from "@/components/ArticleFooter";
 import { notFound } from "next/navigation";
-import Link from "next/link";
-import { ArrowLeft, Calendar, Clock, Folder, Github, Pencil } from "lucide-react";
 import { Metadata } from "next";
 import { env } from "@/env";
 
@@ -29,10 +27,6 @@ interface PostPageProps {
   params: Promise<{
     slug: string[];
   }>;
-}
-
-function getCategoryIcon(category: string): string {
-  return categoryIcons[category] || DEFAULT_CATEGORY_ICON;
 }
 
 export async function generateMetadata({
@@ -112,20 +106,25 @@ export default async function PostPage({ params }: PostPageProps) {
   }
 
   const { content, post: postData } = data;
-  const { content: contentWithoutFrontmatter } = parseFrontMatter(content);
-  const mainContent = stripLeadingH1(contentWithoutFrontmatter);
+  const { content: contentWithoutFrontmatter, frontMatter } =
+    parseFrontMatter(content);
+  const stripped = stripLeadingH1(contentWithoutFrontmatter);
   const title = extractTitle(content) || postData.title;
-  const readingTime = getReadingTime(content);
-  const toc = generateTableOfContents(mainContent);
+  const readTime = getReadingTime(stripped);
+  const tocItems = generateTableOfContents(stripped).filter(
+    (i) => i.level === 2
+  );
 
-  const githubUrl = `https://github.com/jon890/fos-study/blob/main/${postData.path}`;
+  const { visit } = getRepositories();
+  const viewCount = await visit.getVisitCount(postData.path);
+  const desc = extractDescription(content);
+
   const postUrl = `${siteUrl}/posts/${postData.path
     .split("/")
     .map(encodeURIComponent)
     .join("/")}`;
-  const description = extractDescription(content);
 
-  const breadcrumbItems = [
+  const breadcrumbJsonLdItems = [
     { name: "홈", url: siteUrl },
     {
       name: postData.category,
@@ -144,129 +143,54 @@ export default async function PostPage({ params }: PostPageProps) {
     { name: title, url: postUrl },
   ];
 
+  const heroBreadcrumb = [
+    { label: "fos-blog", href: "/" },
+    {
+      label: postData.category,
+      href: `/category/${encodeURIComponent(postData.category)}`,
+    },
+    {
+      label: title.length > 24 ? `${title.slice(0, 24)}…` : title,
+    },
+  ];
+
   return (
     <>
       <ArticleJsonLd
         url={postUrl}
         title={title}
-        description={description}
+        description={desc}
         datePublished={postData.createdAt?.toISOString()}
         dateModified={postData.updatedAt?.toISOString()}
         authorName="jon890"
         authorUrl="https://github.com/jon890"
       />
-      <BreadcrumbJsonLd items={breadcrumbItems} />
+      <BreadcrumbJsonLd items={breadcrumbJsonLdItems} />
 
-      <div className="container mx-auto px-4 py-6 md:py-12">
-        <Link
-          href={`/category/${encodeURIComponent(postData.category)}`}
-          className="inline-flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors mb-8"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          <span>목록으로 돌아가기</span>
-        </Link>
+      <ArticleHero
+        category={postData.category}
+        title={title}
+        description={desc}
+        createdAt={postData.createdAt ?? null}
+        readTimeMinutes={readTime}
+        viewCount={viewCount}
+        breadcrumb={heroBreadcrumb}
+      />
 
-        <div className="flex flex-col lg:flex-row gap-8">
-          <article className="flex-grow min-w-0">
-            <header className="mb-8 pb-8 border-b border-gray-200 dark:border-gray-800">
-              <div className="flex flex-wrap items-center gap-3 mb-4">
-                <Link
-                  href={`/category/${encodeURIComponent(postData.category)}`}
-                  className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-sm font-medium hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors"
-                >
-                  <span>{getCategoryIcon(postData.category)}</span>
-                  <span>{postData.category}</span>
-                </Link>
-                {postData.subcategory && (
-                  <span className="text-sm text-gray-500 dark:text-gray-400">
-                    / {postData.subcategory}
-                  </span>
-                )}
-              </div>
-
-              <h1 className="text-2xl md:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-white mb-4">
-                {title}
-              </h1>
-
-              <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
-                <div className="flex items-center gap-2">
-                  <Clock className="w-4 h-4" />
-                  <span>약 {readingTime}분</span>
-                </div>
-                {postData.createdAt && (
-                  <div className="flex items-center gap-2">
-                    <Calendar className="w-4 h-4" />
-                    <span>
-                      {postData.createdAt.toLocaleDateString("ko-KR", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
-                    </span>
-                  </div>
-                )}
-                {postData.updatedAt &&
-                  postData.createdAt?.getTime() !== postData.updatedAt.getTime() && (
-                    <div className="flex items-center gap-2">
-                      <Pencil className="w-4 h-4" />
-                      <span>
-                        {postData.updatedAt.toLocaleDateString("ko-KR", {
-                          year: "numeric",
-                          month: "long",
-                          day: "numeric",
-                        })}
-                        {"  수정"}
-                      </span>
-                    </div>
-                  )}
-                <PostViewCount
-                  pagePath={postData.path}
-                  className="text-gray-600 dark:text-gray-400"
-                />
-                <a
-                  href={githubUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                >
-                  <Github className="w-4 h-4" />
-                  <span>GitHub에서 보기</span>
-                </a>
-              </div>
-            </header>
-
-            <MarkdownRenderer content={mainContent} basePath={slug} />
-
-            <footer className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800">
-              <div className="flex flex-wrap items-center justify-between gap-4">
-                <Link
-                  href={`/category/${encodeURIComponent(postData.category)}`}
-                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-                >
-                  <Folder className="w-4 h-4" />
-                  <span>{postData.category} 카테고리의 다른 글 보기</span>
-                </Link>
-                <a
-                  href={githubUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100 transition-colors"
-                >
-                  <Github className="w-4 h-4" />
-                  <span>수정 제안하기</span>
-                </a>
-              </div>
-            </footer>
-
-            <Comments postSlug={postData.path} />
-          </article>
-
-          {toc.length > 0 && (
-            <aside className="hidden lg:block w-64 flex-shrink-0">
-              <TableOfContents toc={toc} />
-            </aside>
-          )}
+      <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-8 px-6 py-12 md:grid-cols-[1fr_minmax(0,820px)_240px] md:gap-12 md:py-16">
+        <div className="hidden md:block" aria-hidden />
+        <div className="min-w-0">
+          <MarkdownRenderer content={stripped} basePath={slug} />
         </div>
+        <aside className="hidden md:block">
+          <TableOfContents toc={tocItems} />
+        </aside>
+      </div>
+
+      <ArticleFooter tags={frontMatter.tags} />
+
+      <div className="mx-auto max-w-[880px] px-6 pb-12">
+        <Comments postSlug={postData.path} />
       </div>
     </>
   );

--- a/src/components/ArticleFooter.tsx
+++ b/src/components/ArticleFooter.tsx
@@ -1,0 +1,25 @@
+interface ArticleFooterProps {
+  tags?: string[];
+}
+
+export function ArticleFooter({ tags }: ArticleFooterProps) {
+  if (!tags || tags.length === 0) return null;
+
+  return (
+    <footer className="mx-auto mt-16 max-w-[880px] border-t border-[var(--color-border-subtle)] px-6 py-12">
+      <div className="mb-3 font-mono text-[11px] uppercase tracking-[0.06em] text-[var(--color-fg-muted)]">
+        tags
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded border border-[var(--color-border-subtle)] px-2.5 py-1 font-mono text-[11px] tracking-tight text-[var(--color-fg-secondary)]"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+    </footer>
+  );
+}

--- a/src/components/ArticleHero.tsx
+++ b/src/components/ArticleHero.tsx
@@ -1,0 +1,130 @@
+import Link from "next/link";
+import type { CSSProperties } from "react";
+import {
+  getCategoryColor,
+  getCategoryHue,
+  toCanonicalCategory,
+} from "@/lib/category-meta";
+
+interface ArticleHeroProps {
+  category: string;
+  title: string;
+  description: string;
+  createdAt: Date | null;
+  readTimeMinutes: number;
+  viewCount: number;
+  breadcrumb: { label: string; href?: string }[];
+}
+
+export function ArticleHero({
+  category,
+  title,
+  description,
+  createdAt,
+  readTimeMinutes,
+  viewCount,
+  breadcrumb,
+}: ArticleHeroProps) {
+  const catColor = getCategoryColor(category);
+  const catHue = getCategoryHue(category);
+  const canonical = toCanonicalCategory(category);
+  const inlineStyle = {
+    "--cat-color": catColor,
+    "--mesh-stop-cat": `oklch(0.7 0.16 ${catHue})`,
+  } as CSSProperties;
+
+  const dateStr = createdAt
+    ? `${createdAt.getFullYear()}.${String(createdAt.getMonth() + 1).padStart(2, "0")}.${String(createdAt.getDate()).padStart(2, "0")}`
+    : "";
+
+  return (
+    <header
+      className="relative overflow-hidden border-b border-[var(--color-border-subtle)] px-6 pt-8 pb-12 md:pt-16 md:pb-14"
+      style={inlineStyle}
+    >
+      {/* Mesh gradient */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 z-0 blur-[40px] saturate-[140%]"
+        style={{
+          background:
+            "radial-gradient(60% 80% at 20% 20%, color-mix(in oklch, var(--mesh-stop-cat) 45%, transparent), transparent 60%), radial-gradient(50% 70% at 80% 30%, color-mix(in oklch, var(--mesh-stop-03) 32%, transparent), transparent 60%), radial-gradient(50% 70% at 50% 80%, color-mix(in oklch, var(--mesh-stop-02) 35%, transparent), transparent 60%)",
+        }}
+      />
+      {/* 80px grid mask */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 z-[1]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, var(--color-border-subtle) 1px, transparent 1px)",
+          backgroundSize: "80px 100%",
+          maskImage:
+            "linear-gradient(to bottom, transparent, black 30%, black 80%, transparent)",
+        }}
+      />
+
+      <div className="relative z-[2] mx-auto max-w-[880px]">
+        {/* Breadcrumb */}
+        <nav
+          aria-label="breadcrumb"
+          className="mb-6 flex items-center gap-2 font-mono text-[12px] text-[var(--color-fg-muted)]"
+        >
+          {breadcrumb.map((item, i) => (
+            <span key={i} className="flex items-center gap-2">
+              {i > 0 && (
+                <span className="text-[var(--color-fg-faint)]">/</span>
+              )}
+              {item.href ? (
+                <Link
+                  href={item.href}
+                  className="hover:text-[var(--color-fg-primary)]"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="text-[var(--color-fg-primary)]">
+                  {item.label}
+                </span>
+              )}
+            </span>
+          ))}
+        </nav>
+
+        {/* Category art-tag */}
+        <span
+          className="inline-flex items-center gap-2 rounded-full border px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.06em]"
+          style={{
+            color: "var(--cat-color)",
+            borderColor: "var(--cat-color)",
+            background: "color-mix(in oklch, var(--cat-color), transparent 90%)",
+          }}
+        >
+          <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+          {canonical}
+        </span>
+
+        <h1 className="mt-6 mb-5 max-w-[22ch] text-[34px] font-semibold leading-[1.1] tracking-tight text-[var(--color-fg-primary)] md:text-[52px]">
+          {title}
+        </h1>
+
+        {description && (
+          <p className="mb-4 max-w-[56ch] text-[16px] leading-relaxed text-[var(--color-fg-secondary)] md:text-[18px]">
+            {description}
+          </p>
+        )}
+
+        {/* Meta row */}
+        <div className="mt-6 flex flex-wrap items-center gap-3 font-mono text-[12px] text-[var(--color-fg-muted)]">
+          {dateStr && <span>{dateStr}</span>}
+          {dateStr && (
+            <span className="text-[var(--color-fg-faint)]">·</span>
+          )}
+          <span>{readTimeMinutes} min read</span>
+          <span className="text-[var(--color-fg-faint)]">·</span>
+          <span>{viewCount.toLocaleString()} views</span>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ArticleHero.tsx
+++ b/src/components/ArticleHero.tsx
@@ -71,7 +71,7 @@ export function ArticleHero({
           className="mb-6 flex items-center gap-2 font-mono text-[12px] text-[var(--color-fg-muted)]"
         >
           {breadcrumb.map((item, i) => (
-            <span key={i} className="flex items-center gap-2">
+            <span key={item.label} className="flex items-center gap-2">
               {i > 0 && (
                 <span className="text-[var(--color-fg-faint)]">/</span>
               )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,12 +7,30 @@ import { SearchDialog } from "./SearchDialog";
 import { Book, Github, Home, Menu, X, Search, PanelLeft } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useSidebar } from "./SidebarContext";
+import type { CSSProperties } from "react";
 
 export function Header() {
   const pathname = usePathname();
   const { toggle: toggleSidebar } = useSidebar();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const isArticle = pathname?.startsWith("/posts/");
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (!isArticle) {
+      setProgress(0);
+      return;
+    }
+    const onScroll = () => {
+      const max =
+        document.documentElement.scrollHeight - window.innerHeight;
+      setProgress(max > 0 ? Math.min(1, window.scrollY / max) : 0);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [isArticle]);
 
   // Cmd/Ctrl + K 단축키로 검색 열기
   useEffect(() => {
@@ -40,7 +58,7 @@ export function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 w-full bg-white/80 dark:bg-gray-950/80 backdrop-blur-sm">
       <div className="container mx-auto px-4">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
@@ -153,6 +171,24 @@ export function Header() {
 
       {/* Search Dialog */}
       <SearchDialog isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
+
+      {/* Reading progress — replaces static border-b */}
+      <div
+        aria-hidden
+        className="absolute bottom-0 left-0 h-px w-full bg-[var(--color-border-subtle)]"
+      />
+      {isArticle && (
+        <div
+          aria-hidden
+          className="absolute bottom-0 left-0 h-px bg-[var(--color-brand-400)] transition-[width] duration-75 ease-linear"
+          style={
+            {
+              width: `${progress * 100}%`,
+              boxShadow: "0 0 8px var(--color-brand-400)",
+            } as CSSProperties
+          }
+        />
+      )}
     </header>
   );
 }

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -196,7 +196,7 @@ export function MarkdownRenderer({ content, basePath }: MarkdownRendererProps) {
   };
 
   return (
-    <article className="prose-sm md:prose prose-gray dark:prose-invert max-w-none">
+    <div className="prose-sm md:prose prose-gray dark:prose-invert max-w-none">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeSlug, rehypeHighlight, rehypeRaw]}
@@ -204,6 +204,6 @@ export function MarkdownRenderer({ content, basePath }: MarkdownRendererProps) {
       >
         {content}
       </ReactMarkdown>
-    </article>
+    </div>
   );
 }

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -2,24 +2,13 @@
 
 import { useEffect, useState } from "react";
 import { TocItem } from "@/lib/markdown";
-import { List, ChevronDown } from "lucide-react";
 
 interface TableOfContentsProps {
   toc: TocItem[];
 }
 
-const STORAGE_KEY = "toc-collapsed";
-
 export function TableOfContents({ toc }: TableOfContentsProps) {
   const [activeSlug, setActiveSlug] = useState<string>("");
-  const [isCollapsed, setIsCollapsed] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    if (localStorage.getItem(STORAGE_KEY) === "true") {
-      setIsCollapsed(true);
-    }
-  }, []);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -45,65 +34,40 @@ export function TableOfContents({ toc }: TableOfContentsProps) {
 
   if (toc.length === 0) return null;
 
-  function toggle() {
-    setIsCollapsed((prev) => {
-      const next = !prev;
-      if (next) {
-        localStorage.setItem(STORAGE_KEY, "true");
-      } else {
-        localStorage.removeItem(STORAGE_KEY);
-      }
-      return next;
-    });
-  }
-
   return (
-    <nav className="sticky top-24 rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
-      <button
-        onClick={toggle}
-        aria-expanded={!isCollapsed}
-        aria-controls="toc-content"
-        className="w-full flex items-center justify-between gap-2 p-4 text-sm font-semibold text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-800/50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-      >
-        <span className="flex items-center gap-2">
-          <List className="w-4 h-4" />
-          목차
+    <nav className="sticky top-20 font-mono text-[12px]">
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-3">
+        <div className="h-4 w-[3px] rounded-full bg-[var(--color-brand-400)]" aria-hidden />
+        <span className="uppercase tracking-[0.1em] text-[var(--color-fg-muted)]">
+          on this page
         </span>
-        <ChevronDown
-          className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${
-            isCollapsed ? "" : "rotate-180"
-          }`}
-        />
-      </button>
+      </div>
 
-      <div
-        className="grid transition-[grid-template-rows] duration-200 ease-in-out"
-        style={{ gridTemplateRows: isCollapsed ? "0fr" : "1fr" }}
-      >
-        <ul
-          id="toc-content"
-          className="overflow-hidden space-y-2 text-sm px-4"
-          style={{ paddingBottom: isCollapsed ? 0 : "1rem" }}
-        >
-          {toc.map((item, index) => (
-            <li
-              key={`${item.slug}-${index}`}
-              style={{ paddingLeft: `${(item.level - 1) * 12}px` }}
-            >
+      <ul className="space-y-0">
+        {toc.map((item, idx) => {
+          const isActive = activeSlug === item.slug;
+          return (
+            <li key={`${item.slug}-${idx}`}>
               <a
                 href={`#${item.slug}`}
-                className={`block py-1 transition-colors ${
-                  activeSlug === item.slug
-                    ? "text-blue-600 dark:text-blue-400 font-medium"
-                    : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                className={`flex items-start gap-2 border-l py-1.5 pl-3 transition-colors duration-150 ${
+                  isActive
+                    ? "border-[var(--color-brand-400)] font-medium text-[var(--color-brand-400)]"
+                    : "border-[var(--color-border-subtle)] text-[var(--color-fg-muted)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
                 }`}
               >
-                {item.text}
+                <span
+                  className={`shrink-0 ${isActive ? "text-[var(--color-brand-400)]" : "text-[var(--color-fg-faint)]"}`}
+                >
+                  {String(idx + 1).padStart(2, "0")}
+                </span>
+                <span className="leading-snug">{item.text}</span>
               </a>
             </li>
-          ))}
-        </ul>
-      </div>
+          );
+        })}
+      </ul>
     </nav>
   );
 }

--- a/tasks/plan011-article-page-redesign/index.json
+++ b/tasks/plan011-article-page-redesign/index.json
@@ -1,12 +1,14 @@
 {
   "name": "plan011-article-page-redesign",
   "description": "Claude Design Round 2 mockup 의 Artwork 컴포넌트 기반 글 상세 페이지 리디자인 — Hero (mesh + tag + title + lead + meta) + 3-col body grid + sticky TOC (in-place 리디자인) + Header 통합 reading progress + prose mockup 톤. plan009 (tokens) + plan010 (category-meta) 머지 완료를 전제. series/tags/prev-next 는 issue #72 로 분리.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-04-27",
+  "completed_at": "2026-04-27",
   "total_phases": 1,
   "related_docs": [
     "docs/adr.md",
-    "docs/design-inspiration.md"
+    "docs/design-inspiration.md",
+    "docs/pages/post-detail.md"
   ],
   "depends_on": [
     "plan009-design-tokens-foundation",
@@ -18,7 +20,7 @@
       "file": "phase-01.md",
       "title": "ArticleHero + 3-col body + TOC 리디자인 + Header reading progress + prose 토큰",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan011-article-page-redesign/phase-01.md
+++ b/tasks/plan011-article-page-redesign/phase-01.md
@@ -68,6 +68,10 @@ grep -n -- "--color-cat-system" src/app/globals.css
 test -f src/lib/category-meta.ts
 grep -n "export function getCategoryHue" src/lib/category-meta.ts
 
+# C1 사전 확인: visit count fetch 경로 — 신규 method 만들 필요 없음
+! grep -nE "\\bvisitCount\\b" src/infra/db/schema/posts.ts   # posts 스키마엔 visitCount 없음
+grep -n "getVisitCount" src/infra/db/repositories/VisitRepository.ts   # 기존 메서드 재사용
+
 # 2) 기존 컴포넌트 + 유틸 위치
 test -f src/app/posts/\[...slug\]/page.tsx
 test -f src/components/TableOfContents.tsx
@@ -88,7 +92,9 @@ tar xzOf ~/.claude/projects/-Users-nhn-personal-fos-blog/d11b8756-7896-451b-932e
 
 `/tmp/components-1.jsx` 의 `Artwork` 함수 + `/tmp/components.css` 의 `.art-*` (라인 30-235 범위) 가 source of truth. 코드는 그대로 복사 금지 — fos-blog 의 React/Next 패턴으로 재구성.
 
-## 작업 목록 (총 5개)
+## 작업 목록 (총 7개) — 단일 phase 정당화
+
+> CLAUDE.md "작업 항목 5개 이하" 규약을 검토했지만, 본 plan011 은 **Round 2 mockup 의 단일 시각 응집체** (Hero+grid+TOC+Header progress+prose 가 한 화면에서 같이 보여야 디자인 의도가 성립) 라 PR 단위로 쪼개면 중간 상태 (Hero 만 있고 grid 미적용 등) 가 노출되어 사용자에게 더 큰 시각 회귀로 보임. 따라서 **단일 phase 유지** 하되 작업을 7 항목으로 펼쳐 각 항목별 독립 검증 명령을 보장. critic M1 지적에 따른 표기 정정.
 
 ### 1. `src/components/ArticleHero.tsx` 신규
 
@@ -140,8 +146,10 @@ export function ArticleHero({
         aria-hidden
         className="pointer-events-none absolute inset-0 z-0 blur-[40px] saturate-[140%]"
         style={{
+          // C2 fix: `var(...) / 0.xx` shorthand 는 valid CSS 가 아님.
+          // color-mix() 로 alpha 합성. 모든 stop 동일 패턴.
           background:
-            "radial-gradient(60% 80% at 20% 20%, var(--mesh-stop-cat) / 0.45, transparent 60%), radial-gradient(50% 70% at 80% 30%, var(--mesh-stop-03) / 0.32, transparent 60%), radial-gradient(50% 70% at 50% 80%, var(--mesh-stop-02) / 0.35, transparent 60%)",
+            "radial-gradient(60% 80% at 20% 20%, color-mix(in oklch, var(--mesh-stop-cat) 45%, transparent), transparent 60%), radial-gradient(50% 70% at 80% 30%, color-mix(in oklch, var(--mesh-stop-03) 32%, transparent), transparent 60%), radial-gradient(50% 70% at 50% 80%, color-mix(in oklch, var(--mesh-stop-02) 35%, transparent), transparent 60%)",
         }}
       />
       {/* 80px grid mask */}
@@ -266,6 +274,11 @@ export function ArticleFooter({ tags }: ArticleFooterProps) {
 
 Header 가 이미 client component 인지 확인. 아니면 client 전환 (`"use client"` 추가).
 
+**M5 fix — 기존 `border-b` 유틸 제거 필수**:
+- `Header.tsx:43` 의 `<header className="… border-b border-gray-200 dark:border-gray-800 …">` 에서 **`border-b border-gray-200 dark:border-gray-800` 토큰 제거**.
+- 제거하지 않으면 회색 1px 보더 위에 brand fill 이 덧씌워져 progress 미진입 영역에서 회색 라인이 그대로 보임 (mockup 의 "1px 라인을 progress fill 로 변환" 의도 위반).
+- 대체 fallback 1px 라인은 아래 JSX 의 `absolute bottom-0 h-px w-full bg-[var(--color-border-subtle)]` 가 라이트/다크 모두 cover.
+
 추가:
 ```tsx
 "use client";
@@ -316,17 +329,30 @@ JSX (Header 의 sticky 컨테이너 끝부분):
 - scroll listener 는 `isArticle` 조건에서만 등록 → 메모리 누수 없음
 - transition 75ms (mockup 의 `--duration-instant`) — 스크롤 따라 빠르게 반응
 
-### 5. `page.tsx` + `MarkdownRenderer.tsx` + `globals.css` 통합
-
-#### 5a. `src/app/posts/[...slug]/page.tsx` 재구성
+### 5. `src/app/posts/[...slug]/page.tsx` 재구성 (page.tsx 통합)
 
 기존 layout 을 `ArticleHero` + 3-col grid + `MarkdownRenderer` + `TableOfContents` (filter H2) + `ArticleFooter` + 기존 `Comments` + `JsonLd` 로 교체.
+
+**view count 데이터 경로 (C1 fix)**:
+- `posts` 스키마에는 `visitCount` 컬럼 없음 — `visit_stats` 별도 테이블.
+- 신규 method 만들 필요 없이 기존 `VisitRepository.getVisitCount(pagePath)` 사용 (위치: `src/infra/db/repositories/VisitRepository.ts:59`).
+- `pagePath` 는 PostViewCount 가 사용하는 것과 동일하게 `post.path` (CMS canonical path) 를 그대로 사용 → API/server 모두 일관.
+- 기존 client `<PostViewCount pagePath={postData.path} />` 는 **제거** (Hero meta row 가 흡수). 임시 placeholder 도 두지 말고 import 까지 깨끗이 정리.
+
+신규 import (이전엔 없었음 — executor 누락 방지):
+```tsx
+import { getRepositories } from "@/infra/db/repositories";
+import { ArticleHero } from "@/components/ArticleHero";
+import { ArticleFooter } from "@/components/ArticleFooter";
+import { extractDescription } from "@/lib/markdown"; // 기존 import 목록에 없으면 추가
+```
 
 주요 변경:
 ```tsx
 const tocItems = generateTableOfContents(stripped).filter((i) => i.level === 2);
 const readTime = getReadingTime(stripped);
-const viewCount = data.post.visitCount ?? 0;
+const { visit } = getRepositories();
+const viewCount = await visit.getVisitCount(post.path); // C1 fix: 별도 visit_stats 테이블에서 server-side fetch
 const desc = extractDescription(data.content);
 const breadcrumb = [
   { label: "fos-blog", href: "/" },
@@ -349,9 +375,10 @@ return (
     />
     <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-8 px-6 py-12 md:grid-cols-[1fr_minmax(0,820px)_240px] md:gap-12 md:py-16">
       <div className="hidden md:block" aria-hidden />
-      <article className="prose prose-fos min-w-0">
+      <div className="min-w-0">
+        {/* M2 fix: MarkdownRenderer 가 자체 <article class="prose"> 를 렌더 — 여기서 다시 <article> 로 감싸면 중첩 article + 중복 prose */}
         <MarkdownRenderer content={stripped} />
-      </article>
+      </div>
       <aside className="hidden md:block">
         <TableOfContents items={tocItems} />
       </aside>
@@ -364,14 +391,15 @@ return (
 );
 ```
 
-기존 `<Folder>`, `<Calendar>`, `<Clock>` lucide 아이콘 + `← 목록으로` 링크 등 hero 와 중복되는 메타 영역은 제거 (ArticleHero 가 모두 흡수).
+기존 `<Folder>`, `<Calendar>`, `<Clock>` lucide 아이콘 + `← 목록으로` 링크 + `<PostViewCount …/>` 등 hero 와 중복되는 메타 영역은 모두 제거 (ArticleHero 가 흡수).
 
-#### 5b. `src/components/MarkdownRenderer.tsx` 변경
+### 6. `src/components/MarkdownRenderer.tsx` 변경 (M2 fix)
 
-- 컨테이너 className 에 `prose-fos` 추가 (글로벌 .prose 룰과 합쳐 mockup 톤 강화)
-- mermaid 처리 변경 없음 — globals.css 의 selector 격리로 처리
+- 기존 `<article className="prose-sm md:prose prose-gray dark:prose-invert max-w-none">` (`MarkdownRenderer.tsx:199`) 의 외부 wrapper 를 **`<article>` → `<div>`** 로 변경. 이유: page.tsx 에서 동일 영역을 다시 wrap 하기 어려운 구조 + 단일 글 페이지에 `<article>` 은 한 번만 (page.tsx 가 article 의미를 갖지 않으면 MarkdownRenderer 가 단독 article 유지해도 무방하지만, plan 의 grid 구조상 wrap 충돌 방지를 위해 `<div>` 로 통일).
+- prose className 자체는 그대로 유지 (`prose-sm md:prose prose-gray dark:prose-invert max-w-none`). M3 fix: `prose-fos` 추가하지 않음 (정의된 룰 없는 dead variant).
+- mermaid 처리 변경 없음 — globals.css 의 selector 격리로 처리.
 
-#### 5c. `src/app/globals.css` prose 확장
+### 7. `src/app/globals.css` prose 확장
 
 ```css
 /* mockup 톤 prose — 기존 .prose 룰 확장 */
@@ -450,7 +478,9 @@ pnpm test -- --run
 pnpm build
 
 # mermaid 회귀 테스트 (Q10 A + Q18 C)
-pnpm test -- --run mermaid
+# M4 fix: vitest positional filter 는 파일경로 substring match. 실제 파일은 MarkdownRenderer.regression-1.test.ts.
+# "mermaid" 로 filter 하면 0개 매칭이라 위양성 통과.
+pnpm test -- --run MarkdownRenderer.regression
 ```
 
 수동 smoke (선택, 사용자 PR 리뷰 시):
@@ -511,9 +541,15 @@ pnpm lint
 pnpm type-check
 pnpm build
 
-# 10) mermaid 회귀 테스트 명시 통과 (Q10 A)
-pnpm test -- --run mermaid 2>&1 | grep -E "passed|failed"
-! pnpm test -- --run mermaid 2>&1 | grep -E "failed"
+# 10) mermaid 회귀 테스트 명시 통과 (Q10 A) — M4 fix: 실제 파일명으로 filter + N>=1 통과 검증
+pnpm test -- --run MarkdownRenderer.regression 2>&1 | tee /tmp/plan011-mermaid-test.log
+grep -E "Tests +[1-9][0-9]* passed" /tmp/plan011-mermaid-test.log    # >=1 통과 보장
+! grep -E "failed" /tmp/plan011-mermaid-test.log
+
+# 10-bis) Header border-b 제거 (M5)
+! grep -nE "border-b +border-gray" src/components/Header.tsx
+# Hero mesh CSS 의 invalid `var(...) / 0.xx` shorthand 회귀 차단 (C2)
+! grep -nE "var\\(--mesh-stop[^)]*\\) +/ +0\\." src/components/ArticleHero.tsx
 
 # 11) 금지사항 (critic 반복 지적)
 ! grep -nE "as any" src/components/ArticleHero.tsx src/components/ArticleFooter.tsx src/components/Header.tsx
@@ -535,6 +571,7 @@ executor 는 커밋하지 않는다. team-lead 가 일괄 커밋 (atomic commits
 - `feat(article): add ArticleHero with mesh gradient + breadcrumb + meta row`
 - `feat(article): add ArticleFooter with frontmatter.tags graceful fallback`
 - `feat(toc): redesign TableOfContents with mono sidebar tone`
-- `feat(header): integrate reading progress fill on /posts/* pathname`
+- `feat(header): integrate reading progress fill on /posts/* pathname (drop static border-b)`
+- `refactor(post-page): use ArticleHero + 3-col grid + server-side viewCount + filter H2 TOC`
+- `refactor(markdown-renderer): drop nested <article> wrapper to avoid duplicate prose container`
 - `feat(prose): extend prose tokens with H2 counter + blockquote QUOTE label + inline code`
-- `refactor(post-page): use new ArticleHero + 3-col grid + filter H2 TOC`


### PR DESCRIPTION
## Summary

Claude Design Round 2 mockup 의 Artwork 컴포넌트 패턴을 글 상세 페이지에 in-place 적용. plan009 (design tokens) + plan010 (category-meta) 머지 완료를 전제.

- **ArticleHero** 신설 — mesh 그라디언트 (카테고리 hue 변형 + plan009 토큰, `color-mix(in oklch, ...)`) + breadcrumb + 카테고리 art-tag + 제목 + 리드 + meta row (date · readtime · views)
- **3-col body grid** — `1fr | minmax(0, 820px) | 240px` (한글 가독성). 모바일 단일 컬럼 + TOC 숨김
- **TableOfContents** in-place 리디자인 — mono + 번호 prefix (`01`/`02`) + brand 좌측 라인 + active highlight + sticky. `level === 2` 만 노출 (호출 측 필터). collapse toggle 제거
- **ArticleFooter** 신설 — `frontmatter.tags` graceful fallback (없으면 footer 자체 미렌더)
- **Header reading progress 통합** — `/posts/*` pathname 한정. 기존 회색 `border-b` 제거 후 1px 라인을 brand fill 로 변환. 다른 페이지 영향 0
- **MarkdownRenderer** 외부 wrapper `<article>` → `<div>` (중첩 article + prose counter 충돌 회피)
- **page.tsx** 재구성 — 서버 사이드 `VisitRepository.getVisitCount(post.path)` (기존 client `<PostViewCount>` 폐기). lucide ArrowLeft/Folder/Calendar/Clock + Link import 모두 정리
- **prose 토큰 확장** — H2 CSS counter (`decimal-leading-zero`), blockquote QUOTE 라벨, inline code 토큰 색, ul `—` marker, mermaid 격리 selector
- **docs/pages/post-detail.md** 갱신 — Components/Layout/Interactions/Constraints/Server-side Processing 등 7개 섹션 동기화

scope 외 (별도):
- series 메타 + footer 태그 라우팅 + prev/next 글 navigation → issue #72
- Comments 토큰 적용 → issue #73
- fenced code block 의 filename header / line numbers / copy → plan012

## Pipeline

build-with-teams 파이프라인:
- critic (opus): REVISE (C1 viewCount 데이터 경로 / C2 mesh CSS 무효 shorthand / M1 작업 항목 5개 규약 / M2 중첩 article / M3 prose-fos dead code / M4 vitest filter 위양성 / M5 Header border-b 잔재) → 6건 모두 수정 → APPROVE
- executor (sonnet): 7개 작업 phase-01 실행, 통합 검증 (lint/type-check/175 tests/build) 모두 PASS
- code-reviewer (sonnet): PASS (`console.log`/`as any`/dead import 0, `color-mix` valid, scroll listener cleanup 보존, `getVisitCount` 0 fallback 패턴)
- docs-verifier (architect, sonnet): UPDATE_NEEDED → `docs/pages/post-detail.md` 7개 섹션 갱신 → PASS

## Test plan

- [ ] `pnpm dev` → 글 상세 페이지 (다양한 카테고리: react / db / system / 한글 카테고리) 시각 확인
- [ ] 다크/라이트 토글
- [ ] 스크롤 시 Header 1px 라인 → progress fill 동작 확인 (글 상세 한정), 다른 페이지에서 회색 1px 정상
- [ ] 모바일 (Chrome DevTools 360px) → TOC 숨김 + Hero 단순화 + 본문 전체 폭 사용
- [ ] mermaid 다이어그램 글 (예: 알고리즘 카테고리) 에서 mermaid 정상 렌더 확인
- [ ] H2 번호 prefix (`01`/`02`) 정상 표시
- [ ] frontmatter.tags 가 있는 글에서만 ArticleFooter 노출