### PR TITLE
chore(task): plan022 comments redesign (shadcn + rhf + avatar)

### DIFF
--- a/tasks/plan022-comments-redesign/index.json
+++ b/tasks/plan022-comments-redesign/index.json
@@ -1,0 +1,36 @@
+{
+  "name": "plan022-comments-redesign",
+  "description": "댓글 영역 전면 리디자인 — shadcn (Form/Input/Textarea/Button/AlertDialog) + sonner Toast + react-hook-form + zod 도입. Nickname 이니셜 + plan009 카테고리 9색 hash 기반 아바타 추가. Schema 변경 없음 (threading 미포함). plan020 SearchDialog 패턴 확장.",
+  "status": "pending",
+  "created_at": "2026-05-06",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/pages/post-detail.md"
+  ],
+  "depends_on": [
+    "plan009-design-tokens-foundation"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "shadcn 컴포넌트 install + sonner Toaster 마운트 + Avatar/CommentItem 분리",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "Comments.tsx 리팩토링 — react-hook-form + zod + 아바타 + plan009 토큰",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "검증 + post-detail.md 갱신 + index.json status=completed",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan022-comments-redesign/phase-01.md
+++ b/tasks/plan022-comments-redesign/phase-01.md
@@ -1,0 +1,181 @@
+# Phase 01 — shadcn install + sonner Toaster + Avatar 분리
+
+**Model**: sonnet
+**Goal**: 댓글 리디자인에 필요한 컴포넌트 인프라 구축. UI 재구성은 phase 2 에서.
+
+## Context (자기완결)
+
+`src/components/ui/button.tsx` 만 shadcn 으로 도입돼 있음. 이번 phase 에서 Form / Input / Textarea / AlertDialog 추가 + sonner toast 도입 + Avatar 컴포넌트 신규 + CommentItem 분리.
+
+**플젝 컨벤션**:
+- shadcn 컴포넌트는 `src/components/ui/` 에 자동 생성 (`pnpm dlx shadcn@latest add ...`)
+- 새 client component 는 "use client" 선언
+- Tailwind v4 + plan009 토큰 기준
+- "전면 리디자인" 결정 (사용자 2026-05-06): threading 미포함, avatar nickname 이니셜 + 9색 hash, full shadcn
+
+## 작업 항목
+
+### 1. shadcn 컴포넌트 + sonner 설치
+
+```bash
+# cwd: <repo root>
+pnpm dlx shadcn@latest add input textarea form alert-dialog
+pnpm add sonner react-hook-form @hookform/resolvers zod
+```
+
+`pnpm dlx shadcn@latest add` 가 다음 파일 생성/덮어쓰기:
+- `src/components/ui/input.tsx`
+- `src/components/ui/textarea.tsx`
+- `src/components/ui/form.tsx` (react-hook-form 연동 wrapper)
+- `src/components/ui/alert-dialog.tsx`
+- 추가 dependency: `react-hook-form`, `@hookform/resolvers`, `zod`, `@radix-ui/react-alert-dialog`, `@radix-ui/react-label`, `@radix-ui/react-slot` 등
+
+shadcn init 이전 실행이라 `components.json` 가 이미 있으므로 prompt 없이 진행. Style/baseColor 는 기존 설정 사용.
+
+**Token 충돌 검증**: shadcn 의 `input.tsx` / `textarea.tsx` 는 보통 `bg-background` / `text-foreground` 를 사용 — Tailwind v4 의 `@theme` 매핑이 plan009 의 `--color-bg-base|elevated` / `--color-fg-primary` 와 정합되는지 확인. 충돌 시 src/components/ui/ 파일 내부 className 만 plan009 토큰으로 교체. 핵심 검증: input border 색이 `--color-border-subtle` 와 일치하는지.
+
+### 2. sonner Toaster 마운트
+
+`src/app/layout.tsx` 에 `<Toaster />` 추가:
+
+```tsx
+import { Toaster } from "sonner";
+
+// <body> 직속 children 끝에:
+<Toaster
+  position="bottom-center"
+  theme="system"
+  toastOptions={{
+    classNames: {
+      toast: "bg-[var(--color-bg-elevated)] text-[var(--color-fg-primary)] border border-[var(--color-border-subtle)]",
+      success: "text-[var(--color-brand-400)]",
+      error: "text-red-400",
+    },
+  }}
+/>
+```
+
+`theme="system"` 으로 ThemeProvider(이미 있음) 의 dark/light 자동 감지.
+
+### 3. `src/components/comments/Avatar.tsx` 신규
+
+Nickname 이니셜 + plan009 카테고리 9색 hash 자동 선택:
+
+```tsx
+const CAT_HEX_PALETTE = [
+  "#b3a4d4", // ai
+  "#d4a594", // algorithm
+  "#cdaf85", // db
+  "#8ec8a8", // devops
+  "#7ec5be", // java
+  "#bbb96d", // js
+  "#88b8d6", // react
+  "#d49d99", // next
+  "#9ab0d4", // system
+];
+
+function hashNickname(nickname: string): number {
+  let h = 0;
+  for (const ch of nickname) {
+    h = (h * 31 + ch.charCodeAt(0)) | 0;
+  }
+  return Math.abs(h);
+}
+
+export function Avatar({ nickname, size = 36 }: { nickname: string; size?: number }) {
+  const initial = nickname.trim().charAt(0).toUpperCase() || "?";
+  const color = CAT_HEX_PALETTE[hashNickname(nickname) % CAT_HEX_PALETTE.length];
+  return (
+    <div
+      role="img"
+      aria-label={`${nickname} 아바타`}
+      style={{ width: size, height: size, background: `${color}26`, color, borderColor: `${color}80` }}
+      className="flex items-center justify-center rounded-full border font-semibold select-none"
+    >
+      {initial}
+    </div>
+  );
+}
+```
+
+`size` prop 으로 다양한 자리에서 재사용 (댓글 카드 36px, 답글 작성자 표시 28px 등).
+
+**참고**: hex 값은 plan009 dark mode 카테고리 토큰의 sRGB hex 근사 (plan021 의 `OG_CATEGORY_HEX` 와 동일 출처). 후속 plan 에서 `OG_CATEGORY_HEX` 와 단일 소스로 통합 가능 — 이번 phase 는 인라인 유지. 이 의도를 컴포넌트 상단 주석으로 명시.
+
+### 4. `src/components/comments/CommentItem.tsx` 분리
+
+기존 `Comments.tsx` 에서 한 댓글 카드 렌더링 부분을 별도 컴포넌트로 추출. props:
+- `comment: Comment` (드리즐 type)
+- `onEdit: (comment: Comment) => void`
+- `onDelete: (comment: Comment) => void`
+
+이번 phase 에서는 **빈 골격만 작성** (return null 또는 단순 레이아웃) — 실제 UI 는 phase 2 에서. Phase 1 의 목적은 export 하는 함수 시그니처를 phase 2 가 import 할 수 있게 하는 것.
+
+```tsx
+// src/components/comments/CommentItem.tsx
+"use client";
+
+import type { Comment } from "@/infra/db/schema/comments";
+
+export interface CommentItemProps {
+  comment: Comment;
+  onEdit: (comment: Comment) => void;
+  onDelete: (comment: Comment) => void;
+}
+
+export function CommentItem(_props: CommentItemProps) {
+  // phase 2 에서 구현
+  return null;
+}
+```
+
+### 5. 검증
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+```
+
+자동 verification:
+```bash
+test -f src/components/ui/input.tsx
+test -f src/components/ui/textarea.tsx
+test -f src/components/ui/form.tsx
+test -f src/components/ui/alert-dialog.tsx
+test -f src/components/comments/Avatar.tsx
+test -f src/components/comments/CommentItem.tsx
+grep -n "from \"sonner\"" src/app/layout.tsx
+grep -n '"react-hook-form"' package.json
+grep -n '"sonner"' package.json
+grep -n '"zod"' package.json
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/ui/input.tsx` | 신규 (shadcn) |
+| `src/components/ui/textarea.tsx` | 신규 (shadcn) |
+| `src/components/ui/form.tsx` | 신규 (shadcn) |
+| `src/components/ui/alert-dialog.tsx` | 신규 (shadcn) |
+| `src/components/comments/Avatar.tsx` | 신규 |
+| `src/components/comments/CommentItem.tsx` | 신규 (skeleton) |
+| `src/app/layout.tsx` | 수정 (Toaster 마운트) |
+| `package.json` | 수정 (sonner / react-hook-form / @hookform/resolvers / zod 추가) |
+
+## Out of Scope
+
+- 실제 댓글 UI 재구성 → phase 2
+- API/Repo/Schema 변경 (threading 미포함 결정)
+- post-detail.md 갱신 → phase 3
+
+## Risks & Mitigations
+
+| 리스크 | 완화 |
+|---|---|
+| shadcn input/textarea 가 `bg-background` 등 Tailwind v4 매핑 변수 사용 | plan009 의 `@theme` 가 `--color-bg-base` 등을 export 하면 shadcn 변수와 매핑됨. 안 되면 `src/components/ui/input.tsx` 의 className 만 plan009 토큰으로 직접 교체 |
+| sonner Toaster 의 dark/light 가 ThemeProvider 와 어긋남 | `theme="system"` 사용 — sonner 가 prefers-color-scheme 자동 감지. 우리 ThemeProvider 가 `.dark` 클래스 토글 방식이면 `theme="dark"/"light"` 동기화 wrapper 필요할 수 있음. 동작 확인 후 phase 2 에서 조정 |
+| `shadcn add` 가 기존 button.tsx 덮어씀 | shadcn add 는 conflict 시 prompt — y/n 으로 우리 button 보존 (plan009 적용 상태). 또는 add 후 git diff 로 button.tsx 변경분 revert |
+| react-hook-form + zod 설치 후 next/turbopack 캐시 오류 | `rm -rf .next` 후 `pnpm dev` 재시작 |

--- a/tasks/plan022-comments-redesign/phase-01.md
+++ b/tasks/plan022-comments-redesign/phase-01.md
@@ -62,17 +62,11 @@ import { Toaster } from "sonner";
 Nickname 이니셜 + plan009 카테고리 9색 hash 자동 선택:
 
 ```tsx
-const CAT_HEX_PALETTE = [
-  "#b3a4d4", // ai
-  "#d4a594", // algorithm
-  "#cdaf85", // db
-  "#8ec8a8", // devops
-  "#7ec5be", // java
-  "#bbb96d", // js
-  "#88b8d6", // react
-  "#d49d99", // next
-  "#9ab0d4", // system
-];
+import { OG_CATEGORY_HEX } from "@/lib/og";
+
+// plan021 의 OG_CATEGORY_HEX 를 단일 소스로 재사용 — 색상 변경 시 OG/Avatar 일관성 보장.
+// (record → array 변환은 hash 모듈로 안정적으로 인덱스화하기 위함)
+const AVATAR_PALETTE = Object.values(OG_CATEGORY_HEX);
 
 function hashNickname(nickname: string): number {
   let h = 0;
@@ -82,15 +76,21 @@ function hashNickname(nickname: string): number {
   return Math.abs(h);
 }
 
+const SIZE_CLASS: Record<number, string> = {
+  28: "h-7 w-7",
+  36: "h-9 w-9",
+};
+
 export function Avatar({ nickname, size = 36 }: { nickname: string; size?: number }) {
   const initial = nickname.trim().charAt(0).toUpperCase() || "?";
-  const color = CAT_HEX_PALETTE[hashNickname(nickname) % CAT_HEX_PALETTE.length];
+  const color = AVATAR_PALETTE[hashNickname(nickname) % AVATAR_PALETTE.length];
+  const sizeClass = SIZE_CLASS[size] ?? "h-9 w-9";
   return (
     <div
       role="img"
       aria-label={`${nickname} 아바타`}
-      style={{ width: size, height: size, background: `${color}26`, color, borderColor: `${color}80` }}
-      className="flex items-center justify-center rounded-full border font-semibold select-none"
+      style={{ background: `${color}26`, color, borderColor: `${color}80` }}
+      className={`${sizeClass} flex items-center justify-center rounded-full border font-semibold select-none`}
     >
       {initial}
     </div>
@@ -98,9 +98,9 @@ export function Avatar({ nickname, size = 36 }: { nickname: string; size?: numbe
 }
 ```
 
-`size` prop 으로 다양한 자리에서 재사용 (댓글 카드 36px, 답글 작성자 표시 28px 등).
+`size` prop 으로 다양한 자리에서 재사용 (댓글 카드 36px, 답글 작성자 표시 28px). 동적 색상만 inline style 유지, 크기는 `SIZE_CLASS` 매핑으로 Tailwind class 사용.
 
-**참고**: hex 값은 plan009 dark mode 카테고리 토큰의 sRGB hex 근사 (plan021 의 `OG_CATEGORY_HEX` 와 동일 출처). 후속 plan 에서 `OG_CATEGORY_HEX` 와 단일 소스로 통합 가능 — 이번 phase 는 인라인 유지. 이 의도를 컴포넌트 상단 주석으로 명시.
+**참고**: 팔레트는 plan021 `OG_CATEGORY_HEX` 의 `Object.values()` — 단일 소스. plan021 색상 갱신 시 자동 반영.
 
 ### 4. `src/components/comments/CommentItem.tsx` 분리
 

--- a/tasks/plan022-comments-redesign/phase-02.md
+++ b/tasks/plan022-comments-redesign/phase-02.md
@@ -1,0 +1,182 @@
+# Phase 02 — Comments.tsx 리팩토링
+
+**Model**: sonnet
+**Goal**: 댓글 영역 본체 재구축 — react-hook-form + zod + plan009 토큰 + 아바타 적용. 기능 유지(작성/수정/삭제 + password 인증), UI/UX 만 전면 교체.
+
+## Context (자기완결)
+
+phase 1 에서 shadcn (Form / Input / Textarea / AlertDialog) + sonner + react-hook-form + zod 설치 완료. `src/components/comments/Avatar.tsx`, `CommentItem.tsx` (skeleton) 생성 완료.
+
+이번 phase 는:
+1. `Comments.tsx` 를 컨테이너로 줄이고
+2. `CommentItem.tsx` 를 실제 카드로 채우고
+3. `CommentForm.tsx` 신규 — 작성/수정 통합 form (react-hook-form + zod 검증)
+4. `DeleteConfirmDialog.tsx` 신규 — AlertDialog 래퍼 + password 입력
+5. 모든 색상 plan009 토큰 + Avatar 통합
+
+기존 API (`POST /api/comments`, `PATCH /api/comments/[id]`, `DELETE /api/comments/[id]`) 는 변경 없음. 호출 contract 도 동일.
+
+## 작업 항목
+
+### 1. `src/components/comments/CommentForm.tsx` 신규 (작성/수정 통합)
+
+react-hook-form + zod schema:
+
+```tsx
+"use client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+const schema = z.object({
+  nickname: z.string().min(1, "닉네임을 입력하세요").max(100),
+  password: z.string().min(4, "비밀번호는 4자 이상").max(255),
+  content: z.string().min(1, "내용을 입력하세요").max(5000),
+});
+type FormValues = z.infer<typeof schema>;
+
+export interface CommentFormProps {
+  mode: "create" | "edit";
+  initialContent?: string;
+  initialNickname?: string;  // edit 일 때 read-only 표시 + form 에는 빈 값 (서버 검증은 password 만)
+  onSubmit: (values: FormValues) => Promise<void>;
+  onCancel?: () => void;
+}
+```
+
+- `mode === "edit"` 일 때 nickname 필드 read-only 또는 hidden, password 만 노출 (기존 동작 유지)
+- submit 중 button disabled + 작은 spinner (lucide `Loader2 animate-spin`)
+- error 시 `toast.error(message)` 호출 (sonner)
+
+### 2. `src/components/comments/CommentItem.tsx` 본체 채우기
+
+Phase 1 skeleton 을 채운다. 시각 구조:
+
+```
+┌────────────────────────────────────────┐
+│ [Avatar] nickname    ·  2시간 전    [⋯] │
+│                                          │
+│           댓글 본문 텍스트                │
+│           여러 줄 가능                    │
+│                                          │
+└────────────────────────────────────────┘
+```
+
+- 컨테이너: `bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] rounded-[12px] p-5`
+- 메타: `Avatar` + nickname (`text-[var(--color-fg-primary)] font-medium`) + 시간 (`text-[var(--color-fg-muted)] text-sm`)
+- 본문: `text-[var(--color-fg-secondary)] leading-relaxed whitespace-pre-wrap`
+- 우상단 액션: edit / delete 아이콘 버튼 (`Button variant="ghost" size="icon"`)
+- 시간 포맷: `formatDistanceToNow` 류 — 외부 라이브러리 추가 금지. `src/lib/format-time.ts` 신규 또는 기존 util 재사용. 간단 helper:
+  ```ts
+  export function formatRelativeTime(date: Date): string {
+    const diff = Date.now() - date.getTime();
+    const min = Math.floor(diff / 60000);
+    if (min < 1) return "방금 전";
+    if (min < 60) return `${min}분 전`;
+    const hour = Math.floor(min / 60);
+    if (hour < 24) return `${hour}시간 전`;
+    const day = Math.floor(hour / 24);
+    if (day < 7) return `${day}일 전`;
+    return date.toLocaleDateString("ko-KR");
+  }
+  ```
+  `src/lib/` 에 기존 시간 helper 가 있는지 확인 후 중복 회피.
+
+### 3. `src/components/comments/DeleteConfirmDialog.tsx` 신규
+
+shadcn AlertDialog 래퍼:
+
+```tsx
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+
+export interface DeleteConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (password: string) => Promise<void>;
+}
+```
+
+- AlertDialog open/close 제어
+- 본문: "댓글을 삭제하시겠습니까?" + password Input
+- Confirm 버튼: `variant="destructive"` 또는 `bg-red-600` 류 — plan009 에 `--color-error` 가 있으면 그걸 사용 (`bg-[var(--color-error)]`)
+- Cancel: `variant="outline"`
+
+### 4. `src/components/Comments.tsx` 컨테이너로 슬림화
+
+기존 354줄 → 약 100줄 컨테이너로:
+- `useState` 로 `comments`, `isLoading`, `editingId`, `deletingId` 만 관리
+- `useEffect` 로 댓글 fetch
+- 자식: `<CommentForm mode="create" onSubmit={handleCreate} />`, `<CommentItem ... />` 매핑, `<DeleteConfirmDialog .../>`, edit 시 `<CommentForm mode="edit" .../>` 인라인 표시
+- 모든 색상은 plan009 토큰. 섹션 헤더:
+  ```tsx
+  <section className="mt-12 pt-8 border-t border-[var(--color-border-subtle)]">
+    <h2 className="flex items-center gap-2 text-xl font-semibold text-[var(--color-fg-primary)] mb-6">
+      <MessageCircle className="w-5 h-5 text-[var(--color-brand-400)]" />
+      댓글 ({comments.length})
+    </h2>
+    {/* form + list */}
+  </section>
+  ```
+- 빈 상태: `comments.length === 0 && !isLoading` 시 `text-[var(--color-fg-muted)] text-center py-12` "첫 댓글을 남겨주세요"
+- 로딩: skeleton row 3개 (`bg-[var(--color-bg-subtle)] animate-pulse h-24 rounded-[12px]`)
+
+### 5. `console.error("Failed to ...")` → `toast.error()` 대체
+
+기존 alert / console.error 호출은 sonner toast 로 교체:
+- 작성 성공: `toast.success("댓글이 등록되었습니다")`
+- 작성 실패: `toast.error("댓글 등록 실패")` — 서버 에러 메시지 우선
+- 수정/삭제 동일 패턴
+
+### 6. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+
+# 잔존 하드코딩 색 0줄 (Comments.tsx + comments/ 하위 전체)
+! grep -nE "bg-white|bg-gray-|bg-blue-|bg-red-|text-gray-|text-white|border-gray-|focus:ring-blue" src/components/Comments.tsx src/components/comments/
+
+# 신규 파일
+test -f src/components/comments/CommentForm.tsx
+test -f src/components/comments/DeleteConfirmDialog.tsx
+
+# react-hook-form 사용
+grep -n "useForm" src/components/comments/CommentForm.tsx
+
+# Avatar 사용
+grep -n "Avatar" src/components/comments/CommentItem.tsx
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/Comments.tsx` | 대폭 수정 (컨테이너 슬림화) |
+| `src/components/comments/CommentForm.tsx` | 신규 |
+| `src/components/comments/CommentItem.tsx` | 본체 채우기 (phase 1 skeleton) |
+| `src/components/comments/DeleteConfirmDialog.tsx` | 신규 |
+| `src/lib/format-time.ts` | 신규 (또는 기존 helper 재사용) |
+
+## Out of Scope
+
+- post-detail.md 문서 갱신 → phase 3
+- 댓글 schema 변경 (threading) — 결정상 미포함
+- 댓글 좋아요 / 신고 등 기능 추가
+- 모바일 키보드 자동 띄움 최적화 (현재 동작 유지)
+
+## Risks & Mitigations
+
+| 리스크 | 완화 |
+|---|---|
+| react-hook-form + zod 의 Korean error message 가 한국어로 안 나올 위험 | zod schema 의 `.min()/.max()` 두 번째 인자에 한글 메시지 직접 명시 (예제 코드 참조) |
+| AlertDialog 가 모바일에서 viewport 잘림 | shadcn AlertDialog 는 max-w + overflow auto 기본 적용 — 자체 padding 추가 시 검증 |
+| `formatRelativeTime` 가 SSR/CSR 시간 차이로 hydration mismatch | CommentItem 에 "use client" 명시 — server render 결과는 placeholder, client 에서 useEffect 로 시간 계산하거나, 서버 시간 기준 createdAt ISO string 만 받아 client 에서 변환 |
+| sonner 의 toast 가 dark mode 에서 색 어긋남 | phase 1 의 Toaster `classNames` 토큰 매핑이 정상 작동하는지 시각 확인. 안 되면 `theme="dark"` 또는 ThemeProvider 동기화 hook 도입 |
+| Comments.tsx 슬림화 시 기존 password 인증 로직 누락 | 작성 시 password 그대로 전송, edit/delete 는 DeleteConfirmDialog / CommentForm(mode=edit) 에서 password Input 으로 별도 받음 — 기존 API contract 변경 없음 |

--- a/tasks/plan022-comments-redesign/phase-02.md
+++ b/tasks/plan022-comments-redesign/phase-02.md
@@ -32,25 +32,44 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 
-const schema = z.object({
+// 모드별 schema 분리 — edit 모드는 password + content 만 검증 (nickname 은 변경 불가)
+const createSchema = z.object({
   nickname: z.string().min(1, "닉네임을 입력하세요").max(100),
   password: z.string().min(4, "비밀번호는 4자 이상").max(255),
   content: z.string().min(1, "내용을 입력하세요").max(5000),
 });
-type FormValues = z.infer<typeof schema>;
+const editSchema = createSchema.pick({ password: true, content: true });
 
-export interface CommentFormProps {
-  mode: "create" | "edit";
-  initialContent?: string;
-  initialNickname?: string;  // edit 일 때 read-only 표시 + form 에는 빈 값 (서버 검증은 password 만)
-  onSubmit: (values: FormValues) => Promise<void>;
-  onCancel?: () => void;
-}
+type CreateValues = z.infer<typeof createSchema>;
+type EditValues = z.infer<typeof editSchema>;
+export type CommentFormValues = CreateValues | EditValues;
+
+export type CommentFormProps =
+  | {
+      mode: "create";
+      onSubmit: (values: CreateValues) => Promise<void>;
+      onCancel?: () => void;
+    }
+  | {
+      mode: "edit";
+      initialContent: string;
+      initialNickname: string; // 표시 전용 (수정 불가)
+      onSubmit: (values: EditValues) => Promise<void>;
+      onCancel?: () => void;
+    };
 ```
 
-- `mode === "edit"` 일 때 nickname 필드 read-only 또는 hidden, password 만 노출 (기존 동작 유지)
+- `mode === "edit"` 일 때 schema = `editSchema`, nickname 은 read-only display 만
+- `useForm({ resolver: zodResolver(mode === "edit" ? editSchema : createSchema) })` 로 mode 별 분기
 - submit 중 button disabled + 작은 spinner (lucide `Loader2 animate-spin`)
-- error 시 `toast.error(message)` 호출 (sonner)
+- error 시 `toast.error(message)` 호출 (sonner) — **서버 raw 메시지 직접 노출 금지** (아래 "에러 메시지 sanitization" 참조)
+
+### content XSS 가드 (서버 측 + 표시 측 양쪽)
+
+zod 의 `.max(5000)` 는 길이 검증만. content 가 HTML/script 를 포함하면 표시 시 위험. 두 면 가드:
+
+1. **저장 측**: `CommentRepository.createComment` / `updateComment` 호출 직전 `content` 를 escape 또는 strip-html. 기존 `src/infra/db/repositories/CommentRepository.ts` 의 write 메서드에 sanitization 가드가 없으면 phase-02 안에서 추가 (단순 `< → &lt; > → &gt; & → &amp;` escape 또는 `dompurify` 도입 결정). **executor 가 먼저 현재 구현 확인 후 보고** — 이미 가드 있으면 skip, 없으면 추가
+2. **표시 측**: `CommentItem.tsx` 가 `{comment.content}` 로 React 텍스트로 렌더 시 React 가 자동 escape — `dangerouslySetInnerHTML` 사용 금지. `whitespace-pre-wrap` 만 적용해 줄바꿈 보존
 
 ### 2. `src/components/comments/CommentItem.tsx` 본체 채우기
 
@@ -72,7 +91,10 @@ Phase 1 skeleton 을 채운다. 시각 구조:
 - 우상단 액션: edit / delete 아이콘 버튼 (`Button variant="ghost" size="icon"`)
 - 시간 포맷: `formatDistanceToNow` 류 — 외부 라이브러리 추가 금지. `src/lib/format-time.ts` 신규 또는 기존 util 재사용. 간단 helper:
   ```ts
-  export function formatRelativeTime(date: Date): string {
+  // Drizzle createdAt 이 ISO string 으로 직렬화될 가능성 대비 — Date | string 양쪽 수용
+  export function formatRelativeTime(dateOrIso: Date | string): string {
+    const date = typeof dateOrIso === "string" ? new Date(dateOrIso) : dateOrIso;
+    if (Number.isNaN(date.getTime())) return ""; // invalid input safe fallback
     const diff = Date.now() - date.getTime();
     const min = Math.floor(diff / 60000);
     if (min < 1) return "방금 전";
@@ -84,13 +106,16 @@ Phase 1 skeleton 을 채운다. 시각 구조:
     return date.toLocaleDateString("ko-KR");
   }
   ```
-  `src/lib/` 에 기존 시간 helper 가 있는지 확인 후 중복 회피.
+  `src/lib/` 에 기존 시간 helper 가 있는지 확인 후 중복 회피. executor 는 Drizzle `comments.createdAt` 의 실제 반환 타입(API 직렬화 후) 을 먼저 확인.
 
 ### 3. `src/components/comments/DeleteConfirmDialog.tsx` 신규
 
-shadcn AlertDialog 래퍼:
+shadcn AlertDialog 래퍼 — **client component (password state + async handler)**:
 
 ```tsx
+"use client";
+
+import { useState } from "react";
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 
@@ -99,14 +124,40 @@ export interface DeleteConfirmDialogProps {
   onOpenChange: (open: boolean) => void;
   onConfirm: (password: string) => Promise<void>;
 }
+
+export function DeleteConfirmDialog({ open, onOpenChange, onConfirm }: DeleteConfirmDialogProps) {
+  const [password, setPassword] = useState("");
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  const handleConfirm = async () => {
+    setIsConfirming(true);
+    try {
+      await onConfirm(password);
+      setPassword("");
+    } finally {
+      setIsConfirming(false);
+    }
+  };
+
+  // 다이얼로그 닫힐 때 password reset
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setPassword("");
+    onOpenChange(next);
+  };
+
+  // ... AlertDialog JSX (open={open} onOpenChange={handleOpenChange})
+  // Confirm button: disabled={isConfirming || password.length < 4}, onClick={handleConfirm}
+}
 ```
 
-- AlertDialog open/close 제어
-- 본문: "댓글을 삭제하시겠습니까?" + password Input
-- Confirm 버튼: `variant="destructive"` 또는 `bg-red-600` 류 — plan009 에 `--color-error` 가 있으면 그걸 사용 (`bg-[var(--color-error)]`)
+- AlertDialog open/close 제어 + password / isConfirming local state
+- 본문: "댓글을 삭제하시겠습니까?" + password Input (`type="password"`, controlled)
+- Confirm 버튼: `variant="destructive"` 또는 `bg-red-600` 류 — plan009 에 `--color-error` 가 있으면 그걸 사용 (`bg-[var(--color-error)]`). `disabled={isConfirming || password.length < 4}`
 - Cancel: `variant="outline"`
 
 ### 4. `src/components/Comments.tsx` 컨테이너로 슬림화
+
+**필수**: 첫 줄 `"use client";` 유지/명시 (`useState` / `useEffect` 사용).
 
 기존 354줄 → 약 100줄 컨테이너로:
 - `useState` 로 `comments`, `isLoading`, `editingId`, `deletingId` 만 관리
@@ -125,12 +176,35 @@ export interface DeleteConfirmDialogProps {
 - 빈 상태: `comments.length === 0 && !isLoading` 시 `text-[var(--color-fg-muted)] text-center py-12` "첫 댓글을 남겨주세요"
 - 로딩: skeleton row 3개 (`bg-[var(--color-bg-subtle)] animate-pulse h-24 rounded-[12px]`)
 
-### 5. `console.error("Failed to ...")` → `toast.error()` 대체
+### 5. `console.error("Failed to ...")` → `toast.error()` 대체 (에러 메시지 sanitization 포함)
 
-기존 alert / console.error 호출은 sonner toast 로 교체:
-- 작성 성공: `toast.success("댓글이 등록되었습니다")`
-- 작성 실패: `toast.error("댓글 등록 실패")` — 서버 에러 메시지 우선
-- 수정/삭제 동일 패턴
+기존 alert / console.error 호출은 sonner toast 로 교체. **서버 raw 메시지 클라이언트 직접 노출 금지** — SQL 구문 / 스택 / 내부 식별자 유출 위험.
+
+```ts
+// 작성 성공
+toast.success("댓글이 등록되었습니다");
+
+// 실패: 사용자 친화 일반 메시지만 toast, 상세 에러는 client console (개발용 로그만)
+try {
+  await fetch(...);
+} catch (error) {
+  console.error("[comments] create failed", error); // dev/prod 콘솔만
+  toast.error("댓글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.");
+}
+
+// 4xx 응답에서 사용자 의미 있는 메시지가 있을 때만 (예: "비밀번호가 일치하지 않습니다") 화이트리스트 매핑:
+const USER_FRIENDLY_ERRORS: Record<string, string> = {
+  PASSWORD_MISMATCH: "비밀번호가 일치하지 않습니다",
+  NOT_FOUND: "댓글을 찾을 수 없습니다",
+};
+const code = (await response.json())?.code;
+toast.error(USER_FRIENDLY_ERRORS[code] ?? "요청을 처리할 수 없습니다");
+```
+
+규칙:
+- 작성/수정/삭제 success/failure 모두 같은 패턴
+- `error.message` 또는 `data.message` 직접 toast 금지 (서버 정보 누출)
+- 알려진 사용자 의미 있는 코드는 화이트리스트로 매핑
 
 ### 6. 자동 verification
 

--- a/tasks/plan022-comments-redesign/phase-03.md
+++ b/tasks/plan022-comments-redesign/phase-03.md
@@ -1,0 +1,46 @@
+# Phase 03 — 검증 + docs 갱신 + 마킹
+
+**Model**: haiku
+**Goal**: phase 1+2 결과의 통합 검증 + post-detail.md 갱신 + index.json status 마킹.
+
+## 작업 항목
+
+### 1. 통합 검증
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+```
+
+오류 0건. 오류 있으면 phase 2 로 돌려 수정 후 재실행.
+
+### 2. `docs/pages/post-detail.md` 댓글 섹션 갱신
+
+기존 댓글 영역 설명을 plan022 기준으로 한 단락 갱신:
+- 컴포넌트 분리: `Comments` (컨테이너) / `CommentForm` / `CommentItem` / `DeleteConfirmDialog` / `Avatar`
+- 폼 검증: react-hook-form + zod
+- 알림: sonner toast
+- 아바타: nickname hash 기반 9색 자동 선택
+- threading 미포함 (의도적 — schema 변경 회피)
+
+기존 내용이 자세히 들어가 있다면 짧게 (3~4줄) 압축. docs 작성 원칙 준수 — 컨텍스트 효율.
+
+### 3. `tasks/plan022-comments-redesign/index.json` status 마킹
+
+`status` 와 phase 1/2/3 의 `status` 모두 `"completed"` 로 갱신.
+
+### 4. 자동 verification
+
+```bash
+grep -n "plan022\|CommentForm\|Avatar" docs/pages/post-detail.md | head -5
+grep -n "\"completed\"" tasks/plan022-comments-redesign/index.json | wc -l  # 4 (top + 3 phases)
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `docs/pages/post-detail.md` | 수정 |
+| `tasks/plan022-comments-redesign/index.json` | 수정 (status) |


### PR DESCRIPTION
## Summary

- plan022-comments-redesign task 파일 추가 — 댓글 영역 전면 리디자인
- 3 phases (sonnet × 2 + haiku × 1), schema 변경 없음

## 진단

`Comments.tsx` 354줄 + plan009 디자인 시스템 완전 단절 (`bg-blue-600` / `bg-gray-*` / `text-gray-*` 전반).

## 작업 결정 (사용자 2026-05-06)

| 항목 | 결정 |
|---|---|
| Threading (답글) | 추가 안 함 — schema 변경 회피, F6 범위는 UI 리디자인만 |
| Avatar | Nickname 이니셜 + plan009 카테고리 9색 hash 자동 선택 |
| shadcn 도입 | 전체 (Form / Input / Textarea / Button / AlertDialog) + sonner Toast |
| Form validation | react-hook-form + zod |

## Phase 구성

- **Phase 1**: shadcn 컴포넌트 install + sonner Toaster 마운트 + Avatar/CommentItem skeleton 분리
- **Phase 2**: Comments.tsx 리팩토링 (컨테이너 슬림화, CommentForm/DeleteConfirmDialog 신규, plan009 토큰)
- **Phase 3**: 검증 + post-detail.md 갱신 + 마킹

## Test plan

- [ ] 별도 세션에서 `python3 .claude/skills/plan-and-build/run-phases.py tasks/plan022-comments-redesign` 실행
- [ ] 댓글 작성/수정/삭제 + password 인증 동작 확인
- [ ] 다크/라이트 양쪽 시각 smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)