### PR TITLE
feat(posts): plan016 — index page sub-hero + 1180px container + InfiniteList tokens

### DIFF
--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -40,6 +40,7 @@ src/
 │
 ├── components/
 │   ├── PostsInfiniteList.tsx           [신규] "use client" — IntersectionObserver + 수동 버튼
+│   ├── PostsListSubHero.tsx            [plan016] 인덱스 eyebrow + h1 + meta + optional Flame accent
 │   ├── PostCardSkeleton.tsx            [신규] 스켈레톤 1개
 │   ├── BackToTopButton.tsx             [신규] 플로팅 + 인라인 공용
 │   └── SectionCTAButton.tsx            [신규] 홈 섹션 하단 "더 보기" 버튼

--- a/docs/design-inspiration.md
+++ b/docs/design-inspiration.md
@@ -359,3 +359,15 @@ mockup 을 만들어주세요.
 - **plan014**: Density 토글 + 사이드바 + 검색 (shadcn Sheet/Dialog)
 - **plan015**: motion-one 마이크로 인터랙션
 - → **권장**: 각 plan 시작 전 별도 plan mode 세션에서 components.* 파일 추출/분석 → plan 작성 → build-with-teams 실행
+
+### 3계층 헤더 위계 (plan016)
+
+페이지 헤더의 정보 위계를 의도적으로 차등:
+
+| 레벨 | 컴포넌트 | 시각 무게 | 사용처 |
+|---|---|---|---|
+| Hero | `HomeHero` | 강 (mesh + 큰 텍스트 + 액션) | `/` (홈) |
+| SubHero | `PostsListSubHero` | 중 (eyebrow + h1 + meta, mesh 없음) | `/posts/latest`, `/posts/popular` |
+| ArticleHero | `ArticleHero` | 강 (article-specific mesh + TOC) | `/posts/[...path]` |
+
+**이유**: 인덱스 페이지는 카테고리·정렬 정보가 핵심이지 hero 자체가 콘텐츠는 아님 → mesh 없이 eyebrow + h1 만으로 충분. Hero ↔ ArticleHero 사이 중간 무게가 필요했음.

--- a/docs/pages/posts-latest.md
+++ b/docs/pages/posts-latest.md
@@ -32,6 +32,7 @@
 
 | Component | Role |
 |---|---|
+| `PostsListSubHero` | 페이지 eyebrow + h1 + meta + divider (server, plan016) |
 | `PostsInfiniteList` (mode=`"latest"`) | 클라이언트 — IntersectionObserver + 수동 버튼 + 끝 도달 UX |
 | `PostCard` | 각 글 카드 (visitCount 함께 표시) |
 | `PostCardSkeleton` | 로딩 스켈레톤 (3개) |
@@ -64,8 +65,8 @@
 ## Layout
 
 ```
-[Header]
-  └ "최신 글" h1 + "업데이트 순" 부제
+[Container max-w-[1180px]]
+  [PostsListSubHero eyebrow="INDEX · LATEST" title="최신 글" meta="업데이트 순"]
 [PostsInfiniteList mode="latest"]
   ├ PostCard × N  (누적)
   ├ [스켈레톤 × 3 | 인라인 "더 보기" 버튼 | "재시도" 버튼 | 끝 문구 + 인라인 "맨 위로"]

--- a/docs/pages/posts-popular.md
+++ b/docs/pages/posts-popular.md
@@ -35,6 +35,7 @@
 
 | Component | Role |
 |---|---|
+| `PostsListSubHero` (accent=`"popular"`) | 페이지 eyebrow + h1 + Flame accent + meta + divider (server, plan016) |
 | `PostsInfiniteList` (mode=`"popular"`) | 클라이언트 — IntersectionObserver + 수동 버튼 + 끝 도달 UX |
 | `PostCard` | 각 글 카드 (visitCount 표시) |
 | `PostCardSkeleton` | 로딩 스켈레톤 (3개) |
@@ -67,8 +68,9 @@
 ## Layout
 
 ```
-[Header]
-  └ "인기 글" h1 + "방문수 순" 부제 + 🔥 Flame 아이콘
+[Container max-w-[1180px]]
+  [PostsListSubHero eyebrow="INDEX · POPULAR" title="인기 글" meta="방문수 순" accent="popular"]
+   └ h1 우측 Flame 아이콘 (--color-cat-algorithm, hue 25 orange-red)
 [PostsInfiniteList mode="popular"]
   ├ PostCard × N (visitCount 강조)
   ├ [스켈레톤 × 3 | 인라인 "더 보기" 버튼 | "재시도" 버튼 | 끝 문구 + 인라인 "맨 위로"]

--- a/src/app/posts/latest/page.tsx
+++ b/src/app/posts/latest/page.tsx
@@ -3,6 +3,7 @@ import logger from "@/lib/logger";
 import { DEFAULT_PAGE_SIZE } from "@/lib/pagination";
 import { PostsInfiniteList, type PostItem } from "@/components/PostsInfiniteList";
 import { BackToTopButton } from "@/components/BackToTopButton";
+import { PostsListSubHero } from "@/components/PostsListSubHero";
 
 const log = logger.child({ module: "app/posts/latest/page" });
 
@@ -44,13 +45,8 @@ export default async function PostsLatestPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-3xl">
-      <div className="mb-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
-          최신 글
-        </h1>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">업데이트 순</p>
-      </div>
+    <div className="container mx-auto px-4 max-w-[1180px]">
+      <PostsListSubHero eyebrow="INDEX · LATEST" title="최신 글" meta="업데이트 순" />
 
       <PostsInfiniteList
         mode="latest"

--- a/src/app/posts/popular/page.tsx
+++ b/src/app/posts/popular/page.tsx
@@ -3,7 +3,7 @@ import logger from "@/lib/logger";
 import { DEFAULT_PAGE_SIZE } from "@/lib/pagination";
 import { PostsInfiniteList, type PostItem } from "@/components/PostsInfiniteList";
 import { BackToTopButton } from "@/components/BackToTopButton";
-import { Flame } from "lucide-react";
+import { PostsListSubHero } from "@/components/PostsListSubHero";
 
 const log = logger.child({ module: "app/posts/popular/page" });
 
@@ -53,16 +53,8 @@ export default async function PostsPopularPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-3xl">
-      <div className="mb-8 flex items-center gap-2">
-        <Flame className="w-7 h-7 text-orange-500" />
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
-            인기 글
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">방문수 순</p>
-        </div>
-      </div>
+    <div className="container mx-auto px-4 max-w-[1180px]">
+      <PostsListSubHero eyebrow="INDEX · POPULAR" title="인기 글" meta="방문수 순" accent="popular" />
 
       <PostsInfiniteList
         mode="popular"

--- a/src/components/PostsInfiniteList.tsx
+++ b/src/components/PostsInfiniteList.tsx
@@ -121,7 +121,7 @@ export function PostsInfiniteList(props: Props) {
         {status === "error" && (
           <button
             onClick={loadMore}
-            className="px-4 py-2 rounded-xl bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+            className="px-4 py-2 rounded-lg bg-[var(--color-bg-elevated)] text-[var(--color-error)] hover:bg-[color-mix(in_oklch,var(--color-fg-primary)_5%,transparent)] border border-[var(--color-border-subtle)] hover:border-[var(--color-border-default)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-brand-400)] font-mono text-[12px] uppercase tracking-[0.06em]"
           >
             재시도
           </button>
@@ -130,7 +130,7 @@ export function PostsInfiniteList(props: Props) {
         {status === "idle" && (
           <button
             onClick={loadMore}
-            className="px-4 py-2 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="px-4 py-2 rounded-lg bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)] hover:bg-[color-mix(in_oklch,var(--color-fg-primary)_5%,transparent)] hover:text-[var(--color-fg-primary)] border border-[var(--color-border-subtle)] hover:border-[var(--color-border-default)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-brand-400)] font-mono text-[12px] uppercase tracking-[0.06em]"
           >
             더 보기
           </button>
@@ -138,7 +138,7 @@ export function PostsInfiniteList(props: Props) {
 
         {status === "done" && (
           <>
-            <p role="status" className="text-sm text-gray-500 dark:text-gray-400">
+            <p role="status" className="font-mono text-[11px] uppercase tracking-[0.1em] text-[var(--color-fg-muted)]">
               더 이상 글이 없습니다.
             </p>
             <BackToTopButton variant="inline" />

--- a/src/components/PostsListSubHero.tsx
+++ b/src/components/PostsListSubHero.tsx
@@ -4,7 +4,7 @@ interface PostsListSubHeroProps {
   eyebrow: string;
   title: string;
   meta: string;
-  accent?: "default" | "popular";
+  accent?: "popular";
 }
 
 export function PostsListSubHero({ eyebrow, title, meta, accent }: PostsListSubHeroProps) {
@@ -22,10 +22,7 @@ export function PostsListSubHero({ eyebrow, title, meta, accent }: PostsListSubH
           {title}
         </h1>
         {accent === "popular" && (
-          <Flame
-            className="h-6 md:h-7 w-auto"
-            style={{ color: "var(--color-cat-algorithm)" }}
-          />
+          <Flame className="h-6 md:h-7 w-auto text-[var(--color-cat-algorithm)]" />
         )}
       </div>
 

--- a/src/components/PostsListSubHero.tsx
+++ b/src/components/PostsListSubHero.tsx
@@ -1,0 +1,39 @@
+import { Flame } from "lucide-react";
+
+interface PostsListSubHeroProps {
+  eyebrow: string;
+  title: string;
+  meta: string;
+  accent?: "default" | "popular";
+}
+
+export function PostsListSubHero({ eyebrow, title, meta, accent }: PostsListSubHeroProps) {
+  return (
+    <div className="py-10 md:py-14">
+      <div className="flex items-center gap-3">
+        <span className="h-px w-6 bg-[var(--color-brand-400)]" />
+        <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-[var(--color-fg-muted)]">
+          {eyebrow}
+        </span>
+      </div>
+
+      <div className="mt-4 inline-flex items-center gap-3">
+        <h1 className="text-[28px] md:text-[40px] font-semibold leading-[1.1] tracking-tight text-[var(--color-fg-primary)]">
+          {title}
+        </h1>
+        {accent === "popular" && (
+          <Flame
+            className="h-6 md:h-7 w-auto"
+            style={{ color: "var(--color-cat-algorithm)" }}
+          />
+        )}
+      </div>
+
+      <p className="mt-3 font-mono text-[12px] uppercase tracking-[0.06em] text-[var(--color-fg-muted)]">
+        {meta}
+      </p>
+
+      <div className="mt-8 h-px bg-[var(--color-border-subtle)]" />
+    </div>
+  );
+}

--- a/tasks/plan016-posts-index-redesign/index.json
+++ b/tasks/plan016-posts-index-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan016-posts-index-redesign",
   "description": "/posts/latest + /posts/popular 인덱스 페이지 톤 통일 — sub-hero (eyebrow + h1 + meta), 1180px 컨테이너, PostsInfiniteList 버튼·종료 메시지 토큰화. mockup 불필요 (plan013 HomeHero + plan010 PostCard 패턴 재사용).",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-04-28",
   "total_phases": 1,
   "related_docs": [
@@ -19,7 +19,7 @@
       "file": "phase-01.md",
       "title": "PostsListSubHero + latest/popular 헤더 교체 + InfiniteList 버튼 토큰화",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan016-posts-index-redesign/phase-01.md
+++ b/tasks/plan016-posts-index-redesign/phase-01.md
@@ -35,7 +35,7 @@ interface PostsListSubHeroProps {
 - eyebrow: `font-mono text-[11px] uppercase tracking-[0.1em] text-[var(--color-fg-muted)]` + 1px brand line prefix (`h-px w-6 bg-[var(--color-brand-400)]`) — HomeHero 의 `hero-eyebrow` 와 동일 패턴
 - h1: `mt-4 text-[28px] md:text-[40px] font-semibold leading-[1.1] tracking-tight text-[var(--color-fg-primary)]` (HomeHero 보다 한 단계 작음 — 36/64 → 28/40)
 - meta: `mt-3 font-mono text-[12px] uppercase tracking-[0.06em] text-[var(--color-fg-muted)]` (단일 라인)
-- accent="popular" 일 때 h1 우측에 `<Flame>` lucide 아이콘 (h-6 md:h-7) — color `var(--color-cat-system)` (orange tone). h1 과 같은 baseline 으로 `inline-flex items-center gap-3`
+- accent="popular" 일 때 h1 우측에 `<Flame>` lucide 아이콘 (h-6 md:h-7) — color `var(--color-cat-algorithm)` (oklch 0.74/0.5 hue 25 = orange-red, fire tone). h1 과 같은 baseline 으로 `inline-flex items-center gap-3`. ※ critic 지적: `--color-cat-system` 은 hue 250 인디고라 부적합 → algorithm 토큰 사용
 - 하단 1px divider: `mt-8 h-px bg-[var(--color-border-subtle)]` (본문과 분리)
 
 Mesh / SVG 배경 **없음** — 의도적으로 가볍게.
@@ -64,7 +64,8 @@ PostsInfiniteList 와 BackToTopButton 은 그대로.
 
 **"더 보기" 버튼** (idle 상태, 라인 132–137):
 - `bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700` →
-- `bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-fg-primary)] border border-[var(--color-border-subtle)] hover:border-[var(--color-border-default)]`
+- `bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)] hover:bg-[color-mix(in_oklch,var(--color-fg-primary)_5%,transparent)] hover:text-[var(--color-fg-primary)] border border-[var(--color-border-subtle)] hover:border-[var(--color-border-default)]`
+  - ※ critic MINOR: light 모드에서 `--color-bg-elevated`/`--color-bg-subtle` 모두 #ffffff 라 hover bg 변화 미시 → `color-mix` 로 fg-primary 5% 오버레이 적용 (양 모드 모두 미세한 시각 변화 확보)
 - `focus-visible:ring-blue-500` → `focus-visible:ring-[var(--color-brand-400)]`
 - `rounded-xl` → `rounded-lg` (PostCard / CategoryCard 와 동일)
 - 폰트: `font-mono text-[12px] uppercase tracking-[0.06em]` 추가 — 키 패턴 통일


### PR DESCRIPTION
## Summary

- 신규 `PostsListSubHero` (eyebrow + h1 + meta + optional Flame accent) — HomeHero/ArticleHero 사이 중간 무게 헤더
- `/posts/latest`, `/posts/popular` 헤더 컴포넌트화 + 컨테이너 폭 1180px 통일 (홈 톤 일관)
- `PostsInfiniteList` 더 보기 / 재시도 / 종료 메시지를 design tokens (plan009) 으로 정리

## Highlights

- **Flame 색상 토큰 결정**: `--color-cat-system` (hue 250 인디고) 대신 `--color-cat-algorithm` (hue 25 orange-red) 사용 — category 의미와 무관한 fire tone 차용
- **light 모드 hover 한계 우회**: `--color-bg-elevated`/`--color-bg-subtle` 모두 `#ffffff` 라 hover 시 시각 변화 부재 → `color-mix(in oklch, var(--color-fg-primary) 5%, transparent)` 인라인 mix
- 3계층 헤더 위계 (Hero / SubHero / ArticleHero) 를 `docs/design-inspiration.md` 에 명문화

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm exec vitest run` (21 files / 209 tests)
- [x] `pnpm build` (executor 환경, 287 pages 생성)
- [ ] 수동 smoke (`/posts/latest`, `/posts/popular` 다크/라이트 + 무한 스크롤 더 보기)

## Build

executor 가 worktree 빌드 시 `.env.local` 부재로 1회 실패 → main repo `.env` 복사 후 재빌드 성공. 본 PR 은 .env 의존성 없이도 typecheck/lint/test 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)