### PR TITLE
fix(css): Tailwind v4 JSDoc 코멘트 스캔으로 인한 CSS parse error

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,11 @@
 @import "tailwindcss";
 @source "./app/**/*.{ts,tsx}";
 @source "../components/**/*.{ts,tsx}";
+/* tasks/*.md 의 코드 예시 (예: text-[var(--color-cat-*)]) 가 default scan 에 잡혀
+ * 잘못된 와일드카드 클래스를 생성 → CSS parse error. tasks/, docs/, .claude/ 는 모두 제외. */
+@source not "../../tasks/**";
+@source not "../../docs/**";
+@source not "../../.claude/**";
 
 /* dark: prefix를 미디어쿼리가 아닌 .dark class 기반으로 동작하게 설정 */
 @variant dark (&:where(.dark, .dark *));

--- a/src/lib/category-meta.ts
+++ b/src/lib/category-meta.ts
@@ -43,7 +43,7 @@ export function toCanonicalCategory(raw: string): CanonicalCategory {
 
 /**
  * canonical 에서 oklch hue (degrees) 로 매핑.
- * Round 2 mockup 의 POSTS 데이터 hue 와 일치 — 토큰의 `--color-cat-*` 와도 일치.
+ * Round 2 mockup 의 POSTS 데이터 hue 와 일치 — 토큰의 color-cat 토큰 (canonical key 별) 와도 일치.
  */
 const CANONICAL_TO_HUE: Record<CanonicalCategory, number> = {
   ai: 285,
@@ -70,7 +70,9 @@ export function getCategoryColor(raw: string): string {
 }
 
 /**
- * Tailwind 클래스로 `text-[var(--color-cat-*)]` 를 쓰고 싶을 때 토큰 var 이름 반환.
+ * Tailwind arbitrary class 에서 토큰 참조 시 사용 (canonical 9개에 한해 토큰 존재).
+ * 주의: 이 주석에 Tailwind 클래스처럼 보이는 패턴 (대괄호, 별표, 중괄호) 을 쓰지 말 것.
+ * Tailwind v4 content scanner 가 클래스 후보로 추출해서 globals.css parse error 발생.
  * (canonical 9개에 한해 토큰 존재)
  */
 export function getCategoryTokenVar(raw: string): string {


### PR DESCRIPTION
## Summary
- \`src/lib/category-meta.ts\` 의 JSDoc 코멘트에 \`text-[var(--color-cat-*)]\` 같은 Tailwind 클래스처럼 보이는 예시 문자열이 있었는데, Tailwind v4 content scanner 가 코멘트 내부까지 스캔 → \`*\` / \`{key}\` 를 클래스 후보로 추출 → 잘못된 와일드카드 CSS 규칙 → globals.css parse error → 모든 페이지 500
- 코멘트에서 클래스 패턴 (대괄호 / 별표 / 중괄호) 제거 + globals.css 에 \`@source not\` defense-in-depth 추가

## Test plan
- [x] \`pnpm dev\` 후 \`/\` 200 OK + 페이지 정상 렌더 확인
- [x] \`pnpm lint && pnpm type-check\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)