### PR TITLE
chore(tasks): add plan015 categories redesign tasks (3 phase)

### DIFF
--- a/tasks/plan015-categories-redesign/index.json
+++ b/tasks/plan015-categories-redesign/index.json
@@ -1,0 +1,39 @@
+{
+  "name": "plan015-categories-redesign",
+  "description": "Claude Design (h/SvcdB2wohXQWj4xRJAdUZA) 핸드오프 기반 Categories 페이지 리디자인 — /categories 인덱스 (sub-hero + Most active top-3 featured + All categories grid) + /category/[...path] 상세 (tinted sub-hero + breadcrumb + README frame + SubfolderCard + PostListRow). 신규 토큰 추가 없음 — plan009 토큰만 사용. mockup 의 PostListRow 는 카테고리 detail 전용, 인덱스 (latest/popular) 는 plan016 PostCard 그대로.",
+  "status": "pending",
+  "created_at": "2026-04-28",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/adr.md",
+    "docs/design-inspiration.md"
+  ],
+  "depends_on": [
+    "plan009-design-tokens-foundation",
+    "plan010-card-list-redesign",
+    "plan013-header-hero-redesign"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "CategoriesSubHero + Breadcrumb + CategoryFeatured + CategoryCard 재구성 + /categories 페이지 교체",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "CategoryDetailSubHero + SubfolderCard + PostListRow + ReadmeFrame + /category/[...path] 페이지 교체",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "통합 검증 + legacy 잔재 grep + Lighthouse smoke",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan015-categories-redesign/phase-01.md
+++ b/tasks/plan015-categories-redesign/phase-01.md
@@ -1,0 +1,244 @@
+# Phase 01 — CategoriesSubHero + Breadcrumb + CategoryFeatured + CategoryCard 재구성 + `/categories`
+
+**Model**: sonnet
+**Status**: pending
+
+---
+
+## 목표
+
+Claude Design 핸드오프 (`fos-blog/project/categories.{jsx,css}`) 의 **A 페이지 (`/categories` Index)** 을 구현한다. 신규 토큰 추가 없이 plan009 의 `--color-cat-*` + bg/fg/border 토큰만 사용. mockup 의 좌 2px cat-color accent + radial gradient hover blob + foot 영역 (count + view ↗) 패턴을 충실히 재현.
+
+**참고 핸드오프 위치**: `/tmp/fos-design-categories/fos-blog/project/categories.{jsx,css}` (gzip 풀어둔 상태). 다시 풀어야 하면 webfetch 결과 bin (`~/.claude/projects/-Users-nhn-personal-fos-blog/d11b8756-7896-451b-932e-0678c2241d67/tool-results/webfetch-1777346152645-o83bwy.bin`) 을 `tar xzf` 로 풀면 됨.
+
+---
+
+## 작업 항목 (5)
+
+### 1. `src/infra/db/repositories/CategoryRepository.ts` — `getCategoriesWithLatest()` 추가
+
+기존 `getCategories()` 와 별도. 카테고리 목록 + 카테고리별 max(`posts.updatedAt`) 을 한 번에 반환:
+
+```ts
+async getCategoriesWithLatest(): Promise<Array<CategoryData & { latestUpdatedAt: Date | null }>>
+```
+
+구현 — Drizzle subquery 또는 LEFT JOIN:
+
+```ts
+// posts.category 와 categories.slug 매칭 (raw category key) — toCanonicalCategory 매핑은 app 레이어에서
+const result = await this.db
+  .select({
+    name: categories.name,
+    slug: categories.slug,
+    icon: categories.icon,
+    postCount: categories.postCount,
+    latestUpdatedAt: sql<Date | null>`MAX(${posts.updatedAt})`,
+  })
+  .from(categories)
+  .leftJoin(posts, and(eq(posts.category, categories.slug), eq(posts.isActive, true)))
+  .groupBy(categories.id)
+  .orderBy(desc(categories.postCount));
+```
+
+기존 `getCategories()` 는 그대로 유지 (다른 호출자 영향 차단). 새 메서드는 `/categories` 페이지에서만 호출.
+
+### 2. `src/components/CategoriesSubHero.tsx` 신규
+
+server component. props:
+
+```ts
+interface CategoriesSubHeroProps {
+  eyebrow: string;          // "INDEX · CATEGORIES"
+  title: string;             // "카테고리"
+  sublines: Array<string | { num: string | number; suffix: string }>;
+  // 예: [{ num: 9, suffix: "개 주제" }, { num: 226, suffix: "개의 글" }, "updated 2026.04.27"]
+}
+```
+
+구조 (mockup `.subhero` + `.subhero-inner`):
+- 외곽 `<header>`: `border-b border-[var(--color-border-subtle)] py-14 md:pt-14 md:pb-10`
+- inner: `mx-auto max-w-[1180px] px-8`
+- eyebrow: mono 11px, uppercase, tracking 0.08em, color `var(--color-brand-400)`, 좌측 `::before` 1px×24px brand line (실제로는 `<span className="block h-px w-6 bg-[var(--color-brand-400)]" />`)
+- h1: `clamp(36px,4vw,52px) font-semibold leading-[1.1] tracking-[-0.025em] text-[var(--color-fg-primary)] mt-5`
+- subline: mono 13px, gap-3, items-center, flex-wrap, color `var(--color-fg-muted)`
+  - `num` part: `text-[var(--color-fg-primary)] font-medium`
+  - sep `·`: `text-[var(--color-fg-faint)]`
+
+### 3. `src/components/Breadcrumb.tsx` 신규
+
+mockup 의 `.crumb-row` 를 컴포넌트화. 다른 페이지에서도 재사용 가능하게 일반화 (Categories detail phase 02 에서도 사용).
+
+```ts
+interface BreadcrumbItem {
+  label: string;
+  href?: string;       // undefined 면 현재 페이지 (cur)
+}
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];   // 첫 번째 항목 앞에 home icon 자동 prefix
+}
+```
+
+스타일:
+- wrapper: `mx-auto max-w-[1180px] px-8 pt-[18px] flex items-center gap-2 font-mono text-[12px] text-[var(--color-fg-muted)]`
+- 각 link: `inline-flex items-center gap-1.5 px-2 py-1 rounded transition-colors hover:text-[var(--color-fg-primary)] hover:bg-[var(--color-bg-subtle)]`
+- 현재 페이지 (`href` 없음): `text-[var(--color-fg-primary)] pointer-events-none`
+- separator `/`: `text-[var(--color-fg-faint)] select-none`
+- home icon: lucide `Home` w-3 h-3, 첫 번째 항목 앞에 inline 표시
+
+### 4. `src/components/CategoryFeatured.tsx` 신규 (top-3 featured 카드)
+
+server component. props:
+
+```ts
+interface CategoryFeaturedProps {
+  category: CategoryData;
+  rank: number;           // 1, 2, 3
+  latestUpdatedAt: Date | null;
+}
+```
+
+레이아웃 (mockup `.cat-featured`):
+- 외곽: rounded-lg, border `--color-border-subtle`, **border-l 2px solid `var(--cat-color)`**, `min-h-[220px]`, `p-7 pb-6`
+- 배경: `linear-gradient(to bottom right, color-mix(in oklch, var(--cat-color), transparent 92%) 0%, transparent 60%)`, `var(--color-bg-elevated)` 위에 합성
+- inline style 로 `--cat-color: getCategoryColor(category.slug)` 주입
+- `rank` badge: `top-3.5 right-4 absolute font-mono text-[10px] tracking-[0.1em] text-[var(--color-fg-faint)]` — 표시는 `#01`, `#02`, `#03` (`String(rank).padStart(2,"0")`)
+- head row: 36px tinted icon (`bg: color-mix(--cat-color, transparent 88%)`, `border: 1px solid color-mix(--cat-color, transparent 70%)`, `text: var(--cat-color)`) + key (mono 10px uppercase tracking 0.1em, color `var(--cat-color)`)
+- icon source: `category.icon` (DB) — 기존 emoji icon 유지. lucide icon 매핑은 phase 03 에서 검토 (이번 phase 는 emoji 그대로)
+- h3: 22px font-semibold, tracking -0.018em, mt-1
+- desc: hidden (DB 에 description 컬럼 없음 — mockup 의 desc 는 hardcode). **이 phase 에서는 desc 영역을 생략**하고 h3 와 foot 사이 `flex-1` spacer 만 둠. 향후 컬럼 추가 시 채우기.
+- foot: `mt-auto pt-3 border-t border-[var(--color-border-subtle)]`, mono 11px
+  - 좌측 count: `text-[var(--color-fg-primary)] font-medium text-[16px]` + ` posts` mono 11px
+  - 우측 latest: mono 11px `text-[var(--color-fg-muted)]` + `· {relative}` `text-[var(--color-fg-secondary)]`. relative 표기는 `formatDistanceToNow` 직접 구현 (예: "3일 전", "1주 전") — `latestUpdatedAt` null 이면 `—`
+- hover: `hover:-translate-y-0.5 hover:border-[var(--cat-color)]` transition `transform 200ms cubic-bezier(0.22,1,0.36,1)`
+
+`href`: `/category/${encodeURIComponent(category.slug)}`. 외곽은 `<Link>` 로.
+
+**relative time helper**: 인라인 또는 `src/lib/time.ts` 신규 헬퍼:
+```ts
+export function formatRelativeKo(date: Date | null): string {
+  if (!date) return "—";
+  const now = Date.now();
+  const diff = now - date.getTime();
+  const day = 24 * 60 * 60 * 1000;
+  if (diff < 7 * day) return `${Math.max(1, Math.floor(diff / day))}일 전`;
+  if (diff < 30 * day) return `${Math.floor(diff / (7 * day))}주 전`;
+  if (diff < 365 * day) return `${Math.floor(diff / (30 * day))}개월 전`;
+  return `${Math.floor(diff / (365 * day))}년 전`;
+}
+```
+
+별도 파일로 두면 phase 02 의 SubfolderCard 등에서도 재사용 가능.
+
+### 5. `src/components/CategoryCard.tsx` 재구성 + `src/app/categories/page.tsx` 교체
+
+**5-A. `CategoryCard.tsx` 재구성**:
+
+기존 카드 (좌 2px line + icon + count + canonical key) 를 mockup `.cat-card` 톤으로 변경:
+- 외곽: rounded-lg, border, **border-l 2px solid var(--cat-color)**, `bg-[var(--color-bg-elevated)]`, `p-[22px] pb-5`, `flex flex-col gap-2`
+- head row: 28px tinted icon + key (mono 10px uppercase color cat-color, 우측 정렬)
+- h3: 17px font-semibold tracking -0.012em
+- foot: `mt-3.5 pt-3 border-t border-[var(--color-border-subtle)]`, mono 11px
+  - 좌: count `text-[var(--color-fg-primary)] font-medium text-[13px]` + ` posts` mono 11px
+  - 우: arrow `view <ArrowUpRight />` (lucide). hover 시 `gap` 4 → 8, `color: var(--cat-color)`
+- hover: `-translate-y-0.5`, border `var(--cat-color)`, `::after` radial gradient blob (`radial-gradient(60% 80% at 100% 0%, var(--cat-color), transparent 60%)`, `mix-blend-mode: screen`, dark mode 6%, light mode 8% — `light:` prefix 또는 CSS-in-JS).
+
+mix-blend-mode 는 inline style 로 처리하거나 `src/app/globals.css` 에 `.cat-card` `.cat-card::after` 규칙 추가. **권장: globals.css 에 helper class** (`.cat-card-blob` 같은) 추가 — Tailwind v4 의 inline arbitrary 로 표현 어려움 (mix-blend-mode + 가상 요소).
+
+`category.icon` (emoji) 그대로 사용. 외곽 `<Link>`.
+
+**5-B. `src/app/categories/page.tsx` 교체**:
+
+현재 구조 (단순 h1 + CategoryList) → 다음으로:
+
+```tsx
+<>
+  <Breadcrumb items={[{ label: "fos-blog", href: "/" }, { label: "categories" }]} />
+  <CategoriesSubHero
+    eyebrow="INDEX · CATEGORIES"
+    title="카테고리"
+    sublines={[
+      { num: categories.length, suffix: "개 주제" },
+      { num: totalCount, suffix: "개의 글" },
+      `updated ${formatYYYYMMDD(maxLatestUpdatedAt)}`,
+    ]}
+  />
+  <main className="mx-auto max-w-[1180px] px-8 py-12 pb-20">
+    <Section idx="01" title="Most active" meta="top 3 · 카테고리 전체 기준">
+      <div className="grid grid-cols-3 gap-3">
+        {top3.map((c, i) => (
+          <CategoryFeatured key={c.slug} category={c} rank={i + 1} latestUpdatedAt={c.latestUpdatedAt} />
+        ))}
+      </div>
+    </Section>
+    <Section idx="02" title="All categories" meta={`${rest.length} canonical · alphabetical`}>
+      <div className="grid grid-cols-3 gap-3">
+        {rest.map((c) => <CategoryCard key={c.slug} category={c} />)}
+      </div>
+    </Section>
+  </main>
+</>
+```
+
+`Section` 은 phase 내 inline helper 또는 별도 컴포넌트 (`src/components/CategoriesSection.tsx`):
+- head: `flex items-baseline justify-between mb-5 pb-3.5 border-b border-[var(--color-border-subtle)]`
+  - 좌: h2 18px font-semibold tracking -0.01em + `<span className="font-mono text-[11px] text-[var(--color-fg-faint)] tracking-[0.08em] font-normal mr-3">{idx}</span>`
+  - 우: meta mono 11px `text-[var(--color-fg-muted)]`
+
+**Q1 결정 적용**: top-3 = `categories.slice(0, 3)` (이미 postCount desc 정렬). "지난 30일" 윈도우는 도입 안 함 — section meta 문구도 `top 3 · 카테고리 전체 기준` 으로 mockup 의 "지난 30일" 은 변경.
+
+`maxLatestUpdatedAt = max(latestUpdatedAt) over categories` 로 sub-hero subline `updated YYYY.MM.DD` 계산.
+
+`/categories/page.tsx` 의 기존 `CategoryList` import 제거. 그러나 `CategoryList` 컴포넌트는 다른 곳에서 안 쓰면 phase 02 에서 정리 (이번 phase 는 안 건드림 — 변경 범위 최소화).
+
+---
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/infra/db/repositories/CategoryRepository.ts` | `getCategoriesWithLatest()` 추가 |
+| `src/lib/time.ts` | `formatRelativeKo`, `formatYYYYMMDD` 신규 |
+| `src/components/CategoriesSubHero.tsx` | 신규 |
+| `src/components/Breadcrumb.tsx` | 신규 — Categories + Detail 양쪽 사용 |
+| `src/components/CategoryFeatured.tsx` | 신규 |
+| `src/components/CategoryCard.tsx` | 재구성 (foot + hover blob + view arrow) |
+| `src/components/CategoriesSection.tsx` | 신규 — section head helper (idx + h2 + meta) |
+| `src/app/globals.css` | `.cat-card::after` radial blob 규칙 (mix-blend-mode + opacity transition) |
+| `src/app/categories/page.tsx` | 헤더 + 두 섹션 통합 |
+
+## 검증 (이 phase 한정)
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+
+# 신규 컴포넌트 토큰 사용 확인
+grep -n "var(--color-brand-400)" src/components/CategoriesSubHero.tsx
+grep -n "var(--cat-color)" src/components/CategoryFeatured.tsx
+grep -n "var(--cat-color)" src/components/CategoryCard.tsx
+
+# legacy 색 잔재 (Categories Index 한정)
+! grep -nE "text-gray-(900|500|400)|bg-gray-|text-blue-500" \
+    src/app/categories/page.tsx \
+    src/components/CategoriesSubHero.tsx \
+    src/components/CategoryFeatured.tsx \
+    src/components/CategoryCard.tsx \
+    src/components/CategoriesSection.tsx \
+    src/components/Breadcrumb.tsx
+```
+
+수동 smoke (`pnpm dev`):
+- `/categories` — eyebrow `INDEX · CATEGORIES` brand color, h1 "카테고리", subline mono `N 주제 · M 글 · updated YYYY.MM.DD`
+- top-3 카드: rank `#01/#02/#03` 우상단, cat-color tinted gradient bg, hover -2px lift
+- 6 카드 grid: hover 시 좌 border + 우상단 radial blob 약하게 표시, foot view ↗ 가 cat-color 로 변경
+- breadcrumb: home icon + `fos-blog / categories` (현재)
+- light/dark 양 모드 hover blob 차등 (dark `screen`, light `multiply`)
+
+## 의도 메모
+
+- **`getCategoriesWithLatest()` 신설** 이유: 기존 `getCategories()` 의 호출자(API route, sitemap 등) 영향 없이 페이지 단일 호출만 latest delta 가져오게. 한 번의 LEFT JOIN + GROUP BY 로 N+1 회피
+- **CategoryFeatured 와 CategoryCard 분리** 이유: featured 는 desc 자리 + rank + latest delta 가 추가, base card 와 정보 밀도/높이가 다름. 한 컴포넌트에 variant prop 으로 묶으면 분기 폭증
+- **mockup desc 미구현** 이유: DB 에 description 컬럼 없음. mockup 의 desc 는 mock data — 향후 컬럼 추가 또는 README 첫 단락 추출 시 채우기. 이 phase 에서 무리해 영입하지 않음
+- **mix-blend-mode 가상 요소를 globals.css 로 분리** 이유: Tailwind v4 의 inline arbitrary 로 `::after { mix-blend-mode: screen }` 표현 불가능. 한정된 helper class 한 개로 격리

--- a/tasks/plan015-categories-redesign/phase-02.md
+++ b/tasks/plan015-categories-redesign/phase-02.md
@@ -1,0 +1,266 @@
+# Phase 02 — CategoryDetailSubHero + SubfolderCard + PostListRow + ReadmeFrame + `/category/[...path]`
+
+**Model**: sonnet
+**Status**: pending
+
+---
+
+## 목표
+
+Claude Design 핸드오프 (`fos-blog/project/categories.{jsx,css}`) 의 **B 페이지 (`/category/[...path]` Detail)** 을 구현한다. tinted sub-hero (좌 2px cat-color + 5% gradient), README card frame, SubfolderCard (folder icon + name + count + optional path chip + ↗ arrow), PostListRow (60px num / 1fr title+excerpt / 90px date+time, hover cat-color 좌 border + 4% bg).
+
+기존 `/category/[...path]/page.tsx` 의 legacy `text-gray-*` / `bg-gray-*` / `bg-blue-100` 등은 모두 삭제. 새 컴포넌트로 전면 교체.
+
+---
+
+## 작업 항목 (5)
+
+### 1. `src/components/CategoryDetailSubHero.tsx` 신규
+
+phase 01 의 `CategoriesSubHero` 와 닮았지만 **tinted variant** 가 핵심. 별도 컴포넌트로 분리 (props 분기보다 명확):
+
+```ts
+interface CategoryDetailSubHeroProps {
+  eyebrow: string;            // 예: "JAVA · SPRING" — uppercase 처리 호출자가 미리
+  title: string;              // 예: "Spring"
+  sublines: ReadonlyArray<string | { num: string | number; suffix: string }>;
+  categorySlug: string;       // toCanonicalCategory 적용 후 cat-color hue 결정
+}
+```
+
+스타일:
+- 외곽 `<header>`: 같은 padding (`py-14 md:pt-14 md:pb-10`) + border-b
+- **추가**: `border-l-2 border-[var(--cat-color)]` + bg `linear-gradient(to right, color-mix(in oklch, var(--cat-color), transparent 95%) 0%, transparent 40%)` (inline style)
+- inline style: `--cat-color: getCategoryColor(categorySlug)`
+- inner wrapper: `mx-auto max-w-[1180px] px-8`
+- eyebrow: mono 11px uppercase tracking 0.08em **color `var(--cat-color)`** (brand 아님), `::before` 도 cat-color 1px×24px
+- h1: 동일 (clamp 36–52px, font-semibold, tracking -0.025em)
+- subline: 동일 패턴 (mono 13px, num 강조). 마지막 subline 은 path 표시 — `text-[var(--color-fg-faint)]` 톤 (예: `category/Java/Spring`)
+
+### 2. `src/components/SubfolderCard.tsx` 신규
+
+```ts
+interface SubfolderCardProps {
+  name: string;
+  href: string;
+  count?: number;             // 글 갯수 (선택)
+  pathChip?: string;          // nested 부모 경로 표시 (예: "Spring/Data")
+  categorySlug: string;
+}
+```
+
+레이아웃 (mockup `.sub-card`):
+- 외곽 `<Link>`: rounded-lg, border `--color-border-subtle`, **border-l-2 var(--cat-color)**, `bg-[var(--color-bg-elevated)]`, `p-[18px] pr-[16px] pb-4`, `flex items-start gap-3.5`, `relative overflow-hidden`
+- folder icon (좌측 36×36): bg `color-mix(--cat-color, transparent 90%)`, border `1px solid color-mix(--cat-color, transparent 75%)`, color `var(--cat-color)`, lucide `Folder` w-4 h-4, `rounded-md`, `grid place-items-center flex-none`
+- body (`flex-1 min-w-0`):
+  - path-chip (있을 때): mono 10px tracking 0.02em color `var(--color-fg-faint)` mb-1.5, span 내부 color `var(--color-fg-muted)`
+  - name: 15px font-semibold tracking -0.01em truncate text-`var(--color-fg-primary)` mb-1
+  - meta: mono 11px gap-2 items-center, `n` (count) `text-[var(--color-fg-primary)] font-medium` + ` posts` `text-[var(--color-fg-muted)]`. pathChip 있으면 ` · nested` 추가 (sep `text-[var(--color-fg-faint)]`)
+- arrow (절대 우상단): `top-[18px] right-4 absolute color-[var(--color-fg-faint)]`, lucide `ArrowUpRight` w-3.5 h-3.5
+- hover: `-translate-y-0.5 border-[var(--cat-color)]`, arrow `text-[var(--cat-color)] translate-x-0.5 -translate-y-0.5`, transition `transform 200ms cubic-bezier(0.22,1,0.36,1) + border-color 150ms`
+
+inline style 로 `--cat-color: getCategoryColor(categorySlug)`.
+
+### 3. `src/components/PostListRow.tsx` 신규
+
+mockup `.post-list-row`. server component, `<Link>` 외곽:
+
+```ts
+interface PostListRowProps {
+  index: number;            // 1-based, "001" 패딩
+  title: string;
+  excerpt: string;
+  href: string;
+  updatedAt: Date;
+  readingMinutes?: number;  // 없으면 표시 생략
+  categorySlug: string;     // hover 좌 border 색
+}
+```
+
+레이아웃:
+- 외곽 wrapper (`<div className="post-list-rows">` 가 부모, 각 row 는 `<Link>`):
+  - parent `border-t border-[var(--color-border-subtle)]` (첫 row 위)
+  - row: `grid grid-cols-[60px_1fr_90px] gap-6 py-4.5 pl-4 border-b border-[var(--color-border-subtle)] items-center cursor-pointer relative border-l-2 border-l-transparent transition-[border-left-color,background] duration-150`
+- 컬럼 1 num: mono 11px tracking 0.04em `text-[var(--color-fg-faint)]` — 표시 `— 001` (`String(index).padStart(3,"0")`)
+- 컬럼 2 본문:
+  - title: 15px font-medium tracking -0.01em `text-[var(--color-fg-primary)]` line-height 1.4 mb-1
+  - excerpt: 13px `text-[var(--color-fg-secondary)]` line-clamp-1
+- 컬럼 3 meta: mono 11px right-aligned `text-[var(--color-fg-muted)]`, 두 줄 — `formatYYYYMMDD(updatedAt)` + `<br/>` + `${readingMinutes} min` (없으면 day diff `formatRelativeKo`)
+- hover: `border-l-[var(--cat-color)]`, bg `color-mix(in oklch, var(--cat-color), transparent 96%)` — inline style 또는 globals.css 의 `.post-list-row:hover` 규칙
+
+`<Link href={...} className="post-list-row" style={{ "--cat-color": ... }}>` 패턴.
+
+`readingMinutes` 는 phase 02 에서는 옵셔널 (DB 에 없음). 표시 안 되면 단순 `formatRelativeKo(updatedAt)` 만 두 번째 줄에 표시.
+
+### 4. `src/components/ReadmeFrame.tsx` 신규
+
+mockup `.readme` 의 **frame 만**. 본문 마크다운은 기존 `MarkdownRenderer` 가 렌더 — frame 이 wrapping.
+
+```ts
+interface ReadmeFrameProps {
+  filename?: string;        // default "README"
+  ext?: string;             // default ".md"
+  categorySlug: string;
+  children: ReactNode;       // MarkdownRenderer 결과
+}
+```
+
+스타일:
+- 외곽: rounded-lg border `--color-border-subtle` `bg-[var(--color-bg-elevated)] overflow-hidden`
+- inline style: `--cat-color`
+- head: `flex items-center gap-2.5 px-[18px] py-3 border-b border-[var(--color-border-subtle)] bg-[color-mix(in_oklch,var(--color-bg-subtle),transparent_50%)]`, mono 12px
+  - file: `text-[var(--color-fg-secondary)]`
+  - ext: `text-[var(--color-fg-faint)] -ml-1`
+  - **last edited 우측 정렬은 Q3=제거 결정대로 표시 안 함**
+- body wrapper: `px-7 py-7` (이미 MarkdownRenderer 가 prose-* 적용 — body 안에 별도 prose 적용 X)
+
+mockup 의 `code` chip color `var(--cat-color)` 는 prose 의 `code` 를 cat-color 로 override 하기 위해 inline style 로 `--tw-prose-code: var(--cat-color)` 추가하거나 wrapper `:where(code):not(:where([class~="not-prose"] *))` CSS rule. **간단 처리**: ReadmeFrame body 의 직속 wrapper 에 inline style `[& code]:text-[var(--cat-color)]` 를 Tailwind v4 arbitrary 로 적용 (불가능 시 globals.css `.readme-body :where(code) { color: var(--cat-color); }` 추가).
+
+### 5. `src/app/category/[...path]/page.tsx` 전면 교체
+
+기존 (legacy gray-* / blue-100 / Folder w-12 lazy 카드) 모두 삭제 후:
+
+```tsx
+<>
+  <BreadcrumbJsonLd items={...} />  {/* 기존 SEO 그대로 */}
+  <Breadcrumb
+    items={[
+      { label: "fos-blog", href: "/" },
+      { label: "categories", href: "/categories" },
+      ...pathSegments.map((seg, i) => ({
+        label: seg,
+        href: i === pathSegments.length - 1 ? undefined : `/category/${...slice(0,i+1)...}`,
+      })),
+    ]}
+  />
+  <CategoryDetailSubHero
+    eyebrow={pathSegments.map(s => s.toUpperCase()).join(" · ")}
+    title={currentFolder}
+    sublines={[
+      ...(folders.length > 0 ? [{ num: folders.length, suffix: "폴더" }] : []),
+      ...(posts.length > 0 ? [{ num: posts.length, suffix: "글" }] : []),
+      `category/${pathSegments.join("/")}`,
+    ]}
+    categorySlug={category}
+  />
+  <main className="mx-auto max-w-[1180px] px-8 py-12 pb-20 space-y-14">
+    {readme && (
+      <CategoriesSection idx="README" title={`${currentFolder} 시리즈에 대하여`} meta="README.md">
+        <ReadmeFrame categorySlug={category}>
+          <MarkdownRenderer
+            content={stripLeadingH1(parseFrontMatter(readme).content)}
+            basePath={`${folderPath}/README`}
+          />
+        </ReadmeFrame>
+      </CategoriesSection>
+    )}
+    {folders.length > 0 && (
+      <CategoriesSection idx="01" title="하위 폴더" meta={`${folders.length} folders`}>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {folders.map((f) => (
+            <SubfolderCard
+              key={f.path}
+              name={f.name}
+              href={`/category/${f.path.split("/").map(encodeURIComponent).join("/")}`}
+              count={f.count}
+              pathChip={
+                f.path.split("/").length > pathSegments.length + 1
+                  ? f.path.split("/").slice(0, -1).join("/")
+                  : undefined
+              }
+              categorySlug={category}
+            />
+          ))}
+        </div>
+      </CategoriesSection>
+    )}
+    {posts.length > 0 && (
+      <CategoriesSection idx="02" title="이 폴더의 글" meta={`${posts.length} posts`}>
+        <div className="post-list-rows" style={{ "--cat-color": getCategoryColor(category) } as CSSProperties}>
+          {posts.map((p, i) => (
+            <PostListRow
+              key={p.path}
+              index={i + 1}
+              title={p.title}
+              excerpt={p.excerpt ?? ""}
+              href={`/posts/${encodeURIComponent(p.path)}`}
+              updatedAt={p.updatedAt}
+              categorySlug={category}
+            />
+          ))}
+        </div>
+      </CategoriesSection>
+    )}
+  </main>
+</>
+```
+
+기존 `<header>` (이모지 + h1 + subtitle), 기존 `상위 폴더로` 링크, 기존 README 카드 (`bg-white dark:bg-gray-800`) 모두 삭제. Breadcrumb 가 nav 역할 일원화.
+
+`PostCard` import 제거 (이 페이지에서 더이상 사용 안 함). `Link` / `ArrowLeft` / `Home` / `Folder` / `BookOpen` lucide import 정리 — Breadcrumb / SubfolderCard 내부로 이동.
+
+`getCategoryColor` import: `@/lib/category-meta`.
+
+mockup 의 `post-list-rows` hover 효과 (`border-l-color`, `bg color-mix`) 는 `src/app/globals.css` 에 다음 추가:
+
+```css
+.post-list-row {
+  /* hover 효과만 — 그 외 클래스는 Tailwind */
+}
+.post-list-row:hover {
+  border-left-color: var(--cat-color);
+  background: color-mix(in oklch, var(--cat-color), transparent 96%);
+}
+```
+
+(Tailwind arbitrary 로 `hover:bg-[color-mix(...)]` 가능하지만 가독성 떨어짐 — globals.css 한 블록 권장.)
+
+---
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/components/CategoryDetailSubHero.tsx` | 신규 — tinted variant |
+| `src/components/SubfolderCard.tsx` | 신규 — folder icon + path chip + ↗ |
+| `src/components/PostListRow.tsx` | 신규 — 60/1fr/90 grid row |
+| `src/components/ReadmeFrame.tsx` | 신규 — file/ext head + body wrapper |
+| `src/app/category/[...path]/page.tsx` | 전면 교체 |
+| `src/app/globals.css` | `.post-list-row:hover` cat-color border + bg |
+| `src/components/MarkdownRenderer.regression-1.test.ts` | (영향 시) 카테고리 페이지 README 렌더 회귀 — 영향 없음 예상 |
+
+## 검증
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+
+# legacy 잔재 (Category Detail 한정)
+! grep -nE "text-gray-(900|700|500|400)|bg-gray-(100|200|800)|bg-blue-(100|500)|text-blue-400|bg-white" \
+    src/app/category/[...path]/page.tsx \
+    src/components/CategoryDetailSubHero.tsx \
+    src/components/SubfolderCard.tsx \
+    src/components/PostListRow.tsx \
+    src/components/ReadmeFrame.tsx
+
+# 신규 컴포넌트 토큰 사용
+grep -n "var(--cat-color)" src/components/SubfolderCard.tsx
+grep -n "var(--cat-color)" src/components/PostListRow.tsx
+grep -n "var(--cat-color)" src/components/CategoryDetailSubHero.tsx
+```
+
+수동 smoke (`pnpm dev`):
+- `/category/Java` (1단 깊이) — eyebrow `JAVA` cat-color, h1 "Java", sub-hero 좌 border + 5% gradient bg
+- `/category/Java/Spring` (2단) — eyebrow `JAVA · SPRING`, breadcrumb `fos-blog / categories / Java / Spring`
+- README 카드: head `README` + `.md` faint, body code chip cat-color, 마크다운 본문 정상 렌더
+- 하위 폴더 카드: hover 시 -2px lift + border cat-color + arrow translate
+- PostListRow: hover 시 좌 border cat-color + bg 4% mix, 컬럼 정렬 (num / title+excerpt / date+min)
+- 다크/라이트 양 모드
+
+## 의도 메모
+
+- **CategoryDetailSubHero 분리** 이유: tinted variant 가 base sub-hero 와 시각 차이 큼 (border + gradient). props 분기보다 두 컴포넌트가 명확. 향후 다른 페이지에서 base sub-hero 만 가져다 쓸 때도 깔끔
+- **PostListRow 신규** 이유: PostCard 와 정보 밀도/레이아웃이 다름 (3-컬럼 grid + num enumerate + cat-color hover). 카테고리 detail 전용 — 인덱스 (`/posts/latest`) 는 plan016 이 PostCard 그대로
+- **path chip** 적용 조건: subfolder 의 `path` 깊이 가 현재 pathSegments + 1 보다 크면 (즉 grandchild 가 직접 노출되는 경우만) 표시. 일반 1단 깊이 자식엔 chip 미표시
+- **mockup 의 desc 미구현** 은 phase 01 와 동일 사유 (DB 컬럼 없음)

--- a/tasks/plan015-categories-redesign/phase-03.md
+++ b/tasks/plan015-categories-redesign/phase-03.md
@@ -1,0 +1,96 @@
+# Phase 03 — 통합 검증 + legacy 잔재 grep + Lighthouse smoke
+
+**Model**: haiku
+**Status**: pending
+
+---
+
+## 목표
+
+phase 01 + 02 의 통합 점검. 기계적 검증 위주 — 새 코드 추가 없음.
+
+---
+
+## 작업 항목 (3)
+
+### 1. legacy Tailwind 잔재 grep + 빌드 검증
+
+```bash
+# Categories 영역 전체에 legacy gray-* / blue-* 잔재 없음
+! grep -rnE "text-gray-(900|700|500|400)|bg-gray-(100|200|800)|bg-blue-(100|500)|text-blue-(400|500|600)|bg-white(?! /)" \
+    src/app/categories/ \
+    src/app/category/ \
+    src/components/Categor* \
+    src/components/Breadcrumb.tsx \
+    src/components/SubfolderCard.tsx \
+    src/components/PostListRow.tsx \
+    src/components/ReadmeFrame.tsx
+
+# 기존 CategoryList.tsx 가 어디서도 import 되지 않으면 삭제
+grep -rn "from \"@/components/CategoryList\"\|from \"./CategoryList\"" src/ ; echo "exit=$?"
+# exit=1 (no match) 면 src/components/CategoryList.tsx 삭제
+
+# 빌드
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+```
+
+`pnpm build` 결과:
+- 빌드 산출물에 신규 카테고리 컴포넌트 포함:
+  ```bash
+  grep -rE "CategoriesSubHero|CategoryDetailSubHero|SubfolderCard|PostListRow|ReadmeFrame" .next/server/app/categor* 2>/dev/null | head -3
+  ```
+- `.next` 빌드 시 chunk 사이즈 회귀 없음 (홈 페이지 first-load JS 가 plan013 베이스라인 ±5KB)
+
+### 2. 수동 smoke + Lighthouse
+
+`pnpm dev` 로:
+
+- `/categories` 인덱스
+  - top-3 featured 카드: 실제 DB 의 postCount desc 정렬 — 데이터 비어있으면 sublines `0 주제 / 0 글` 표시 (graceful)
+  - 6 (또는 N-3) 일반 카드 grid
+  - hover blob radial gradient — light/dark 모두 옅게
+  - breadcrumb home icon 표시
+- `/category/Java` (1단)
+  - eyebrow `JAVA`, sub-hero tinted (좌 border + 5% gradient)
+  - sub-hero subline `N 폴더 · M 글 · category/Java`
+  - 하위 폴더 / 글 섹션
+- `/category/Java/Spring` (2단)
+  - eyebrow `JAVA · SPRING`
+  - breadcrumb 4단 chain
+  - 만약 README 가 있으면 ReadmeFrame 렌더, 없으면 섹션 자체 노출 안 됨
+  - PostListRow hover 좌 border + bg cat-color 4%
+- 다크/라이트 토글 양 모드 동작
+- 모바일 (DevTools 375px): 폴더/카테고리 grid 1-col
+
+**Lighthouse 자동 검증**: `.github/workflows/lighthouse.yml` CI 가 PR 단위 실행. Performance ≥ 90, Accessibility ≥ 95 임계 자동 차단 (ADR-017 합의).
+
+### 3. SEO + JSON-LD 회귀 점검
+
+`/category/[...path]` 의 기존 `BreadcrumbJsonLd` 가 그대로 동작하는지 view-source 로 확인. 새 Breadcrumb 컴포넌트는 시각 표시만, JSON-LD 는 별도 — 영향 없음 예상이지만 phase 02 변경 후 누락 가능성 차단.
+
+```bash
+# 빌드 산출물에 JSON-LD 포함
+grep -rE "@context.*schema.org.*BreadcrumbList" .next/server/app/category/ 2>/dev/null | head -1
+```
+
+`/categories` 인덱스 페이지의 기존 metadata (canonical, og:image) 도 그대로 유지 확인 — phase 01 에서 metadata export 안 건드림.
+
+---
+
+## Critical Files
+
+이 phase 는 코드 변경 없음. 검증 + 잔재 정리만:
+- 기존 `src/components/CategoryList.tsx` — 사용처 없으면 삭제 후 commit (atomic)
+- 기존 `src/app/categories/opengraph-image.tsx` — 그대로 유지
+
+## 검증
+
+위 1~3 모두 통과해야 plan 완료. Lighthouse 점수 회귀 시 phase 01/02 로 회귀 — 관련 컴포넌트 (radial blob, gradient bg) 가 paint cost 큰 후보.
+
+## 의도 메모
+
+- **별도 phase 분리** 이유: phase 01/02 가 컴포넌트 + 페이지 변경으로 작업 항목 5개 한도 근접. 검증 + 잔재 정리는 모델·시간 절약 위해 haiku 로 분리
+- **CategoryList 삭제** 이유: phase 01 에서 `/categories/page.tsx` 가 더이상 import 안 함. 다른 사용처 없으면 dead code — atomic commit 으로 정리


### PR DESCRIPTION
## Summary
- plan015 task 파일 추가 — Claude Design 핸드오프 (\`h/SvcdB2wohXQWj4xRJAdUZA\`) 기반 \`/categories\` 인덱스 + \`/category/[...path]\` 상세 리디자인
- 3 phase 분해: ① Sub-hero + Breadcrumb + CategoryFeatured + CategoryCard 재구성 + 인덱스 페이지 (sonnet), ② tinted Sub-hero + SubfolderCard + PostListRow + ReadmeFrame + 상세 페이지 (sonnet), ③ 잔재 grep + Lighthouse + JSON-LD (haiku)
- 신규 토큰 추가 없음 — plan009 의 \`--color-cat-*\` + bg/fg/border 만 사용
- 의존: plan009 + plan010 + plan013 (모두 머지됨)

## Decisions (사용자 사전 합의)
- Q1=a: top-3 = postCount desc 단순 정렬, latest delta 는 카테고리 max(updatedAt) 기반 \"X일 전\" — 30일 윈도우 미적용
- Q2=a: PostListRow num 은 배열 순서 (\`— 001\`)
- Q3=제거: README head 의 \`last edited\` 미표시 (file/ext 만)
- Q4=a: 3 phase 분해 (페이지별 atomic)

## Out of scope (다음)
- mockup 의 desc 컬럼 (DB 미존재) — README 첫 단락 추출은 별도 plan
- 코드 구문 강조 누락 진단 — 별도 후속 (plan017 후보)

## Test plan
- [ ] task 파일 자체 (build-with-teams 실행은 별도 trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)