### PR TITLE
chore(skills): import plan-and-build skill from webtoon-maker-v1

### DIFF
--- a/.claude/skills/plan-and-build/SKILL.md
+++ b/.claude/skills/plan-and-build/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: plan-and-build
+description: AI 에이전트 하네스를 사용한 대규모 구현 자동화. 논의 → 계획 → task 생성 → 순차 실행. 새 기능 추가, 리팩토링 등 multi-phase 작업에 사용.
+---
+
+# plan-and-build
+
+새 기능이나 대규모 변경을 phase 단위로 분리하고, `run-phases.py` 하네스를 통해 Claude Code가 자동으로 순차 실행하는 시스템.
+
+## 핵심 원칙 — 사용자에게 묻지 말고 자동으로 따를 것
+
+**모든 작업은 반드시 이 순서를 자동으로 따른다. 사용자가 매번 지시하지 않아도 된다:**
+
+1. 논의가 필요하면 먼저 논의
+2. **docs 반영 + 커밋** (task 생성 전 필수, 건너뛰기 금지)
+3. **task 파일 생성 + 커밋** (실행 전 필수)
+4. task 실행
+5. 완료 후 검증
+
+이 순서를 어기면 안 된다. "docs 반영해줘", "task 생성해줘"를 사용자가 반복 요청할 필요 없다.
+
+## 실행 절차
+
+### 1. 문서 파악
+
+`docs/` 하위 문서들을 읽어 프로젝트 기획·아키텍처·설계 의도를 파악한다.
+필요 시 여러 Explore 에이전트를 병렬로 사용한다.
+
+참조 문서:
+
+- `docs/prd.md` — 제품 범위, MVP 기능 명세
+- `docs/data-schema.md` — DB 스키마, 테이블 관계, Json 구조 명세
+- `docs/flow.md` — 사용자 플로우, 화면 레이아웃
+- `docs/code-architecture.md` — 디렉터리 구조, 레이어 (app → services → infra), API 전략
+- `docs/adr.md` — 기술 결정 기록
+- `CLAUDE.md` — 코딩 규칙, 금지사항
+
+### 2. 논의
+
+구체화가 필요한 점, 기술적으로 논의할 점을 사용자에게 제시한다.
+사용자가 충분히 논의됐다고 판단하면 3단계로 넘어간다.
+
+### 2.5. docs 최신화 + 커밋 (task 생성 전 필수)
+
+논의 결과를 반드시 **task 생성 전에** docs에 반영한다. task 내부(phase)에서는 docs를 수정하지 않는다.
+
+- `docs/adr.md` — 새 의사결정 기록 (ADR 추가)
+- `docs/data-schema.md` — 스키마 변경 반영
+- `docs/flow.md` — 플로우 변경 반영
+- `docs/code-architecture.md` — 디렉터리/파이프라인 변경 반영
+
+**순서**: docs 최신화 → **docs 별도 커밋 + push** → task 생성 → task 실행.
+
+**docs-first 커밋 원칙**:
+- docs 변경사항을 먼저 단독 커밋 (`📝 docs: ...` 또는 `docs: ...`)
+- 그 후 task 파일 생성 및 실행
+- 장점: task 실패 시에도 docs는 main에 남아있음, task 커밋과 분리되어 history 명확
+
+### 3. 구현 계획 초안
+
+`.claude/skills/planning/task-create.md`를 정확히 숙지한 후, 다음을 포함한 초안을 작성한다:
+
+- phase별 분리 이유와 작업 목록
+- 성공 기준 (실행 가능한 명령어)
+- 논의 필요한 사항
+
+사용자 피드백을 받아 계획을 확정한다.
+
+### 4. Task 생성
+
+`.claude/skills/planning/task-create.md` 형식에 따라 task와 phase 파일을 생성한다:
+
+```
+tasks/{task-name}/
+  index.json
+  phase-01.md
+  phase-02.md
+  ...
+```
+
+각 phase 프롬프트는 **자기완결적**이어야 한다 — 이전 대화 없이 독립 실행 가능.
+
+### 5. 실행
+
+**실행 전 필수 확인**: `git status --porcelain`으로 working directory 상태 확인.
+
+- **이상적**: clean 상태 (docs 커밋 완료 후)
+- **허용 가능**: task와 무관한 format-on-save만 존재 (추적 가능한 상태)
+- **금지**: 같은 working directory에서 다른 task와 병렬 실행. git add/commit/push 충돌 발생
+
+**병렬 실행 규칙**: 두 task를 동시에 실행하려면 반드시 **git worktree 분리** 또는 **claude teams**(subagent)를 사용. 같은 working directory에서 `run-phases.py`를 2개 동시 실행 금지.
+
+**반드시 `run-phases.py`를 Bash `run_in_background: true`로 실행한다.**
+사용자 개입 없이 자기 완결적으로 동작해야 한다.
+
+```bash
+# 전체 실행 (백그라운드)
+python3 .claude/skills/plan-and-build/run-phases.py tasks/{task-name}
+
+# 특정 phase부터 재개
+python3 .claude/skills/plan-and-build/run-phases.py tasks/{task-name} --from-phase 3
+```
+
+실행 중 `tasks/{task-name}/index.json`의 status가 자동 갱신된다.
+
+**Task phase에서 파일 커밋 규칙**:
+- 각 phase는 **자신의 변경 + 암묵적 의존성** 모두 커밋해야 함
+- 예: DB 스키마 변경 → 관련 TypeScript 타입 파일도 자동 수정됨 → 함께 커밋
+- 예: API 마이그레이션 → 호출자 컴포넌트도 수정됨 → 함께 커밋
+
+**마지막 2 phase 표준** (모든 task 의 마지막 2 phase 는 아래 구조):
+
+| Phase | 제목               | 모델    | 내용                                                               |
+| ----- | ------------------ | ------- | ------------------------------------------------------------------ |
+| N-1   | 빌드 검증 + 테스트 | `haiku` | `pnpm build && pnpm test`, 금지사항 검증 (`grep` 체크)             |
+| N     | 커밋 + push        | `haiku` | 변경 파일 `git add` → `git commit` → `git push`. task 파일도 포함. |
+
+**커밋 phase (Phase N) 실행 순서**:
+1. `git status --porcelain` 실행 → 전체 수정/신규 파일 목록 확보
+2. task 관련 파일 판별:
+   - 명시적 목록에 있는 파일 → 포함
+   - 명시적 목록에 없지만 task 의 변경으로 수정된 파일(타입·의존성) → 포함
+   - format-only 변경(prettier) + task 무관 파일 → 제외 + 로그
+3. 선별된 파일만 `git add` (`git add -A` 금지 — 다른 task 변경/format-on-save 혼입 방지)
+4. `git commit -m "feat/fix/chore(scope): 설명"` + `git push`
+5. push 실패 시 `PHASE_BLOCKED: push 실패 — 원격 변경사항 확인 필요`
+
+병렬 실행은 `git worktree` 격리 필요 (현재는 순차 실행 전용).
+
+### 5.1. 실패 복구 — 반드시 실패한 phase부터 재시작
+
+**Phase가 타임아웃/에러로 실패한 경우, 해당 phase를 "완료"로 판단하지 말 것.**
+
+- 타임아웃은 "작업 중간"에서 끊긴 것이지 "완료 직전"이 보장되지 않음
+- diff가 많아 보여도 일부 파일만 수정하고 나머지를 놓쳤을 수 있음
+- **각 phase는 자기완결적으로 설계됨** — 이미 수정된 파일은 건너뛰고 놓친 파일을 잡아냄
+
+**복구 절차**:
+1. `--from-phase {실패한 phase 번호}`로 재시작 (다음 phase가 아닌 **실패한 phase**)
+2. index.json의 해당 phase status를 `"pending"`으로 리셋 (completed로 마킹 금지)
+3. phase가 스스로 현재 코드 상태를 읽고 남은 작업을 판단하게 위임
+
+**금지**: 실패한 phase의 diff를 눈으로 보고 "거의 완료됐으니 다음으로 넘기자"는 판단.
+
+### 6. 완료 후 처리
+
+1. `index.json` status 확인 → `completed` 이면 성공
+2. **`pnpm run ci` 실행하여 최종 통합 검증** — lint + test + build 전원 통과 필수 (`pnpm build && pnpm test`만 돌리지 말 것. lint 누락 방지)
+3. ci 실패 시 해당 phase로 회귀 (`--from-phase N`) — "tsc만 통과했으니 OK"로 넘기지 않는다
+4. 사용자에게 로컬 테스트 요청
+5. 사용자 확인 후 **git commit + push** 진행
+6. 다음 plan으로 이동
+
+### 7. 알림 (DOORAY_WEBHOOK_URL 설정 시 자동)
+
+run-phases.py 종료 코드에 따라 웹훅 알림 발송:
+
+| exit code | 의미    | 메시지                                       |
+| --------- | ------- | -------------------------------------------- |
+| 0         | 성공    | `✅ Task {name} 완료 (N phases)`             |
+| 1         | 오류    | `❌ Task {name} phase {n} 실패: {error}`     |
+| 2         | blocked | `⚠️ Task {name} phase {n} blocked: {reason}` |
+
+---
+
+## 구조
+
+```
+tasks/
+  {task-name}/
+    index.json        # task 메타데이터 + phase 목록
+    phase-01.md       # 자기완결적 실행 프롬프트
+    phase-02.md
+    ...
+
+.claude/skills/plan-and-build/
+  run-phases.py       # phase 순차 실행기 (실시간 스트리밍, --from-phase 지원)
+
+.claude/skills/planning/
+  task-create.md      # task/phase 작성 가이드 (planning 스킬 산출물 규격)
+```
+
+## fos-blog 레이어별 phase 순서
+
+CLAUDE.md "Architecture" 의 레이어 (`app → services → infra`, `lib` 는 횡단). 새 기능 추가 시 권장 phase 분리:
+
+| Phase | 내용 | 비고 |
+| --- | --- | --- |
+| 1 | infra 레이어 (`src/infra/db/` 또는 `src/infra/github/`) | Drizzle schema / repository / Octokit 클라이언트 |
+| 2 | service 레이어 (`src/services/`) | 도메인 로직, idempotency, 트랜잭션 |
+| 3 | app 레이어 (`src/app/`) — page / API route | server action 또는 route handler |
+| 4 | UI 컴포넌트 (`src/components/`) | shadcn/ui + 디자인 토큰 사용 |
+| 5 | 빌드 + lint + type-check + test 통합 검증 | `pnpm lint && pnpm type-check && pnpm test --run && pnpm build` |
+
+DB 스키마 변경이 필요한 경우 별도 plan 으로 선행 — Drizzle 규칙 (`pnpm db:generate` → SQL 커밋 → `pnpm db:migrate`). `db:push` 프로덕션 금지 (CLAUDE.md 의 DB 스키마 변경 규칙 참조).
+
+## Phase 모델 라우팅 (토큰 효율 최우선)
+
+**원칙**: 계획/설계는 Opus, 실제 구현은 Sonnet, 단순 작업은 Haiku.
+
+Opus는 Sonnet의 약 5배 비싸고 Claude Code Max 5시간 한도를 빠르게 소모한다. 토큰 효율을 위해 **phase의 대부분은 sonnet**을 사용하고, opus는 설계/논의/복잡 디버깅에만 한정한다.
+
+| 모델     | 용도                                                      | 예시                                                    |
+| -------- | --------------------------------------------------------- | ------------------------------------------------------- |
+| `haiku`  | 기계적 작업 (git commit+push, 빌드 검증, 파일 삭제)       | 빌드 검증 + 커밋 phase, 단순 삭제                      |
+| `sonnet` | **실제 구현 대부분** — 코드 작성/수정/rename/리팩토링     | AI 함수 작성, 컴포넌트 수정, rename, DB repo 수정, UI  |
+| `opus`   | **계획/설계/논의** (task 외부에서만) + 복잡 알고리즘 설계 | planner, architect, deep-interview, 복잡한 아키텍처 설계 |
+
+**Task phase에서 opus 사용 금지 원칙** (예외만 허용):
+- ❌ 기계적 rename/이동: sonnet으로 충분
+- ❌ 파일 수가 많다는 이유만으로 opus: sonnet으로 충분 (패턴이 같으면 파일 수는 무관)
+- ❌ 여러 레이어 동시 수정: sonnet으로 충분
+- ✅ 새로운 아키텍처 설계가 phase 안에 포함된 경우: opus 허용
+- ✅ 복잡한 알고리즘 구현 (AI 파이프라인 신규 설계): opus 허용
+
+**판단 기준**: "이 phase는 *무엇을 할지 결정*하는 작업인가, *이미 결정된 것을 수행*하는 작업인가?"
+- 결정 = opus / 수행 = sonnet
+
+**세션 외부 opus 사용**: 사용자와의 논의, docs 작성, task 계획 수립은 main 세션(opus)에서 수행. task phase는 sonnet으로 실행하여 토큰을 절약.
+
+## Phase 프롬프트 작성 핵심 규칙
+
+1. **원자적 단일 책임**: 성격이 다른 작업(기능 추가 vs 버그 수정)은 반드시 별도 phase로 분리
+2. **작업 항목 5개 이하**: 하나의 phase에 작업 항목이 5개를 초과하면 반드시 분리. 너무 많은 항목을 담으면 AI 에이전트가 뒤쪽 항목을 누락한다 (실증: plan119 phase-02에서 11개 항목 중 뒤 3개 누락)
+3. **자기완결적**: 이전 대화 컨텍스트 없이 `claude --print`로 독립 실행
+4. **먼저 읽을 문서 명시**: 각 phase 상단에 반드시 참조할 파일 경로 나열
+5. **기존 코드 참조 섹션**: 패턴 파악용 기존 파일 경로 명시 (새 코드가 기존 패턴과 일관되도록)
+6. **구체적 시그니처**: 생성할 함수의 이름, 파라미터, 반환 타입을 phase에 명시
+7. **성공 기준에 모든 작업 검증 포함**: 성공 기준의 grep/ls 검증이 작업 목록의 모든 항목을 커버해야 함. 검증이 빠지면 누락을 감지할 수 없다
+8. **Blocked 조건**: 자동 복구 불가능한 상황의 마커 (`PHASE_BLOCKED: ...`)
+
+## 실행 흐름 요약
+
+```
+[문서 파악] → [사용자와 논의] → [계획 확정]
+    → [docs 최신화] → [docs 커밋 + push]        ← docs-first
+    → [task 파일 생성] → [git status 확인]       ← clean working dir 확인
+    → [run-phases.py 백그라운드 실행]
+    → [완료 확인] → [사용자 로컬 테스트]
+    → [다음 plan]
+```
+
+## Exit Codes
+
+| 코드 | 의미                                              |
+| ---- | ------------------------------------------------- |
+| 0    | 모든 phase 완료                                   |
+| 1    | phase 실행 오류 (index.json error_message 참고)   |
+| 2    | 사용자 개입 필요 (index.json blocked_reason 참고) |

--- a/.claude/skills/plan-and-build/run-phases.py
+++ b/.claude/skills/plan-and-build/run-phases.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+Agent harness — Claude Code phase 순차 실행기.
+
+Usage:
+  python .claude/skills/plan-and-build/run-phases.py <task-dir> [--from-phase N]
+
+  예: python .claude/skills/plan-and-build/run-phases.py tasks/v1-initial-setup
+      python .claude/skills/plan-and-build/run-phases.py tasks/v1-initial-setup --from-phase 3
+
+Exit codes:
+  0  — 모든 phase 완료
+  1  — phase 실행 오류 (index.json의 error_message 참고)
+  2  — 사용자 개입 필요 (index.json의 blocked_reason 참고)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ── .env 로드 ────────────────────────────────────────────────────────────────
+
+def load_dotenv() -> None:
+    """프로젝트 루트의 .env 파일을 읽어 환경변수로 설정. 이미 설정된 변수는 덮어쓰지 않음."""
+    # .claude/skills/plan-and-build/ 기준으로 상위 4단계가 프로젝트 루트
+    env_path = Path(__file__).resolve().parent.parent.parent.parent / ".env"
+    if not env_path.exists():
+        return
+    with open(env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key not in os.environ:
+                os.environ[key] = value
+
+
+load_dotenv()
+
+
+# ── 웹훅 알림 ──────────────────────────────────────────────────────────────────
+
+def notify(message: str) -> None:
+    """DOORAY_WEBHOOK_URL 환경변수가 있을 때만 전송. 없으면 조용히 스킵."""
+    webhook_url = os.environ.get("DOORAY_WEBHOOK_URL")
+    if not webhook_url:
+        return
+    payload = json.dumps({
+        "botName": "fos-blog",
+        "botIconImage": "https://static.dooray.com/static_images/dooray-bot.png",
+        "text": message,
+    }).encode()
+    req = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=10)
+    except Exception as e:
+        print(f"[warn] 웹훅 알림 실패: {e}", file=sys.stderr)
+
+
+# ── Task 파일 헬퍼 ────────────────────────────────────────────────────────────
+
+def validate_task(task: dict, task_dir: Path) -> None:
+    """index.json 필수 필드 검증. tasks/schema.ts 참고."""
+    errors: list[str] = []
+
+    required_task_fields = [
+        "name", "description", "created_at", "updated_at",
+        "status", "current_phase", "total_phases",
+        "error_message", "blocked_reason", "phases",
+    ]
+    for field in required_task_fields:
+        if field not in task:
+            errors.append(f"task 필수 필드 누락: '{field}'")
+
+    if "phases" in task:
+        phases = task["phases"]
+        if not isinstance(phases, list) or len(phases) == 0:
+            errors.append("phases는 1개 이상의 배열이어야 합니다")
+        else:
+            if task.get("total_phases") != len(phases):
+                errors.append(
+                    f"total_phases({task.get('total_phases')}) != "
+                    f"phases 배열 길이({len(phases)})"
+                )
+
+            required_phase_fields = [
+                "number", "title", "file", "status", "allowedTools",
+            ]
+            for i, phase in enumerate(phases):
+                for field in required_phase_fields:
+                    if field not in phase:
+                        errors.append(
+                            f"phase[{i}] 필수 필드 누락: '{field}'"
+                        )
+
+                expected_num = i + 1
+                if phase.get("number") != expected_num:
+                    errors.append(
+                        f"phase[{i}].number={phase.get('number')}, "
+                        f"expected={expected_num}"
+                    )
+
+                phase_file = task_dir / phase.get("file", "")
+                if phase.get("file") and not phase_file.exists():
+                    errors.append(f"phase 파일 없음: {phase_file}")
+
+    if errors:
+        print("\n❌ index.json 검증 실패:\n", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        print(
+            "\n  → tasks/schema.ts 및 .claude/skills/planning/task-create.md 참고\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def load_task(task_dir: Path) -> tuple[dict, Path]:
+    index_path = task_dir / "index.json"
+    if not index_path.exists():
+        print(f"[error] index.json not found: {index_path}", file=sys.stderr)
+        sys.exit(1)
+    with open(index_path, encoding="utf-8") as f:
+        task = json.load(f)
+    validate_task(task, task_dir)
+    return task, index_path
+
+
+def save_task(task: dict, index_path: Path) -> None:
+    task["updated_at"] = datetime.now(timezone.utc).isoformat()
+    with open(index_path, "w", encoding="utf-8") as f:
+        json.dump(task, f, indent=2, ensure_ascii=False)
+
+
+# ── Phase 실행 ────────────────────────────────────────────────────────────────
+
+DEFAULT_TOOLS = "Read,Write,Edit,Bash,Glob,Grep"
+DEFAULT_PHASE_TIMEOUT = 600  # 기본 10분 (초)
+BLOCKED_MARKER = "PHASE_BLOCKED:"
+FAILED_MARKER = "PHASE_FAILED:"
+
+
+def run_phase(
+    phase_file: Path,
+    allowed_tools: list[str],
+    model: str | None = None,
+    timeout: int = DEFAULT_PHASE_TIMEOUT,
+) -> tuple[int, str, str]:
+    """
+    phase 프롬프트를 Claude에 전달하고 (returncode, stdout, stderr) 반환.
+    stdout을 실시간 스트리밍하면서 동시에 캡처한다.
+    timeout초 이내에 완료되지 않으면 프로세스를 kill하고 에러 반환.
+    """
+    with open(phase_file, encoding="utf-8") as f:
+        prompt = f.read()
+
+    tools = ",".join(allowed_tools) if allowed_tools else DEFAULT_TOOLS
+
+    cmd = ["claude", "--print", "--allowedTools", tools]
+    if model:
+        cmd.extend(["--model", model])
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    proc.stdin.write(prompt)
+    proc.stdin.close()
+
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+    deadline = time.monotonic() + timeout
+    last_output_time = time.monotonic()
+
+    import selectors
+    sel = selectors.DefaultSelector()
+    sel.register(proc.stdout, selectors.EVENT_READ)
+
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                proc.kill()
+                proc.wait()
+                return -1, "".join(stdout_lines), f"PHASE_FAILED: 타임아웃 ({timeout}초) 초과"
+
+            events = sel.select(timeout=min(remaining, 5.0))
+            if events:
+                line = proc.stdout.readline()
+                if not line:
+                    break  # EOF
+                print(line, end="", flush=True)
+                stdout_lines.append(line)
+                last_output_time = time.monotonic()
+            else:
+                # 5초간 출력 없음 — 아직 deadline 전이면 계속 대기
+                if proc.poll() is not None:
+                    break  # 프로세스 종료됨
+    finally:
+        sel.unregister(proc.stdout)
+        sel.close()
+
+    proc.wait()
+    stderr_output = proc.stderr.read()
+    if stderr_output:
+        print(stderr_output, end="", file=sys.stderr)
+        stderr_lines.append(stderr_output)
+
+    return proc.returncode, "".join(stdout_lines), "".join(stderr_lines)
+
+
+def find_marker(text: str, marker: str) -> str | None:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(marker):
+            return stripped[len(marker):].strip()
+    return None
+
+
+def fmt_elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m{s:02d}s" if m else f"{s}s"
+
+
+# ── 메인 ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+
+    task_dir = Path(args[0]).resolve()
+    if not task_dir.is_dir():
+        print(f"[error] task 디렉터리 없음: {task_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    from_phase = 1
+    if "--from-phase" in args:
+        idx = args.index("--from-phase")
+        try:
+            from_phase = int(args[idx + 1])
+        except (IndexError, ValueError):
+            print("[error] --from-phase 뒤에 정수를 지정하세요", file=sys.stderr)
+            sys.exit(1)
+
+    task, index_path = load_task(task_dir)
+    task_name = task["name"]
+    phases = task["phases"]
+    total = len(phases)
+
+    print(f"\n🚀  Task: {task_name}  ({total} phases)\n")
+
+    for phase in phases:
+        phase_num = phase["number"]
+        phase_title = phase.get("title", f"Phase {phase_num}")
+
+        if phase_num < from_phase:
+            print(f"  ⏭  Phase {phase_num}/{total}: {phase_title}  (skipped)")
+            continue
+
+        if phase["status"] == "completed":
+            print(f"  ✓  Phase {phase_num}/{total}: {phase_title}  (already completed)")
+            continue
+
+        phase_file = task_dir / phase["file"]
+        if not phase_file.exists():
+            msg = f"phase 파일 없음: {phase_file}"
+            phase["status"] = "failed"
+            task["status"] = "failed"
+            task["error_message"] = msg
+            save_task(task, index_path)
+            notify(f"❌ Task **{task_name}** phase {phase_num} 실패: {msg}")
+            print(f"  ✗  {msg}", file=sys.stderr)
+            sys.exit(1)
+
+        allowed_tools = phase.get("allowedTools", [])
+        model = phase.get("model")  # "haiku" | "sonnet" | "opus" | None (기본 모델)
+        timeout = phase.get("timeout", DEFAULT_PHASE_TIMEOUT)  # 초 단위, 기본 10분
+
+        model_label = f" [{model}]" if model else ""
+        timeout_label = f" (timeout: {timeout}s)" if timeout != DEFAULT_PHASE_TIMEOUT else ""
+        print(f"  ▶  Phase {phase_num}/{total}: {phase_title}{model_label}{timeout_label}")
+        print(f"  {'─' * 60}")
+
+        phase["status"] = "running"
+        task["status"] = "running"
+        task["current_phase"] = phase_num
+        save_task(task, index_path)
+        notify(f"▶️ Task **{task_name}** phase {phase_num}/{total} 시작: {phase_title}{model_label}")
+
+        start_time = time.monotonic()
+        returncode, stdout, stderr = run_phase(phase_file, allowed_tools, model, timeout)
+        elapsed = time.monotonic() - start_time
+
+        print(f"  {'─' * 60}")
+
+        blocked = find_marker(stdout, BLOCKED_MARKER) or find_marker(stderr, BLOCKED_MARKER)
+        if blocked:
+            phase["status"] = "blocked"
+            task["status"] = "blocked"
+            task["blocked_reason"] = blocked
+            save_task(task, index_path)
+            msg = f"⚠️ Task **{task_name}** phase {phase_num} blocked: {blocked}"
+            print(f"\n  ⚠  {msg}", file=sys.stderr)
+            notify(msg)
+            sys.exit(2)
+
+        if returncode != 0:
+            error = (
+                find_marker(stdout, FAILED_MARKER)
+                or find_marker(stderr, FAILED_MARKER)
+                or stderr.strip()
+                or f"exit code {returncode}"
+            )
+            phase["status"] = "failed"
+            task["status"] = "failed"
+            task["error_message"] = error
+            save_task(task, index_path)
+            msg = f"❌ Task **{task_name}** phase {phase_num} 실패: {error}"
+            print(f"\n  ✗  {msg}", file=sys.stderr)
+            notify(msg)
+            sys.exit(1)
+
+        phase["status"] = "completed"
+        # 최신 커밋 SHA 기록
+        try:
+            sha_result = subprocess.run(
+                ["git", "log", "-1", "--format=%H"],
+                cwd=index_path.parent.parent,
+                capture_output=True, text=True,
+            )
+            if sha_result.returncode == 0:
+                phase["commitSha"] = sha_result.stdout.strip()[:12]
+        except Exception:
+            pass
+        save_task(task, index_path)
+        notify(f"✅ Task **{task_name}** phase {phase_num}/{total} 완료: {phase_title} [{fmt_elapsed(elapsed)}]")
+        print(f"  ✓  Phase {phase_num}/{total}: {phase_title}  완료  [{fmt_elapsed(elapsed)}]\n")
+
+    task["status"] = "completed"
+    save_task(task, index_path)
+
+    # 커밋/push는 마지막 phase에서 처리 (.claude/skills/planning/task-create.md 표준)
+    # run-phases.py에서는 자동 커밋하지 않음
+
+    msg = f"✅ Task **{task_name}** 완료 ({total} phases)"
+    print(f"\n{msg}\n")
+    notify(msg)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- 웹툰 프로젝트 (\`~/projects/webtoon/webtoon-maker-v1\`) 의 검증된 \`plan-and-build\` 스킬을 fos-blog 로 import
- \`run-phases.py\` 하네스로 task phase 를 순차 실행하는 자동화 (claude --print 비대화형)
- \`build-with-teams\` (agent teams 가시 협업) 와 보완 관계 — 큰 task 를 백그라운드 batch 실행할 때 사용

## Adaptations
- "webtoon-maker-v1 레이어별 phase 순서" → "fos-blog 레이어별 phase 순서" (\`app → services → infra\`, Drizzle/MySQL)
- \`code-architecture.md\` 설명의 "허용 AI 모델" 제거
- run-phases.py 의 Dooray 알림 botName \`webtoon-maker\` → \`fos-blog\`

## 그대로 유지
- task 디렉터리 구조 (planning/task-create.md 와 호환)
- model 라우팅 (haiku/sonnet/opus)
- phase 작성 규칙 + docs-first 커밋 원칙

## Test plan
- [ ] 다음 task 실행 시 \`/plan-and-build\` 트리거 동작 확인
- [ ] run-phases.py 가 task 디렉터리 읽고 phase 순차 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)