### PR TITLE
feat(footer): redesign SiteFooter — 4-col + categories + connect (graceful) [plan013-2]

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -342,6 +342,14 @@
 - **Header brand mark 변경**: `📚 FOS Study` 이모지 → `● fos-blog/study` (Geist Mono + 시안 dot + glow). 이모지는 dev-blog 톤과 매치 안 됨, mono + dot 패턴이 Vercel/Linear 톤과 일관. dot 은 `--color-brand-400` 토큰 사용으로 다크/라이트 자동 전환.
 - **HomeHero `<dl>` 통계 4 슬롯**: posts/categories 는 실데이터, series/subscribers 는 placeholder ("—"). UI 그리드 균형 + 향후 채울 자리 명시 의도 — 비활성 슬롯이라 disabled style 명시.
 
+**plan013-2 추가 결정 (Footer)**:
+
+- **SiteFooter 컴포넌트 분리**: 기존 `layout.tsx` 인라인 footer → `src/components/SiteFooter.tsx` server component 로 추출. 4-column (Brand / Site+Policy / Categories / Connect) + Eyebrow status row + mesh accent + bottom built-with stack 으로 복잡도 증가 → layout.tsx 가독성 + 재사용성 확보. sub-component (`ColHead`/`FooterList`/`SocialItem`) 는 같은 파일 안 private 유지 — 재사용 범위 footer 한정이라 types/ 분리 불필요.
+- **미구현 기능 graceful fallback 패턴**: RSS feed (`/rss.xml`) / Newsletter 는 별도 issue 로 위임하되 Footer 의 자리 예약 의도로 visible 유지. 처리 방식: `disabled` prop → `<a>` 가 아닌 `<span aria-disabled="true" title="준비 중">` + `pointer-events-none opacity-40`. 클릭 차단하면서 UI 자리 보존 — "곧 나올 것" 신호. 구현 시점에 prop 만 제거.
+- **POLICY column arrow=path 패턴**: 정책 링크 (`/about`, `/privacy`, `/contact`) 의 hover decoration 은 `↗` 대신 경로 문자열 자체 (`arrowMono: true` mono font). 외부 링크 (Connect col 의 GitHub/Source ↗) 와 시각 차별화 + 내부 경로 명시. mockup 디자인 의도, helper 통일 권장 금지.
+- **BUILD_DATE 하드코딩 follow-up**: `const BUILD_DATE = "2026.04.27"` 빌드 타임 스탬프. `process.env.BUILD_DATE` 또는 `package.json.version` 기반 동적화는 별도 issue. Footer eyebrow row 의 `v0.1 · {BUILD_DATE} · seoul, kr` 표시용.
+- **category-meta canonical self-map 보강**: SiteFooter 가 lowercase canonical key (`"ai"`, `"db"`, `"js"`) 직접 호출 → 기존 `RAW_TO_CANONICAL` 은 raw key (`"AI"`, `"database"`, `"javascript"`) 만 매핑이라 fallback `"system"` 으로 잘못 처리됨 (3 카테고리 hue 오류). `RAW_TO_CANONICAL` 에 self-map 4 항목 (`ai/db/js/system`) 추가. `algorithm/devops/java/react/next` 는 raw==canonical 동일이라 자동.
+
 
 <a id="adr-019"></a>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -572,3 +572,15 @@ html:not(.dark) .shiki span {
 
 /* === Header brand-mark dot === */
 /* 인라인 className 으로 처리 — 별도 룰 불필요 */
+
+/* === Footer accent line === */
+.fbf-accent {
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in oklch, var(--color-brand-400), transparent 60%) 30%,
+    var(--color-brand-400) 50%,
+    color-mix(in oklch, var(--color-brand-400), transparent 60%) 70%,
+    transparent
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,8 +7,8 @@ import { env } from "@/env";
 import { OG_WIDTH, OG_HEIGHT } from "@/lib/og";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Header } from "@/components/Header";
-import { VisitorCount } from "@/components/VisitorCount";
 import { SidebarProvider } from "@/components/SidebarContext";
+import { SiteFooter } from "@/components/SiteFooter";
 import { FolderSidebarWrapper } from "@/app/components/FolderSidebarWrapper";
 
 const siteUrl = env.NEXT_PUBLIC_SITE_URL;
@@ -141,103 +141,7 @@ export default function RootLayout({
             <Header />
             <FolderSidebarWrapper />
             <main>{children}</main>
-            <footer className="border-t border-gray-200 dark:border-gray-800 py-12 mt-16">
-              <div className="container mx-auto px-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-8">
-                  {/* Brand */}
-                  <div>
-                    <div className="flex items-center gap-2 text-lg font-bold text-gray-900 dark:text-white mb-3">
-                      <span>📚</span>
-                      <span>FOS Study</span>
-                    </div>
-                    <p className="text-sm text-gray-600 dark:text-gray-400">
-                      개발 학습 기록을 정리하는 블로그입니다.
-                    </p>
-                  </div>
-                  {/* Links */}
-                  <div>
-                    <h3 className="font-semibold text-gray-900 dark:text-white mb-3">
-                      바로가기
-                    </h3>
-                    <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
-                      <li>
-                        <a
-                          href="/"
-                          className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                        >
-                          홈
-                        </a>
-                      </li>
-                      <li>
-                        <a
-                          href="/categories"
-                          className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                        >
-                          카테고리
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                  {/* Social */}
-                  <div>
-                    <h3 className="font-semibold text-gray-900 dark:text-white mb-3">
-                      소셜
-                    </h3>
-                    <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
-                      <li>
-                        <a
-                          href="https://github.com/jon890"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                        >
-                          GitHub
-                        </a>
-                      </li>
-                      <li>
-                        <a
-                          href="https://github.com/jon890/fos-study"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                        >
-                          Source Repository
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                  {/* Policy */}
-                  <div>
-                    <h3 className="font-semibold text-gray-900 dark:text-white mb-3">
-                      정책
-                    </h3>
-                    <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
-                      <li>
-                        <a href="/about" className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                          소개
-                        </a>
-                      </li>
-                      <li>
-                        <a href="/privacy" className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                          개인정보처리방침
-                        </a>
-                      </li>
-                      <li>
-                        <a href="/contact" className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                          연락처
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
-                <div className="pt-8 border-t border-gray-200 dark:border-gray-800 text-center space-y-3">
-                  <VisitorCount />
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    © 2025 FOS Study. Built with Next.js & Tailwind CSS
-                  </p>
-                </div>
-              </div>
-            </footer>
+            <SiteFooter />
           </div>
           </SidebarProvider>
         </ThemeProvider>

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,297 @@
+import Link from "next/link";
+import type { CSSProperties } from "react";
+import { Github, Code2, Rss, Mail } from "lucide-react";
+import { VisitorCount } from "./VisitorCount";
+import { getCategoryColor } from "@/lib/category-meta";
+
+const FOOTER_CATEGORIES = [
+  { id: "ai",        label: "AI" },
+  { id: "algorithm", label: "Algorithm" },
+  { id: "db",        label: "DB" },
+  { id: "devops",    label: "DevOps" },
+  { id: "java",      label: "Java/Spring" },
+  { id: "js",        label: "JS/TS" },
+  { id: "react",     label: "React" },
+  { id: "next",      label: "Next.js" },
+  { id: "system",    label: "System" },
+] as const;
+
+const SITE_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/posts/latest", label: "Posts" },
+  { href: "/categories", label: "Categories" },
+  { href: "/about", label: "About" },
+];
+
+const POLICY_LINKS = [
+  { href: "/about", label: "소개", path: "/about" },
+  { href: "/privacy", label: "개인정보처리방침", path: "/privacy" },
+  { href: "/contact", label: "연락처", path: "/contact" },
+];
+
+const BUILD_DATE = "2026.04.27"; // build time stamp — package 또는 env 로 동적화 가능 (별도 issue)
+
+export function SiteFooter() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="fbf relative overflow-hidden border-t border-[var(--color-border-subtle)] bg-[var(--color-bg-base)]">
+      {/* Top accent line */}
+      <div aria-hidden className="fbf-accent absolute top-0 left-0 right-0 h-px" />
+
+      {/* Mesh accent (subtle) */}
+      <div
+        aria-hidden
+        className="fbf-mesh pointer-events-none absolute inset-0 opacity-30"
+        style={{
+          background:
+            "radial-gradient(40% 80% at 10% 0%, oklch(0.7 0.16 230 / 0.45), transparent 60%), radial-gradient(40% 70% at 90% 0%, oklch(0.65 0.18 280 / 0.32), transparent 60%), radial-gradient(35% 60% at 50% 100%, oklch(0.78 0.13 195 / 0.40), transparent 60%)",
+          filter: "blur(40px) saturate(140%)",
+        }}
+      />
+      {/* Grid lines */}
+      <div
+        aria-hidden
+        className="fbf-grid pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: "linear-gradient(to right, var(--color-border-subtle) 1px, transparent 1px)",
+          backgroundSize: "80px 100%",
+          maskImage: "linear-gradient(to bottom, transparent, black 30%, black 90%)",
+        }}
+      />
+
+      <div className="relative z-[2] mx-auto max-w-[1280px] px-6 pt-16 pb-7 md:px-8">
+        {/* Eyebrow */}
+        <div className="fbf-eyebrow flex flex-col gap-3 border-b border-[var(--color-border-subtle)] pb-7 mb-10 font-mono text-[11px] uppercase tracking-[0.08em] text-[var(--color-fg-muted)] md:flex-row md:items-center md:justify-between">
+          <span className="inline-flex items-center gap-2.5 text-[var(--color-brand-400)]">
+            <span aria-hidden className="block h-px w-6 bg-[var(--color-brand-400)]" />
+            FOS-BLOG · FOOTER
+          </span>
+          <span className="inline-flex flex-wrap items-center gap-3.5 text-[var(--color-fg-faint)]">
+            <span className="inline-flex items-center gap-2 text-[var(--color-fg-secondary)]">
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--color-success)]"
+                style={{ boxShadow: "0 0 6px var(--color-success)" }}
+              />
+              all systems normal
+            </span>
+            <span className="hidden md:inline opacity-50">·</span>
+            <span className="hidden md:inline">v0.1 · {BUILD_DATE}</span>
+            <span className="hidden md:inline opacity-50">·</span>
+            <span className="hidden md:inline">seoul, kr</span>
+          </span>
+        </div>
+
+        {/* 4-column grid (모바일 1-col stack) */}
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-[1.5fr_1fr_1fr_1.2fr] md:gap-8">
+          {/* Brand col */}
+          <div>
+            <Link href="/" className="inline-flex items-center gap-3">
+              <span
+                aria-hidden
+                className="grid h-9 w-9 place-items-center rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] font-mono text-[14px] font-semibold text-[var(--color-brand-400)]"
+                style={{ boxShadow: "inset 0 1px 0 0 rgb(255 255 255 / 0.04)" }}
+              >
+                F
+              </span>
+              <span className="font-mono text-[14px] tracking-tight text-[var(--color-fg-primary)]">
+                fos-blog<span className="text-[var(--color-fg-muted)]">/study</span>
+              </span>
+            </Link>
+            <p className="mt-4 max-w-[36ch] text-[13px] leading-relaxed text-[var(--color-fg-secondary)]">
+              개발 학습 기록을 정리하는 블로그입니다. 공부하면서 기록하고, 기록하면서 다시 배웁니다.
+            </p>
+            <div className="mt-6 inline-flex items-center gap-2 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-3 py-2 font-mono text-[11px]">
+              <span className="text-[var(--color-fg-muted)] uppercase tracking-[0.06em]">visitors</span>
+              <span className="text-[var(--color-brand-400)] tabular-nums">
+                <VisitorCount />
+              </span>
+            </div>
+          </div>
+
+          {/* Site + Policy col */}
+          <div>
+            <ColHead idx="01" label="site" />
+            <FooterList
+              items={SITE_LINKS.map((l) => ({ href: l.href, label: l.label, arrow: "↗" }))}
+            />
+            <div className="mt-8" />
+            <ColHead idx="02" label="policy" />
+            <FooterList
+              items={POLICY_LINKS.map((l) => ({ href: l.href, label: l.label, arrow: l.path, arrowMono: true }))}
+            />
+          </div>
+
+          {/* Categories col */}
+          <div>
+            <ColHead idx="03" label="categories" />
+            <ul className="space-y-2">
+              {FOOTER_CATEGORIES.map((c) => {
+                const color = getCategoryColor(c.id);
+                return (
+                  <li key={c.id}>
+                    <Link
+                      href={`/categories#${c.id}`}
+                      style={{ "--cat-color": color } as CSSProperties}
+                      className="group flex items-center gap-2.5 text-[13px] text-[var(--color-fg-secondary)] transition-colors hover:text-[var(--color-fg-primary)]"
+                    >
+                      <span
+                        aria-hidden
+                        className="h-1.5 w-1.5 rounded-full"
+                        style={{ background: "var(--cat-color)" }}
+                      />
+                      <span>{c.label}</span>
+                      <span className="ml-auto font-mono text-[11px] text-[var(--color-fg-faint)] opacity-0 transition-opacity group-hover:opacity-100 group-hover:text-[var(--color-brand-400)]">
+                        ↗
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          {/* Connect col */}
+          <div>
+            <ColHead idx="04" label="connect" />
+            <ul className="space-y-3">
+              <SocialItem
+                href="https://github.com/jon890"
+                external
+                Icon={Github}
+                ttl="GitHub"
+                sub="@jon890"
+                arrow="↗"
+              />
+              <SocialItem
+                href="https://github.com/jon890/fos-study"
+                external
+                Icon={Code2}
+                ttl="Source repository"
+                sub="jon890/fos-study"
+                arrow="↗"
+              />
+              <SocialItem
+                href="/rss.xml"
+                Icon={Rss}
+                ttl="RSS feed"
+                sub="/rss.xml"
+                arrow="↗"
+                disabled // 미구현 — 별도 issue. graceful fallback.
+              />
+              <SocialItem
+                href="#newsletter"
+                Icon={Mail}
+                ttl="Newsletter"
+                sub="매주 1 회 · 한 편의 글"
+                arrow="→"
+                disabled // 미구현 — 별도 issue.
+              />
+            </ul>
+          </div>
+        </div>
+
+        {/* Bottom row */}
+        <div className="mt-12 flex flex-col gap-3 border-t border-[var(--color-border-subtle)] pt-7 font-mono text-[11px] text-[var(--color-fg-muted)] md:flex-row md:items-center md:justify-between">
+          <div className="copy">
+            © {year} <strong className="font-semibold text-[var(--color-fg-primary)]">FOS Study</strong>. All posts MIT-licensed.
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span>built with</span>
+            {["Next.js", "Tailwind v4", "Geist", "Pretendard", "oklch"].map((s) => (
+              <span key={s} className="inline-flex items-center gap-2">
+                <span className="opacity-50">·</span>
+                <span>{s}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function ColHead({ idx, label }: { idx: string; label: string }) {
+  return (
+    <div className="mb-4 inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.08em] text-[var(--color-fg-muted)]">
+      <span className="rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-[var(--color-fg-faint)]">
+        {idx}
+      </span>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+interface FooterItem {
+  href: string;
+  label: string;
+  arrow: string;
+  arrowMono?: boolean;
+}
+function FooterList({ items }: { items: FooterItem[] }) {
+  return (
+    <ul className="space-y-2">
+      {items.map((it) => (
+        <li key={`${it.href}-${it.label}`}>
+          <Link
+            href={it.href}
+            className="group flex items-center justify-between gap-3 text-[13px] text-[var(--color-fg-secondary)] transition-colors hover:text-[var(--color-fg-primary)]"
+          >
+            <span>{it.label}</span>
+            <span
+              className={`text-[var(--color-fg-faint)] opacity-0 transition-opacity group-hover:opacity-100 group-hover:text-[var(--color-brand-400)] ${it.arrowMono ? "font-mono text-[10px]" : ""}`}
+            >
+              {it.arrow}
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface SocialItemProps {
+  href: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  ttl: string;
+  sub: string;
+  arrow: string;
+  external?: boolean;
+  disabled?: boolean;
+}
+function SocialItem({ href, Icon, ttl, sub, arrow, external, disabled }: SocialItemProps) {
+  const className =
+    "group flex items-center gap-3 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-3 py-2.5 transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-overlay)]" +
+    (disabled ? " pointer-events-none opacity-40" : "");
+  const inner = (
+    <>
+      <Icon className="h-4 w-4 shrink-0 text-[var(--color-fg-muted)] group-hover:text-[var(--color-brand-400)]" />
+      <span className="flex flex-1 flex-col">
+        <span className="text-[13px] text-[var(--color-fg-primary)]">{ttl}</span>
+        <span className="font-mono text-[11px] text-[var(--color-fg-muted)]">{sub}</span>
+      </span>
+      <span className="font-mono text-[12px] text-[var(--color-fg-faint)] group-hover:text-[var(--color-brand-400)]">
+        {arrow}
+      </span>
+    </>
+  );
+
+  return (
+    <li>
+      {disabled ? (
+        <span className={className} aria-disabled="true" title="준비 중">
+          {inner}
+        </span>
+      ) : external ? (
+        <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+          {inner}
+        </a>
+      ) : (
+        <Link href={href} className={className}>
+          {inner}
+        </Link>
+      )}
+    </li>
+  );
+}

--- a/src/lib/category-meta.ts
+++ b/src/lib/category-meta.ts
@@ -17,6 +17,7 @@ export type CanonicalCategory =
   | "system";
 
 const RAW_TO_CANONICAL: Record<string, CanonicalCategory> = {
+  // raw → canonical (기존)
   AI: "ai",
   algorithm: "algorithm",
   database: "db",
@@ -28,6 +29,12 @@ const RAW_TO_CANONICAL: Record<string, CanonicalCategory> = {
   css: "js",
   react: "react",
   next: "next",
+  // canonical → canonical self-map (Footer / 직접 호출 안전망)
+  ai: "ai",
+  db: "db",
+  js: "js",
+  // algorithm/devops/java/react/next 는 raw 값과 canonical 값이 동일하므로 위 라인이 그대로 self-map 역할
+  system: "system",
 };
 
 export function toCanonicalCategory(raw: string): CanonicalCategory {

--- a/tasks/plan013-2-footer-redesign/index.json
+++ b/tasks/plan013-2-footer-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan013-2-footer-redesign",
   "description": "Claude Design Round 3 footer.jsx + footer.css 기반 Footer 리디자인 — 4-column grid (Brand / Site+Policy / Categories / Connect), eyebrow with status pulse, mesh accent + grid line, visitor counter, RSS/Newsletter graceful fallback, MIT-license + 'built with' stack. plan013 (Header+Hero) 머지 후 진행. layout.tsx 인라인 footer → 신규 SiteFooter 컴포넌트로 분리.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-04-27",
   "total_phases": 1,
   "related_docs": [
@@ -18,7 +18,7 @@
       "file": "phase-01.md",
       "title": "SiteFooter 4-column + Categories + Connect (RSS/Newsletter graceful) + eyebrow status + bottom stack",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan013-2-footer-redesign/phase-01.md
+++ b/tasks/plan013-2-footer-redesign/phase-01.md
@@ -59,7 +59,7 @@ scope 외 (별도 plan/issue):
 # 1) plan009 + plan013 머지 완료 확인
 grep -n -- "--mesh-stop-01" src/app/globals.css
 grep -n "HomeHero" src/components/HomeHero.tsx
-grep -n "fos-blog/dev-notes" src/components/Header.tsx
+grep -n "fos-blog<span" src/components/Header.tsx     # plan013 의 Header brand wordmark 존재 확인 (slug suffix 는 어떤 값이든 통과)
 grep -n "FOS-WORLD · DEV NOTES" src/components/HomeHero.tsx
 
 # 2) 재사용 대상 확인
@@ -80,7 +80,41 @@ grep -n "<footer" src/app/layout.tsx
 
 ## 작업 목록 (총 5개)
 
-### 1. `src/components/SiteFooter.tsx` 신규 (server)
+### 1. `src/lib/category-meta.ts` — canonical self-map 보강
+
+현재 `RAW_TO_CANONICAL` 은 `"AI"`, `"database"`, `"javascript"` 등 raw 키만 매핑. SiteFooter 가 canonical 키 (`"ai"`, `"db"`, `"js"`, `"algorithm"`, `"devops"`, `"java"`, `"react"`, `"next"`, `"system"`) 를 직접 넘기면 `toCanonicalCategory("ai")` 가 `undefined → "system"` 으로 fallback → 3개 카테고리(ai/db/js) 의 hue 가 system(250) 으로 잘못 렌더링.
+
+`RAW_TO_CANONICAL` 에 canonical → canonical self-map 9 항목 추가:
+
+```ts
+const RAW_TO_CANONICAL: Record<string, CanonicalCategory> = {
+  // raw → canonical (기존)
+  AI: "ai",
+  algorithm: "algorithm",
+  database: "db",
+  redis: "db",
+  devops: "devops",
+  java: "java",
+  javascript: "js",
+  html: "js",
+  css: "js",
+  react: "react",
+  next: "next",
+  // canonical → canonical self-map (Footer / 직접 호출 안전망)
+  ai: "ai",
+  db: "db",
+  js: "js",
+  // algorithm/devops/java/react/next 는 raw 값과 canonical 값이 동일하므로 위 라인이 그대로 self-map 역할
+  system: "system",
+};
+```
+
+설계 메모:
+- canonical key 도 `RAW_TO_CANONICAL` 의 key 로 추가하면 "raw 가 canonical 일 때도 통과" 가 자연스러워진다 (멱등). 호출자가 "이 값이 raw 인가 canonical 인가" 신경 쓸 필요 없음
+- `algorithm`/`devops`/`java`/`react`/`next` 는 이미 self-map 효과 (raw 키와 canonical 값이 우연히 동일)
+- `getCategoryColor` / `getCategoryHue` / `getCategoryTokenVar` 모두 자동으로 영향 받아 정합
+
+### 2. `src/components/SiteFooter.tsx` 신규 (server)
 
 ```tsx
 import Link from "next/link";
@@ -390,7 +424,7 @@ function SocialItem({ href, Icon, ttl, sub, arrow, external, disabled }: SocialI
 - `lucide-react` 의 `Github / Code2 / Rss / Mail / ArrowUpRight` 사용 (모두 기존 의존성)
 - mesh / grid / accent 모두 inline style — globals.css 룰 추가 없이 자기완결
 
-### 2. `src/app/layout.tsx` — 인라인 footer 제거 + `<SiteFooter />` 호출
+### 3. `src/app/layout.tsx` — 인라인 footer 제거 + `<SiteFooter />` 호출
 
 ```tsx
 import { SiteFooter } from "@/components/SiteFooter";
@@ -403,7 +437,7 @@ import { SiteFooter } from "@/components/SiteFooter";
 
 기존 라인 144-240 의 인라인 `<footer>` 전체 삭제. `<SiteFooter />` 한 줄로 교체. `<VisitorCount />` 도 footer 안으로 이동 (layout.tsx 에서 import 제거).
 
-### 3. `src/app/globals.css` — `.fbf-accent` 그라디언트 룰 (선택)
+### 4. `src/app/globals.css` — `.fbf-accent` 그라디언트 룰 (선택)
 
 mockup 의 `.fbf-accent` 는 horizontal gradient line:
 ```css
@@ -421,23 +455,7 @@ mockup 의 `.fbf-accent` 는 horizontal gradient line:
 
 inline style 로 처리하기 어색해 globals.css 에 추가 (한 룰만).
 
-### 4. RSS / Newsletter 미구현 issue 등록
-
-phase 종료 후 team-lead 가 등록 (executor 는 제외):
-
-```bash
-gh issue create \
-  --title "RSS feed 라우트 신설 (/rss.xml)" \
-  --body "Footer 의 RSS 링크 활성화 위해 /rss.xml 라우트 + RSS 2.0 XML 생성 필요. plan013-2 에서 graceful fallback (disabled) 처리됨. 사용자 결정 필요: 직접 구현 vs feed 생성 라이브러리 (예: feed npm). category/series 필터 적용 여부."
-
-gh issue create \
-  --title "Newsletter 구독 기능 도입" \
-  --body "Footer 의 Newsletter 링크 활성화 위해 구독 폼 + 백엔드 (Buttondown / Mailchimp / 자체 SMTP) 결정 필요. plan013-2 에서 graceful fallback (disabled) 처리됨. HomeHero 의 subscribers stat 도 Newsletter 구현 후 실값 반영. 무료 플랜 비교 + 운영 비용 고려."
-```
-
-(이 작업은 phase 의 직접 결과물 아님. team-lead 가 PR 생성 시 함께 처리)
-
-### 5. 통합 검증
+### 5. 통합 검증 + `index.json` completed 마킹
 
 ```bash
 # cwd: <worktree root>
@@ -469,6 +487,14 @@ grep -rE "fbf-accent|FOS-BLOG · FOOTER" .next/server/app/ 2>/dev/null | head -3
 - RSS / Newsletter 클릭 시 비활성 (pointer-events-none) + tooltip "준비 중"
 - VisitorCount 가 Brand col 의 counter 안에 정상 표시
 - Categories 9개 hover 시 cat-color dot + arrow 노출
+
+마지막으로 `tasks/plan013-2-footer-redesign/index.json` 의 `status` 와 `phases[0].status` 를 `"completed"` 로 업데이트:
+
+```bash
+# cwd: <worktree root>
+jq '.status = "completed" | .phases[0].status = "completed"' tasks/plan013-2-footer-redesign/index.json > tasks/plan013-2-footer-redesign/index.json.tmp \
+  && mv tasks/plan013-2-footer-redesign/index.json.tmp tasks/plan013-2-footer-redesign/index.json
+```
 
 ## 성공 기준 (기계 명령만)
 
@@ -523,6 +549,16 @@ pnpm build
 ! grep -nE "as any" src/components/SiteFooter.tsx
 ! grep -nE "console\.(log|warn|error)" src/components/SiteFooter.tsx
 ! grep -nE "alert\(|confirm\(|prompt\(" src/components/SiteFooter.tsx
+
+# 11) category-meta canonical self-map
+grep -nE '^\s+ai:\s*"ai"' src/lib/category-meta.ts
+grep -nE '^\s+db:\s*"db"' src/lib/category-meta.ts
+grep -nE '^\s+js:\s*"js"' src/lib/category-meta.ts
+grep -nE '^\s+system:\s*"system"' src/lib/category-meta.ts
+
+# 12) index.json completed 마킹
+[ "$(jq -r .status tasks/plan013-2-footer-redesign/index.json)" = "completed" ]
+[ "$(jq -r '.phases[0].status' tasks/plan013-2-footer-redesign/index.json)" = "completed" ]
 ```
 
 ## PHASE_BLOCKED 조건
@@ -535,9 +571,27 @@ pnpm build
 ## 커밋 제외 (phase 내부)
 
 executor 는 커밋하지 않는다. team-lead 가 일괄 커밋:
+- `fix(category-meta): add canonical self-map for direct canonical-key lookups`
 - `feat(footer): add SiteFooter component (4-col + categories + connect)`
 - `feat(footer): integrate eyebrow status row + mesh accent + bottom stack`
 - `refactor(layout): replace inline footer with <SiteFooter />`
 - `feat(globals): add .fbf-accent gradient line rule`
+- `chore(tasks): mark plan013-2 completed`
 
-team-lead 가 PR 생성 시 RSS / Newsletter graceful fallback 에 대응하는 issue 2건 (`gh issue create`) 도 함께 등록 — 작업 4 참조.
+team-lead 가 PR 생성 시 RSS / Newsletter graceful fallback 에 대응하는 issue 2건도 함께 등록 (executor 책임 아님 — phase 본문 외):
+
+```bash
+gh issue create \
+  --title "RSS feed 라우트 신설 (/rss.xml)" \
+  --body "Footer 의 RSS 링크 활성화 위해 /rss.xml 라우트 + RSS 2.0 XML 생성 필요. plan013-2 에서 graceful fallback (disabled) 처리됨. 사용자 결정 필요: 직접 구현 vs feed 생성 라이브러리 (예: feed npm). category/series 필터 적용 여부."
+
+gh issue create \
+  --title "Newsletter 구독 기능 도입" \
+  --body "Footer 의 Newsletter 링크 활성화 위해 구독 폼 + 백엔드 (Buttondown / Mailchimp / 자체 SMTP) 결정 필요. plan013-2 에서 graceful fallback (disabled) 처리됨. HomeHero 의 subscribers stat 도 Newsletter 구현 후 실값 반영. 무료 플랜 비교 + 운영 비용 고려."
+```
+
+## NOTE (critic v1)
+
+- POLICY_LINKS 의 `arrow: l.path` 는 의도된 mockup 디자인 (정책 링크는 hover 시 path 가 표시되는 게 의도). `arrowMono: true` 로 mono font 분리 처리됨. 변경 안 함
+- `<span aria-disabled="true">` (RSS/Newsletter disabled) — minor a11y. `role="link"` 추가하면 SR 이 정확히 announce. 단 plain text fallback 으로도 시각/키보드 동작에 차이 없음. 향후 a11y 패스에서 일괄 처리 (별도 plan 또는 follow-up)
+- `BUILD_DATE = "2026.04.27"` 하드코딩 — 동적화는 별도 issue 로 위임 (env 또는 빌드시 주입)

--- a/tasks/plan013-2-footer-redesign/phase-01.md
+++ b/tasks/plan013-2-footer-redesign/phase-01.md
@@ -119,7 +119,7 @@ const RAW_TO_CANONICAL: Record<string, CanonicalCategory> = {
 ```tsx
 import Link from "next/link";
 import type { CSSProperties } from "react";
-import { Github, Code2, Rss, Mail, ArrowUpRight } from "lucide-react";
+import { Github, Code2, Rss, Mail } from "lucide-react";
 import { VisitorCount } from "./VisitorCount";
 import { getCategoryColor } from "@/lib/category-meta";
 
@@ -215,7 +215,7 @@ export function SiteFooter() {
                 F
               </span>
               <span className="font-mono text-[14px] tracking-tight text-[var(--color-fg-primary)]">
-                fos-blog<span className="text-[var(--color-fg-muted)]">/dev-notes</span>
+                fos-blog<span className="text-[var(--color-fg-muted)]">/study</span>
               </span>
             </Link>
             <p className="mt-4 max-w-[36ch] text-[13px] leading-relaxed text-[var(--color-fg-secondary)]">


### PR DESCRIPTION
## Summary

- `src/components/SiteFooter.tsx` 신규 server component — 4-column grid (Brand / Site+Policy / Categories(9) / Connect(4)) + Eyebrow status row + mesh accent + bottom MIT/built-with stack
- `layout.tsx` 인라인 footer 제거, `<SiteFooter />` 한 줄로 교체
- RSS / Newsletter graceful fallback (`disabled` → visible but pointer-events-none, "준비 중" tooltip) — 별도 issue 로 위임
- `src/lib/category-meta.ts` canonical self-map 보강 (Footer 의 lowercase canonical key 직접 호출 안전망 — ai/db/js 카테고리 hue 정합)
- `globals.css` `.fbf-accent` gradient line 룰 추가 (Footer top accent)
- ADR-017 에 plan013-2 결정 5건 기록

## Atomic commits

- `fix(category-meta)`: canonical self-map 4 항목
- `feat(footer)`: SiteFooter 신규 (4-col + eyebrow + mesh + bottom stack)
- `refactor(layout)`: 인라인 footer 제거 + `<SiteFooter />`
- `feat(globals)`: `.fbf-accent` gradient
- `chore(tasks)`: plan013-2 completed
- `docs(adr)`: ADR-017 plan013-2 결정 5건 기록
- `chore(tasks)`: phase-01 v2 (critic REVISE 반영) + minor (ArrowUpRight 제거 / brand /study 통일)

## Build

- ✅ `pnpm lint` PASS
- ✅ `pnpm type-check` PASS
- ✅ `pnpm test -- --run` 204 passed
- ✅ `pnpm build` PASS (executor 단계)

## Pipeline

- critic: APPROVE (v2, REVISE 3건 + minor 2건 모두 반영)
- code-reviewer: PASS (LOW 2건 — clsx/cn 스타일, POLICY href===path)
- docs-verifier: PASS (v2, ADR-017 5결정 기록)

## Test plan

- [ ] 모든 페이지에서 Footer 확인 (홈/카테고리/글 상세/about/privacy)
- [ ] 다크/라이트 토글 시 mesh + grid + 색 토큰 자연 전환
- [ ] 모바일 (360px) 4-col → 1-col stack
- [ ] RSS / Newsletter 클릭 비활성 + tooltip "준비 중"
- [ ] Categories 9 hover 시 cat-color dot + arrow 노출
- [ ] VisitorCount 가 Brand col counter 안에 정상 표시

## Follow-up issues

별도 등록 예정 — RSS feed 라우트 신설 (`/rss.xml`), Newsletter 구독 기능, BUILD_DATE 동적화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)