### PR TITLE
fix(blog): repair shiki syntax highlighting on code blocks (plan017)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -359,7 +359,7 @@
 
 **Decision**:
 
-- **`rehype-pretty-code` (shiki 기반)** 채택. dual theme `{ light: "github-light", dark: "github-dark" }` 구성 → CSS variable (`--shiki-light` / `--shiki-dark`) 기반 토글 한 줄 (`html.dark .shiki { color: var(--shiki-dark); }`) 로 다크/라이트 전환
+- **`rehype-pretty-code` (shiki 기반)** 채택. dual theme `{ light: "github-light", dark: "github-dark" }` 구성 → CSS variable (`--shiki-light` / `--shiki-dark`) 기반 토글 한 줄 (`html.dark .code-card-body pre span { color: var(--shiki-dark); }`) 로 다크/라이트 전환. **셀렉터 주의 (plan017)**: rehype-pretty-code v14 는 `.shiki` className 을 부여하지 않으므로 `.shiki` 셀렉터는 매칭 실패 → `.code-card-body pre span` 으로 토큰 span 직접 타깃. `unified-pipeline.test.ts` 가 이 계약 (className 부재 + `--shiki-light`/`--shiki-dark` 변수 보유) 을 회귀 테스트로 고정
 - **`figure data-rehype-pretty-code-figure` 출력 구조 활용**: react-markdown `components.figure` 핸들러가 figure 를 받아 신규 `<CodeCard>` (client wrapper, copy 버튼) 로 교체. filename 은 자식 figcaption.textContent, language 는 자식 code.data-language 에서 추출 (헬퍼 `findChildText` / `findCodeProp` 을 `src/lib/markdown.ts` 에 신설)
 - **mermaid 우회**: pretty-code Options 에 `filter` 가 없어 (fictional API), `data-language === "mermaid"` 검사로 우회. `components.figure` / `isMermaidPreNode()` 모두 `data-language` 기반 분기 + 기존 className 기반 검사 (legacy 호환) 동시 지원
 - **`bypassInlineCode: true`**: plan011 의 `.prose :not(pre) > code` 인라인 룰 보존. inline code 는 shiki 처리 skip

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -285,6 +285,8 @@ code, kbd, samp, pre {
   padding: 16px 20px;
   background: transparent !important; /* keepBackground:false 와 결합 */
   border: none !important;
+  /* fallback color — shiki 가 처리하지 못한 영역 (data-line 외부, plain text 등).
+   * 토큰 span 은 아래 .code-card-body pre span 규칙이 var(--shiki-{light|dark}) 로 override. */
   color: var(--color-fg-secondary);
 }
 
@@ -354,16 +356,14 @@ code, kbd, samp, pre {
   margin-right: 1ch;
 }
 
-/* shiki dual theme — html.dark 클래스 기반 토글 */
-html.dark .shiki,
-html.dark .shiki span {
-  color: var(--shiki-dark) !important;
-  background-color: var(--shiki-dark-bg) !important;
+/* shiki dual theme — rehype-pretty-code v14 는 .shiki className 부여하지 않으므로
+ * .code-card-body 의 pre/code 후손 span 을 직접 타깃. html.dark 클래스로 토글.
+ * keepBackground: false 와 결합되어 background-color 는 부모 (.code-card-body pre) 가 담당. */
+html.dark .code-card-body pre span {
+  color: var(--shiki-dark);
 }
-html:not(.dark) .shiki,
-html:not(.dark) .shiki span {
-  color: var(--shiki-light) !important;
-  background-color: var(--shiki-light-bg) !important;
+html:not(.dark) .code-card-body pre span {
+  color: var(--shiki-light);
 }
 
 /* Custom scrollbar */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -358,11 +358,12 @@ code, kbd, samp, pre {
 
 /* shiki dual theme — rehype-pretty-code v14 는 .shiki className 부여하지 않으므로
  * .code-card-body 의 pre/code 후손 span 을 직접 타깃. html.dark 클래스로 토글.
- * keepBackground: false 와 결합되어 background-color 는 부모 (.code-card-body pre) 가 담당. */
-html.dark .code-card-body pre span {
+ * keepBackground: false 와 결합되어 background-color 는 부모 (.code-card-body pre) 가 담당.
+ * .prose 스코프는 다른 .code-card-body 규칙과 일관성 유지 — markdown 렌더러 외부 사용 시 의도치 않은 적용 차단. */
+html.dark .prose .code-card-body pre span {
   color: var(--shiki-dark);
 }
-html:not(.dark) .code-card-body pre span {
+html:not(.dark) .prose .code-card-body pre span {
   color: var(--shiki-light);
 }
 

--- a/src/components/markdown/unified-pipeline.test.ts
+++ b/src/components/markdown/unified-pipeline.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+
+// vitest node 환경에서 server-only 가드 우회
+vi.mock("server-only", () => ({}));
+
+import type { Root, Element, RootContent } from "hast";
+import { parseMarkdownToHast } from "./unified-pipeline";
+
+// hast 트리 탐색 헬퍼 — RootContent 는 ElementContent | Doctype 의 상위 집합
+// Root.children: RootContent[], Element.children: ElementContent[] — 공통 상위 타입으로 통일
+function isElement(node: RootContent): node is Element {
+  return node.type === "element";
+}
+function findChildElement(parent: Element | Root, tagName: string): Element | undefined {
+  return (parent.children as RootContent[]).find(
+    (c): c is Element => isElement(c) && c.tagName === tagName,
+  );
+}
+
+describe("rehype-pretty-code output structure (regression guard for plan017)", () => {
+  it("produces span tokens with --shiki-light + --shiki-dark CSS variables", async () => {
+    const tree: Root = await parseMarkdownToHast("```ts\nconst x = 42;\n```");
+
+    // figure > pre > code > span[data-line] > span[style="--shiki-..."]
+    const figure = findChildElement(tree, "figure");
+    expect(figure?.properties?.["data-rehype-pretty-code-figure"]).toBeDefined();
+    if (!figure) throw new Error("figure missing");
+
+    const pre = findChildElement(figure, "pre");
+    expect(pre?.properties?.["data-language"]).toBe("ts");
+    expect(String(pre?.properties?.["data-theme"] ?? "")).toContain("github-light");
+    expect(String(pre?.properties?.["data-theme"] ?? "")).toContain("github-dark");
+    if (!pre) throw new Error("pre missing");
+
+    const code = findChildElement(pre, "code");
+    if (!code) throw new Error("code missing");
+    const lineSpan = code.children.find(
+      (c): c is Element =>
+        isElement(c) && c.tagName === "span" && c.properties?.["data-line"] !== undefined,
+    );
+    expect(lineSpan).toBeDefined();
+    if (!lineSpan) throw new Error("lineSpan missing");
+
+    // 토큰 span 들이 --shiki-light + --shiki-dark CSS 변수를 inline style 로 보유
+    const tokenSpans = lineSpan.children.filter(
+      (c): c is Element => isElement(c) && c.tagName === "span",
+    );
+    expect(tokenSpans.length).toBeGreaterThan(0);
+    const styleStrs = tokenSpans.map((s) => String(s.properties?.style ?? ""));
+    expect(styleStrs.some((s) => s.includes("--shiki-light"))).toBe(true);
+    expect(styleStrs.some((s) => s.includes("--shiki-dark"))).toBe(true);
+  });
+
+  it("does NOT add .shiki className (selector contract held by globals.css)", async () => {
+    const tree: Root = await parseMarkdownToHast("```ts\nconst x = 42;\n```");
+    const figure = findChildElement(tree, "figure");
+    if (!figure) throw new Error("figure missing");
+    const pre = findChildElement(figure, "pre");
+
+    // .shiki className 부재가 globals.css 의 .code-card-body pre span 셀렉터 선택의 근거.
+    // 이게 깨지면 (= rehype-pretty-code 가 .shiki 부여하기 시작하면) globals.css 도 다시 검토 필요.
+    // hast Properties.className 은 string[] | string | number 가능 — Array.isArray 가드로 안전 검증.
+    const rawClassName = pre?.properties?.className;
+    const className = Array.isArray(rawClassName) ? rawClassName : [];
+    expect(className).not.toContain("shiki");
+  });
+});

--- a/src/components/markdown/unified-pipeline.test.ts
+++ b/src/components/markdown/unified-pipeline.test.ts
@@ -6,8 +6,9 @@ vi.mock("server-only", () => ({}));
 import type { Root, Element, RootContent } from "hast";
 import { parseMarkdownToHast } from "./unified-pipeline";
 
-// hast 트리 탐색 헬퍼 — RootContent 는 ElementContent | Doctype 의 상위 집합
-// Root.children: RootContent[], Element.children: ElementContent[] — 공통 상위 타입으로 통일
+// hast 트리 탐색 헬퍼 — Element.children(ElementContent[]) ⊂ RootContent[]
+// 이므로 widening cast 안전. parent가 Element | Root 유니온일 때 .children
+// 추론이 ElementContent[] | RootContent[] 로 갈라져 직접 .find() 불가 → 단언 필요.
 function isElement(node: RootContent): node is Element {
   return node.type === "element";
 }

--- a/tasks/plan017-syntax-highlight-fix/index.json
+++ b/tasks/plan017-syntax-highlight-fix/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan017-syntax-highlight-fix",
   "description": "코드 블록 syntax highlighting 누락 수정 — globals.css 의 .shiki 셀렉터가 rehype-pretty-code v14 의 실제 출력 (className 부재 + data-theme 속성) 과 매칭 실패. .code-card-body pre span 으로 셀렉터 교체 + 회귀 테스트로 재발 차단.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-04-28",
   "total_phases": 2,
   "related_docs": [
@@ -16,14 +16,14 @@
       "file": "phase-01.md",
       "title": "globals.css shiki 셀렉터 교체 + 색상 회귀 테스트 추가",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "통합 검증 + Lighthouse smoke + index.json status=completed",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `globals.css` 의 dual theme 셀렉터가 rehype-pretty-code v14 의 실제 출력 (`.shiki` className 미부여 + `--shiki-light/dark` CSS 변수 inline) 과 매칭 실패해 코드 블록 토큰이 단색으로 보이던 문제 수정. `.code-card-body pre span` 으로 토큰 span 직접 타깃 + specificity 자연 우선으로 `!important` 제거
- 회귀 테스트 2건 추가 (`unified-pipeline.test.ts`) — `--shiki-light`/`--shiki-dark` 변수 존재 + `.shiki` className 부재 계약을 고정해 라이브러리 업데이트로 출력 구조가 바뀌면 즉시 빨갛게 표시
- `docs/adr.md` ADR-019 의 dead `.shiki` 셀렉터 예시 교정 + plan017 컨텍스트 한 줄 추가

## Test plan

- [x] `pnpm lint` pass
- [x] `pnpm type-check` pass
- [x] `pnpm test --run` pass (206 tests, 회귀 테스트 2건 포함)
- [x] `pnpm build` 성공 + 빌드 산출물 grep 검증 (`.code-card-body pre span` 포함, `html.dark .shiki` 부재)
- [ ] 머지 후 production smoke: 다크/라이트 모드 코드 블록 색상 확인

## Build

- 통합 검증 (lint/type-check/test/build) 모두 plan017 변경 파일 기준으로 PASS. 외부 의존 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)