### PR TITLE
fix(rate-limit): relax 60/min → 1000/min/IP (hotfix)

### DIFF
--- a/src/middleware/rateLimit.test.ts
+++ b/src/middleware/rateLimit.test.ts
@@ -29,18 +29,18 @@ describe("rateLimit — fixed window", () => {
     expect(rateLimit(req)).toBeNull();
   });
 
-  it("60번째 요청까지 null 반환", async () => {
-    const { rateLimit } = await import("./rateLimit");
+  it("한도 마지막 요청까지 null 반환", async () => {
+    const { rateLimit, MAX_REQUESTS_PER_WINDOW } = await import("./rateLimit");
     const req = makeRequest("1.2.3.4");
-    for (let i = 0; i < 59; i++) rateLimit(req);
-    expect(rateLimit(req)).toBeNull(); // 60번째
+    for (let i = 0; i < MAX_REQUESTS_PER_WINDOW - 1; i++) rateLimit(req);
+    expect(rateLimit(req)).toBeNull(); // 한도와 같은 번째 — 통과
   });
 
-  it("61번째 요청은 429 반환 + Retry-After 헤더", async () => {
-    const { rateLimit } = await import("./rateLimit");
+  it("한도 초과 요청은 429 반환 + Retry-After 헤더", async () => {
+    const { rateLimit, MAX_REQUESTS_PER_WINDOW } = await import("./rateLimit");
     const req = makeRequest("1.2.3.4");
-    for (let i = 0; i < 60; i++) rateLimit(req);
-    const res = rateLimit(req); // 61번째
+    for (let i = 0; i < MAX_REQUESTS_PER_WINDOW; i++) rateLimit(req);
+    const res = rateLimit(req); // (한도+1) 번째
     expect(res).not.toBeNull();
     expect(res?.status).toBe(429);
     expect(res?.headers.get("Retry-After")).toBeTruthy();
@@ -49,33 +49,43 @@ describe("rateLimit — fixed window", () => {
   });
 
   it("윈도우 경계 통과 시 새 windowKey 로 count 리셋", async () => {
-    const { rateLimit } = await import("./rateLimit");
+    const { rateLimit, MAX_REQUESTS_PER_WINDOW, WINDOW_MS } = await import(
+      "./rateLimit"
+    );
     const req = makeRequest("1.2.3.4");
-    for (let i = 0; i < 60; i++) rateLimit(req);
-    expect(rateLimit(req)?.status).toBe(429); // 61번째 — 차단
+    for (let i = 0; i < MAX_REQUESTS_PER_WINDOW; i++) rateLimit(req);
+    expect(rateLimit(req)?.status).toBe(429); // 한도 초과 — 차단
 
-    // WINDOW_MS = 60_000 ms 진행 → 새 윈도우
-    vi.advanceTimersByTime(60_000);
+    // WINDOW_MS 진행 → 새 윈도우
+    vi.advanceTimersByTime(WINDOW_MS);
     expect(rateLimit(req)).toBeNull(); // 새 윈도우 첫 요청 — 통과
   });
 
   it("Googlebot UA 는 항상 null", async () => {
-    const { rateLimit } = await import("./rateLimit");
-    for (let i = 0; i < 100; i++) {
-      expect(rateLimit(makeRequest("1.2.3.4", "Mozilla/5.0 (compatible; Googlebot/2.1)"))).toBeNull();
+    const { rateLimit, MAX_REQUESTS_PER_WINDOW } = await import("./rateLimit");
+    // 한도보다 많이 요청해도 모두 통과
+    for (let i = 0; i < MAX_REQUESTS_PER_WINDOW + 10; i++) {
+      expect(
+        rateLimit(
+          makeRequest(
+            "1.2.3.4",
+            "Mozilla/5.0 (compatible; Googlebot/2.1)"
+          )
+        )
+      ).toBeNull();
     }
   });
 
   it("localhost 127.0.0.1 은 항상 null", async () => {
-    const { rateLimit } = await import("./rateLimit");
-    for (let i = 0; i < 100; i++) {
+    const { rateLimit, MAX_REQUESTS_PER_WINDOW } = await import("./rateLimit");
+    for (let i = 0; i < MAX_REQUESTS_PER_WINDOW + 10; i++) {
       expect(rateLimit(makeRequest("127.0.0.1"))).toBeNull();
     }
   });
 
   it("localhost ::1 은 항상 null", async () => {
-    const { rateLimit } = await import("./rateLimit");
-    for (let i = 0; i < 100; i++) {
+    const { rateLimit, MAX_REQUESTS_PER_WINDOW } = await import("./rateLimit");
+    for (let i = 0; i < MAX_REQUESTS_PER_WINDOW + 10; i++) {
       expect(rateLimit(makeRequest("::1"))).toBeNull();
     }
   });
@@ -86,10 +96,10 @@ describe("rateLimit — fixed window", () => {
   });
 
   it("다른 IP 는 독립 카운트", async () => {
-    const { rateLimit } = await import("./rateLimit");
+    const { rateLimit, MAX_REQUESTS_PER_WINDOW } = await import("./rateLimit");
     const reqA = makeRequest("1.1.1.1");
     const reqB = makeRequest("2.2.2.2");
-    for (let i = 0; i < 60; i++) rateLimit(reqA);
+    for (let i = 0; i < MAX_REQUESTS_PER_WINDOW; i++) rateLimit(reqA);
     expect(rateLimit(reqA)?.status).toBe(429); // A 차단
     expect(rateLimit(reqB)).toBeNull(); // B 독립 — 통과
   });
@@ -107,26 +117,28 @@ describe("rateLimit — 메모리 가드 (MAX_BUCKETS sweep)", () => {
   });
 
   it("MAX_BUCKETS 도달 후 새 windowKey 진입 시 만료 entry sweep + 활성 entry 보존", async () => {
-    const { rateLimit } = await import("./rateLimit");
+    const { rateLimit, MAX_BUCKETS, MAX_REQUESTS_PER_WINDOW, WINDOW_MS } =
+      await import("./rateLimit");
 
-    // MAX_BUCKETS = 10_000 개 IP 를 현재 윈도우에서 채움
-    const MAX_BUCKETS = 10_000;
+    // MAX_BUCKETS 개 IP 를 현재 윈도우에서 채움
     for (let i = 0; i < MAX_BUCKETS; i++) {
       const ip = `10.${Math.floor(i / 65536)}.${Math.floor((i % 65536) / 256)}.${i % 256}`;
       rateLimit(makeRequest(ip));
     }
 
     // 새 windowKey 로 이동
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(WINDOW_MS);
 
     // 새 IP 추가 — sweep 트리거 + 새 entry 생성
     const newIp = "99.99.99.99";
     expect(rateLimit(makeRequest(newIp))).toBeNull();
 
-    // 새 IP 는 새 윈도우에서 독립 카운트 시작 — 60번 요청 가능
-    // 첫 호출(위 expect)에서 count=1, 여기서 58번 더 → count=59
-    for (let i = 1; i < 59; i++) rateLimit(makeRequest(newIp));
-    expect(rateLimit(makeRequest(newIp))).toBeNull(); // 60번째 — 통과
-    expect(rateLimit(makeRequest(newIp))?.status).toBe(429); // 61번째 — 차단
+    // 새 IP 는 새 윈도우에서 독립 카운트 시작 — 한도까지 통과
+    // 첫 호출(위 expect)에서 count=1, 여기서 (한도-2) 번 더 호출 → count=한도-1
+    for (let i = 1; i < MAX_REQUESTS_PER_WINDOW - 1; i++) {
+      rateLimit(makeRequest(newIp));
+    }
+    expect(rateLimit(makeRequest(newIp))).toBeNull(); // 한도 번째 — 통과
+    expect(rateLimit(makeRequest(newIp))?.status).toBe(429); // 한도 초과 — 차단
   });
 });

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -3,9 +3,9 @@ import logger from "@/lib/logger";
 
 const log = logger.child({ module: "middleware/rateLimit" });
 
-const WINDOW_MS = 60_000; // 1분
-const MAX_REQUESTS_PER_WINDOW = 60;
-const MAX_BUCKETS = 10_000;
+export const WINDOW_MS = 60_000; // 1분
+export const MAX_REQUESTS_PER_WINDOW = 1000;
+export const MAX_BUCKETS = 10_000;
 const BOT_UA_PATTERN = /Googlebot/i;
 const LOCALHOST_IPS = new Set(["127.0.0.1", "::1"]);
 


### PR DESCRIPTION
## Summary
- **Hotfix**: rate limit 60/min/IP → **1000/min/IP** 완화
- 개발/캐시-비우기-새로고침 시나리오에서 **5 페이지도 안 봤는데 차단되는** 문제 해결
- 한도 상수 (`WINDOW_MS / MAX_REQUESTS_PER_WINDOW / MAX_BUCKETS`) 를 export → 테스트가 hardcoded 60 대신 import한 상수 사용 (향후 한도 변경 시 테스트 자동 적응)

## 왜 이번 hotfix 만으로 부족한가 (별도 plan 후속 권장)

본질 원인은 한도 자체가 아니라 **카운트되는 request 범위가 너무 넓어서**:

1. `proxy.ts` matcher 가 `/_next/data/**` (RSC payload) 와 `/api/**` 를 모두 잡음 → 한 글 상세 페이지 1번 = HTML + RSC + Comments API + Visit API ≈ 4-6 카운트
2. `LOCALHOST_IPS` 가 `::ffff:127.0.0.1` (IPv4-mapped IPv6) + 사설 대역 (`192.168.x.x` 등) 미인식 → LAN 내 접속도 일반 IP 처리
3. API path 별도 한도 없음 → `/api/visit` 매 페이지 호출이 60 한도 합산
4. 운영자 IP allowlist 없음

→ 별도 plan 에서 (1) matcher 좁히기 + (2) localhost 매핑 확장 + (3) API 별도 한도 또는 (4) env allowlist 도입.

## Test plan
- [x] `pnpm lint` 통과
- [x] `pnpm type-check` 통과
- [x] `pnpm test -- --run` — 38 files 350 tests passed (rateLimit 테스트 모두 import 한 상수로 리팩토링됨)
- [x] `pnpm build` 통과
- [ ] (수동) 홈서버 배포 후 5+ 페이지 navigation 시 차단 없는지 확인

## 영향 범위
- `src/middleware/rateLimit.ts` — 상수 3개 export + 한도 60 → 1000
- `src/middleware/rateLimit.test.ts` — hardcoded 60/60_000/10_000 → import한 상수

🤖 Generated with [Claude Code](https://claude.com/claude-code)