### PR TITLE
fix(hero): rephrase awkward Korean copy in HomeHero

### DIFF
--- a/src/components/HomeHero.tsx
+++ b/src/components/HomeHero.tsx
@@ -40,9 +40,9 @@ export function HomeHero({ postCount, categoryCount, seriesCount, subscriberCoun
         </div>
 
         <h1 className="mt-5 max-w-[22ch] text-[36px] font-semibold leading-[1.05] tracking-tight text-[var(--color-fg-primary)] md:text-[64px]">
-          한국어 개발자를 위한
+          매일 쌓는
           <br />
-          학습 노트
+          개발 학습 노트
           <em className="not-italic font-mono text-[var(--color-cat-react)]">
             (.mdx)
           </em>


### PR DESCRIPTION
## Summary
- HomeHero h1 의 \"한국어 개발자를 위한 학습 노트\" → \"매일 쌓는 개발 학습 노트\" 로 변경
- \"한국어 개발자\"가 \"한국어를 쓰는 개발자\" / \"한국 개발자\" 사이에서 모호한 직역투라 어색 → 사이트 콘텐츠가 자연히 한국어이므로 언어 명시를 제거, 지속성/행위 강조

## Test plan
- [ ] \`pnpm dev\` → \`/\` hero 카피 \"매일 쌓는 / 개발 학습 노트 (.mdx)\" 로 표시
- [ ] 다른 페이지 / 메타 / OG 이미지에 \"한국어 개발자\" 잔재 없음 (grep 확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)