### PR TITLE
feat(comments): plan022 redesign — shadcn + rhf + zod + sonner + Avatar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ Next.js 16 developer blog that syncs Markdown from `jon890/fos-study` (GitHub) �
 | Database    | MySQL 8.4 (Docker) + Drizzle ORM 0.45.1                                |
 | GitHub API  | @octokit/rest 21.0.0                                                   |
 | Markdown    | unified (remark-parse + remark-gfm + remark-rehype) + rehype-pretty-code (shiki, dual theme) + rehype-slug + rehype-raw + hast-util-to-jsx-runtime + mermaid |
-| Logging     | pino (JSON) + pino-pretty (dev only)                                   |
+| Logging     | pino (JSON) + pino-pretty (dev only) — server only                     |
+| Forms       | react-hook-form 7.x + @hookform/resolvers + zod (CommentForm 등 client form) |
+| Toast       | sonner 2.x (client 알림, ThemeProvider 바깥 mount)                       |
 | Testing     | Vitest 4.1.0                                                           |
 | Package mgr | pnpm 9.15.0                                                            |
 
@@ -96,7 +98,7 @@ See `.env.example` for full list.
 - **Components:** PascalCase, named exports, no direct DB calls
 - **TypeScript:** strict mode, `@/*` path alias, `_` prefix for unused vars
 - **Tailwind:** `src/app/globals.css` must include `@source` for every dir with Tailwind classes
-- **Logging:** `logger.child({ module: '...' })` from `@/lib/logger` — no `console.log`. **예외**: `scripts/*.ts` 는 standalone 실행이라 path alias 미동작 → `console.log/error` 허용 (eslint.config.mjs 에서 globals 명시)
+- **Logging:** `logger.child({ module: '...' })` from `@/lib/logger` — no `console.log`. **예외**: ① `scripts/*.ts` 는 standalone 실행이라 path alias 미동작 → `console.log/error` 허용 (eslint.config.mjs 에서 globals 명시). ② `"use client"` 컴포넌트는 pino 가 server-only 라 `console.error` 만 사용 가능 (catch 블록의 dev 로그용 — 사용자 노출은 별도 toast/UI 로 처리, raw error 는 직접 노출 금지)
 - **Error handling:** `err: error instanceof Error ? error : new Error(String(error))`
 - **Tests:** co-located `*.test.ts`, Vitest, mock repositories with `vi.mock()`
 - **API routes:** Bearer token auth via `SYNC_API_KEY`

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -47,6 +47,7 @@
 
 - [ADR-019](#adr-019) — 코드 블록 하이라이팅 (rehype-pretty-code + shiki dual theme)
 - [ADR-020](#adr-020) — 마크다운 변환 react-markdown → unified async (server component, plan014)
+- [ADR-021](#adr-021) — 댓글 디자인 라이브러리 + 보안 정책 (rhf + zod + sonner / escapeHtml 단방향 / USER_FRIENDLY_ERRORS / og-palette 분리, plan022)
 
 ---
 
@@ -329,6 +330,7 @@
 - **다크 우선**: default `dark` 유지 (Vercel/Linear 컨벤션, 현 동작과 일치)
 - **토큰 시스템**: Tailwind v4 `@theme` 블록 (`globals.css`) 으로 표준화 — 컬러/타이포/spacing/radii/shadows/motion primitives
 - **카테고리 9종 (canonical)**: `ai / algorithm / db / devops / java / js / react / next / system` — oklch chroma 0.09, lightness 0.74 (dark) / 0.50 (light). 데이터의 raw 카테고리 키 (architecture/network/interview/kafka/internet 등) 는 헬퍼 (`src/lib/category-meta.ts`, plan010) 에서 9종 중 하나로 정규화 (미매핑 → `system`)
+- **OG / Avatar 팔레트는 7색 부분집합** (plan021/022): `og-palette.ts` 의 `OG_CATEGORY_HEX` 는 9종 중 `next` / `system` 제외한 7개만 hex 매핑. 이유: hash % palette.length 라 색 다양성만 충분하면 되고 `system` 은 fallback (`OG_CATEGORY_DEFAULT_HEX` brand teal) 와 의미가 겹침. `next` 는 forward-compat 자리
 - **워크플로우**: Claude Design (Anthropic Labs Research Preview) 으로 mockup 생성 → 이 저장소에서 코드 구현. 단계별 프롬프트는 `docs/design-inspiration.md`
 
 **Why**:
@@ -392,3 +394,29 @@
   - theme dual → single — 라이트/다크 토글 색 깨짐, 디자인 시스템 (ADR-017/019) 후퇴
   - react-markdown 의 async 모드 — 라이브러리 미지원 (sync 전용 설계)
 - **트레이드오프**: react-markdown 의 `components` prop 사용 코드를 `hast-util-to-jsx-runtime` 형태로 일괄 이전 필요. 번들은 순수 감소 (react-markdown 제거, unified / remark-parse / remark-rehype / hast-util-to-jsx-runtime 은 transitive 였음 → direct dep promote 만).
+
+
+<a id="adr-021"></a>
+
+## ADR-021. 댓글 디자인 라이브러리 + 보안 정책 (plan022)
+
+**Context**: 댓글 영역 354줄 자체 구현 (`Comments.tsx`) 을 plan022 에서 shadcn + react-hook-form + zod + sonner 로 전면 리디자인. UI 라이브러리 선택과 함께 client 번들 격리 / XSS 가드 / 사용자 노출 메시지 정책 동시 결정.
+
+**Decision**:
+
+1. **Form**: `react-hook-form` + `@hookform/resolvers` + `zod`. shadcn `Form` (Controller wrapper) 사용. 모드 별 schema 분리 (`createSchema` / `editSchema = createSchema.pick({password, content})`) + props discriminated union.
+2. **Toast**: `sonner` 2.x (~6KB). `<Toaster />` 는 `<ThemeProvider>` 바깥에 mount (shadcn 권장).
+3. **Avatar 팔레트**: `og-palette.ts` 신규 — `OG_CATEGORY_HEX` (7색) + `getCategoryHex` 의 단일 소스. `og.ts` 는 re-export 만. **이유**: `og.ts` 가 `node:fs` import 하므로 client component (Avatar.tsx) 에서 직접 import 시 Turbopack 이 fs 를 클라이언트 번들에 포함하려다 실패. palette 데이터를 pure module 로 떼면서 단일 소스 유지.
+4. **Comment 타입**: `src/components/comments/types.ts` 신규 (`CommentData`). client component 가 `@/infra/db/schema/comments` (Drizzle) 직접 import 시 같은 번들 오염 발생 → 분리.
+5. **XSS 가드 (단방향 저장 시점 escape)**: `src/lib/escape-html.ts` 의 `escapeHtml` (5문자: `& < > " '`) 을 `CommentRepository.createComment` / `updateComment` 의 `content` 인자에 적용. **read 시 unescape 없음** — React JSX text node 가 자동 escape 하므로 이중 escape 회피 (1회만 적용). `dangerouslySetInnerHTML` 사용 금지.
+6. **에러 메시지 정책 (`USER_FRIENDLY_ERRORS` 화이트리스트)**: API 에러 응답에 `code` 필드 (`PASSWORD_MISMATCH` / `NOT_FOUND` 등) 포함, 클라이언트는 `USER_FRIENDLY_ERRORS[code] ?? "요청을 처리할 수 없습니다"` 로 매핑하여 toast. **`error.message` / `data.message` 직접 toast 금지** — SQL 구문 / 스택 / 내부 식별자 누출 위험.
+
+**Why**:
+
+- **react-hook-form 채택**: uncontrolled form → 리렌더 최소화 + zod 통합. 자체 useState 폼 대비 valida tion 로직 통일 + 타입 안전. shadcn `Form` 가 thin wrapper 라 lock-in 없음
+- **sonner 채택**: 자체 toast 구현 회피 (~6KB), shadcn 공식 권장. dark/light 자동 (theme="system")
+- **단일 소스 og-palette**: plan021 의 `OG_CATEGORY_HEX` 와 댓글 Avatar 팔레트가 같은 색이어야 — 색 변경 시 한 파일만 수정. 단 server-only deps 격리 위해 pure module 로 분리
+- **단방향 escape**: React 가 이미 한 번 escape 하므로 read 시점 unescape = 이중 escape → `&amp;lt;` 같은 잘못된 표시. 저장 시 1회만 적용이 정답. dompurify 같은 풀 라이브러리 회피 — 댓글은 markdown 미지원 plain text 라 5문자 escape 면 충분
+- **USER_FRIENDLY_ERRORS 화이트리스트**: 서버 raw error 노출은 SQL injection probe / 정보 노출 공격면 확장. code 필드 명시적 매핑이 모든 메시지의 단일 진입점
+
+**Scope 명시**: 이 ADR 의 정책은 댓글 영역 한정. 다른 client form (검색 dialog, 향후 로그인) 도입 시 이 결정을 ADR-021 의 패턴으로 따른다 (rhf + zod + sonner + USER_FRIENDLY_ERRORS).

--- a/docs/pages/post-detail.md
+++ b/docs/pages/post-detail.md
@@ -43,7 +43,7 @@
 | `ReadingProgressBar` | viewport 최상단 fixed 1px 진행 띠 (`z-50`, plan019). passive scroll/resize listener → 0~100 % width. brand-400 토큰 색상. `role="progressbar"` + `aria-valuenow` 접근성 메타. Header 의 하단 라인 reading progress 와 별개로 viewport 절대 최상단에서 동작 |
 | `MobileTocButton` | 모바일 전용 floating TOC FAB + bottom sheet (plan019, `md:hidden`). 우하단 원형 brand 버튼 (lucide `List`) → 클릭 시 fixed bottom sheet (`role="dialog" aria-modal="true"`) 펼침. ESC keydown / backdrop click 으로 닫기 (둘 다 useEffect cleanup 에서 listener 해제). 단순 fixed div + state — `<dialog>` element 미사용 (SSR hydration mismatch 회피 의도). H2/H3 nesting 동일 적용. `toc.length === 0` 시 자체 미렌더 |
 | `ArticleFooter` | `frontmatter.tags` 가 있는 경우만 렌더되는 태그 칩 영역 (graceful fallback) |
-| `Comments` | 댓글 섹션 (postPath 전달) |
+| `Comments` | 댓글 컨테이너 (plan022). 자식: `CommentForm` (작성/수정, react-hook-form + zod) / `CommentItem` (카드, nickname hash avatar + 상대 시간) / `DeleteConfirmDialog` (shadcn AlertDialog + password). 알림: sonner toast. 아바타 색상: `OG_CATEGORY_HEX` 7색 팔레트 hash — plan021 단일 소스. threading 미포함(의도적) |
 | `ArticleJsonLd` | JSON-LD 아티클 구조화 데이터 |
 | `BreadcrumbJsonLd` | JSON-LD 브레드크럼 |
 
@@ -136,7 +136,11 @@
 - `src/components/ReadingProgressBar.tsx` — viewport 최상단 1px 진행 띠 (plan019)
 - `src/components/MobileTocButton.tsx` — 모바일 floating TOC button + bottom sheet (plan019)
 - `src/components/Header.tsx` — `/posts/*` 한정 하단 라인 reading progress (별개 컴포넌트)
-- `src/components/Comments.tsx`
+- `src/components/Comments.tsx` — 댓글 컨테이너 (plan022)
+- `src/components/comments/CommentForm.tsx` — 작성/수정 통합 폼
+- `src/components/comments/CommentItem.tsx` — 댓글 카드
+- `src/components/comments/DeleteConfirmDialog.tsx` — 삭제 확인 다이얼로그
+- `src/components/comments/Avatar.tsx` — nickname hash 색상 아바타
 - `src/components/JsonLd.tsx`
 - `src/infra/db/repositories/PostRepository.ts`
 - `src/infra/db/repositories/VisitRepository.ts` — `getVisitCount(pagePath)`

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@hookform/resolvers": "^5.2.2",
     "@octokit/rest": "^21.0.0",
     "@t3-oss/env-nextjs": "^0.13.11",
     "bcryptjs": "^3.0.3",
@@ -36,6 +37,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hook-form": "^7.75.0",
     "rehype-pretty-code": "^0.14.3",
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
@@ -44,6 +46,7 @@
     "remark-rehype": "^11.1.2",
     "shadcn": "^4.5.0",
     "shiki": "^4.0.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "unified": "^11.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.75.0(react@19.2.4))
       '@octokit/rest':
         specifier: ^21.0.0
         version: 21.1.1
@@ -68,6 +71,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.4(react@19.2.4)
+      react-hook-form:
+        specifier: ^7.75.0
+        version: 7.75.0(react@19.2.4)
       rehype-pretty-code:
         specifier: ^0.14.3
         version: 0.14.3(shiki@4.0.2)
@@ -92,6 +98,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -892,6 +901,11 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1418,6 +1432,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -4298,6 +4315,12 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-hook-form@7.75.0:
+    resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -4534,6 +4557,12 @@ packages:
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5667,6 +5696,11 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.75.0(react@19.2.4))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.75.0(react@19.2.4)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -6109,6 +6143,8 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -9394,6 +9430,10 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-hook-form@7.75.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   react-is@16.13.1: {}
 
   react@19.2.4: {}
@@ -9796,6 +9836,11 @@ snapshots:
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -43,7 +43,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
     if (!updatedComment) {
       return NextResponse.json(
-        { error: "댓글을 찾을 수 없습니다." },
+        { code: "NOT_FOUND", error: "댓글을 찾을 수 없습니다." },
         { status: 404 }
       );
     }
@@ -51,7 +51,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ comment: updatedComment });
   } catch (error) {
     if (error instanceof Error && error.message === "비밀번호가 일치하지 않습니다.") {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ code: "PASSWORD_MISMATCH", error: error.message }, { status: 403 });
     }
     log.error({ err: error instanceof Error ? error : new Error(String(error)) }, "Failed to update comment");
     return NextResponse.json(
@@ -89,7 +89,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
 
     if (!deleted) {
       return NextResponse.json(
-        { error: "댓글을 찾을 수 없습니다." },
+        { code: "NOT_FOUND", error: "댓글을 찾을 수 없습니다." },
         { status: 404 }
       );
     }
@@ -97,7 +97,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ success: true });
   } catch (error) {
     if (error instanceof Error && error.message === "비밀번호가 일치하지 않습니다.") {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ code: "PASSWORD_MISMATCH", error: error.message }, { status: 403 });
     }
     log.error({ err: error instanceof Error ? error : new Error(String(error)) }, "Failed to delete comment");
     return NextResponse.json(

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import Script from "next/script";
+import { Toaster } from "sonner";
 import "./globals.css";
 import { env } from "@/env";
 import { OG_WIDTH, OG_HEIGHT } from "@/lib/og";
@@ -145,6 +146,17 @@ export default function RootLayout({
           </div>
           </SidebarProvider>
         </ThemeProvider>
+        <Toaster
+          position="bottom-center"
+          theme="system"
+          toastOptions={{
+            classNames: {
+              toast: "bg-[var(--color-bg-elevated)] text-[var(--color-fg-primary)] border border-[var(--color-border-subtle)]",
+              success: "text-[var(--color-brand-400)]",
+              error: "text-red-400",
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,15 +1,20 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { MessageCircle, Send, Trash2, Edit2, X, Check } from "lucide-react";
+import { MessageCircle } from "lucide-react";
+import { toast } from "sonner";
+import type { CommentData } from "@/components/comments/types";
+import { CommentForm, type CommentFormValues } from "@/components/comments/CommentForm";
+import { CommentItem } from "@/components/comments/CommentItem";
+import { DeleteConfirmDialog } from "@/components/comments/DeleteConfirmDialog";
 
-interface Comment {
-  id: number;
-  postSlug: string;
-  nickname: string;
-  content: string;
-  createdAt: string | null;
-  updatedAt: string | null;
+const USER_FRIENDLY_ERRORS: Record<string, string> = {
+  PASSWORD_MISMATCH: "비밀번호가 일치하지 않습니다",
+  NOT_FOUND: "댓글을 찾을 수 없습니다",
+};
+
+function friendlyError(code: string | undefined): string {
+  return USER_FRIENDLY_ERRORS[code ?? ""] ?? "요청을 처리할 수 없습니다";
 }
 
 interface CommentsProps {
@@ -17,338 +22,157 @@ interface CommentsProps {
 }
 
 export function Comments({ postSlug }: CommentsProps) {
-  const [comments, setComments] = useState<Comment[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [comments, setComments] = useState<CommentData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editingComment, setEditingComment] = useState<CommentData | null>(null);
+  const [deletingComment, setDeletingComment] = useState<CommentData | null>(null);
 
-  // 새 댓글 작성 폼
-  const [nickname, setNickname] = useState("");
-  const [password, setPassword] = useState("");
-  const [content, setContent] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-
-  // 수정/삭제 상태
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [editContent, setEditContent] = useState("");
-  const [deleteId, setDeleteId] = useState<number | null>(null);
-  const [actionPassword, setActionPassword] = useState("");
-
-  // 댓글 목록 조회
   useEffect(() => {
     let isMounted = true;
     const fetchComments = async () => {
       try {
-        setLoading(true);
-        const res = await fetch(
-          `/api/comments?slug=${encodeURIComponent(postSlug)}`
-        );
+        setIsLoading(true);
+        const res = await fetch(`/api/comments?slug=${encodeURIComponent(postSlug)}`);
         const data = await res.json();
         if (isMounted) {
           if (res.ok) {
             setComments(data.comments);
           } else {
-            setError(data.error);
+            toast.error("댓글을 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.");
           }
         }
-      } catch {
-        if (isMounted) setError("댓글을 불러오는데 실패했습니다.");
+      } catch (error) {
+        console.error("[comments] fetch failed", error);
+        if (isMounted) toast.error("댓글을 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.");
       } finally {
-        if (isMounted) setLoading(false);
+        if (isMounted) setIsLoading(false);
       }
     };
 
     fetchComments();
-
-    return () => {
-      isMounted = false;
-    };
+    return () => { isMounted = false; };
   }, [postSlug]);
 
-  // 댓글 작성
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSubmitting(true);
-    setError(null);
-
+  const handleCreate = async (values: CommentFormValues) => {
     try {
       const res = await fetch("/api/comments", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ postSlug, nickname, password, content }),
+        body: JSON.stringify({ postSlug, ...values }),
       });
       const data = await res.json();
-
       if (res.ok) {
         setComments((prev) => [data.comment, ...prev]);
-        setContent("");
-        // 닉네임과 비밀번호는 유지
+        toast.success("댓글이 등록되었습니다");
       } else {
-        setError(data.error);
+        toast.error(friendlyError(data.code));
       }
-    } catch {
-      setError("댓글 작성에 실패했습니다.");
-    } finally {
-      setSubmitting(false);
+    } catch (error) {
+      console.error("[comments] create failed", error);
+      toast.error("댓글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
   };
 
-  // 댓글 수정
-  const handleEdit = async (id: number) => {
-    setError(null);
+  const handleEdit = async (values: CommentFormValues) => {
+    if (!editingComment) return;
     try {
-      const res = await fetch(`/api/comments/${id}`, {
+      const res = await fetch(`/api/comments/${editingComment.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          password: actionPassword,
-          content: editContent,
-        }),
+        body: JSON.stringify(values),
       });
       const data = await res.json();
-
       if (res.ok) {
-        setComments((prev) => prev.map((c) => (c.id === id ? data.comment : c)));
-        setEditingId(null);
-        setEditContent("");
-        setActionPassword("");
+        setComments((prev) =>
+          prev.map((c) => (c.id === editingComment.id ? data.comment : c))
+        );
+        setEditingComment(null);
+        toast.success("댓글이 수정되었습니다");
       } else {
-        setError(data.error);
+        toast.error(friendlyError(data.code));
       }
-    } catch {
-      setError("댓글 수정에 실패했습니다.");
+    } catch (error) {
+      console.error("[comments] edit failed", error);
+      toast.error("댓글 수정에 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
   };
 
-  // 댓글 삭제
-  const handleDelete = async (id: number) => {
-    setError(null);
+  const handleDelete = async (password: string) => {
+    if (!deletingComment) return;
     try {
-      const res = await fetch(`/api/comments/${id}`, {
+      const res = await fetch(`/api/comments/${deletingComment.id}`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password: actionPassword }),
+        body: JSON.stringify({ password }),
       });
       const data = await res.json();
-
       if (res.ok) {
-        setComments((prev) => prev.filter((c) => c.id !== id));
-        setDeleteId(null);
-        setActionPassword("");
+        setComments((prev) => prev.filter((c) => c.id !== deletingComment.id));
+        setDeletingComment(null);
+        toast.success("댓글이 삭제되었습니다");
       } else {
-        setError(data.error);
+        toast.error(friendlyError(data.code));
       }
-    } catch {
-      setError("댓글 삭제에 실패했습니다.");
+    } catch (error) {
+      console.error("[comments] delete failed", error);
+      toast.error("댓글 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.");
     }
-  };
-
-  const formatDate = (dateStr: string | null) => {
-    if (!dateStr) return "";
-    const date = new Date(dateStr);
-    return date.toLocaleDateString("ko-KR", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
   };
 
   return (
-    <section className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800">
-      <h2 className="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white mb-6">
-        <MessageCircle className="w-5 h-5" />
-        댓글 {comments.length > 0 ? `(${comments.length})` : null}
+    <section className="mt-12 pt-8 border-t border-[var(--color-border-subtle)]">
+      <h2 className="flex items-center gap-2 text-xl font-semibold text-[var(--color-fg-primary)] mb-6">
+        <MessageCircle className="w-5 h-5 text-[var(--color-brand-400)]" />
+        댓글 ({comments.length})
       </h2>
 
-      {/* 에러 메시지 */}
-      {error ? (
-        <div className="mb-4 p-3 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-sm">
-          {error}
-        </div>
-      ) : null}
-
-      {/* 댓글 작성 폼 */}
-      <form onSubmit={handleSubmit} className="mb-8 space-y-4">
-        <div className="grid grid-cols-2 gap-4">
-          <input
-            type="text"
-            placeholder="닉네임"
-            aria-label="닉네임"
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
-            maxLength={100}
-            required
-            className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
-          />
-          <input
-            type="password"
-            placeholder="비밀번호 (4자 이상)"
-            aria-label="비밀번호"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            minLength={4}
-            required
-            className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
+      {editingComment ? (
+        <div className="mb-8">
+          <CommentForm
+            mode="edit"
+            initialContent={editingComment.content}
+            initialNickname={editingComment.nickname}
+            onSubmit={handleEdit}
+            onCancel={() => setEditingComment(null)}
           />
         </div>
-        <textarea
-          placeholder="댓글을 작성해주세요..."
-          aria-label="댓글 내용"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          maxLength={5000}
-          required
-          rows={4}
-          className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none resize-none"
-        />
-        <div className="flex justify-end">
-          <button
-            type="submit"
-            disabled={submitting}
-            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <Send className="w-4 h-4" />
-            {submitting ? "작성 중..." : "댓글 작성"}
-          </button>
+      ) : (
+        <div className="mb-8">
+          <CommentForm mode="create" onSubmit={handleCreate} />
         </div>
-      </form>
+      )}
 
-      {/* 댓글 목록 */}
-      {loading ? (
-        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-          댓글을 불러오는 중...
+      {isLoading ? (
+        <div className="space-y-4">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="bg-[var(--color-bg-subtle)] animate-pulse h-24 rounded-[12px]"
+            />
+          ))}
         </div>
       ) : comments.length === 0 ? (
-        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-          아직 댓글이 없습니다. 첫 댓글을 작성해보세요!
-        </div>
+        <p className="text-[var(--color-fg-muted)] text-center py-12">
+          첫 댓글을 남겨주세요
+        </p>
       ) : (
         <div className="space-y-4">
           {comments.map((comment) => (
-            <div
+            <CommentItem
               key={comment.id}
-              className="p-4 rounded-lg bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700"
-            >
-              {/* 수정 모드 */}
-              {editingId === comment.id ? (
-                <div className="space-y-3">
-                  <textarea
-                    value={editContent}
-                    onChange={(e) => setEditContent(e.target.value)}
-                    rows={3}
-                    className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white outline-none resize-none"
-                  />
-                  <input
-                    type="password"
-                    placeholder="비밀번호 확인"
-                    value={actionPassword}
-                    onChange={(e) => setActionPassword(e.target.value)}
-                    className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white outline-none"
-                  />
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => handleEdit(comment.id)}
-                      className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm"
-                    >
-                      <Check className="w-4 h-4" />
-                      수정
-                    </button>
-                    <button
-                      onClick={() => {
-                        setEditingId(null);
-                        setEditContent("");
-                        setActionPassword("");
-                      }}
-                      className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-sm"
-                    >
-                      <X className="w-4 h-4" />
-                      취소
-                    </button>
-                  </div>
-                </div>
-              ) : deleteId === comment.id ? (
-                /* 삭제 확인 모드 */
-                <div className="space-y-3">
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    댓글을 삭제하려면 비밀번호를 입력해주세요.
-                  </p>
-                  <input
-                    type="password"
-                    placeholder="비밀번호 확인"
-                    value={actionPassword}
-                    onChange={(e) => setActionPassword(e.target.value)}
-                    className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white outline-none"
-                  />
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => handleDelete(comment.id)}
-                      className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                      삭제
-                    </button>
-                    <button
-                      onClick={() => {
-                        setDeleteId(null);
-                        setActionPassword("");
-                      }}
-                      className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-sm"
-                    >
-                      <X className="w-4 h-4" />
-                      취소
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                /* 일반 모드 */
-                <>
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium text-gray-900 dark:text-white">
-                        {comment.nickname}
-                      </span>
-                      <span className="text-sm text-gray-500 dark:text-gray-400">
-                        {formatDate(comment.createdAt)}
-                      </span>
-                    </div>
-                    <div className="flex gap-1">
-                      <button
-                        onClick={() => {
-                          setEditingId(comment.id);
-                          setEditContent(comment.content);
-                          setDeleteId(null);
-                          setActionPassword("");
-                        }}
-                        className="p-1.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400 transition-colors"
-                        title="수정"
-                        aria-label="댓글 수정"
-                      >
-                        <Edit2 className="w-4 h-4" />
-                      </button>
-                      <button
-                        onClick={() => {
-                          setDeleteId(comment.id);
-                          setEditingId(null);
-                          setActionPassword("");
-                        }}
-                        className="p-1.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400 transition-colors"
-                        title="삭제"
-                        aria-label="댓글 삭제"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </div>
-                  <p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
-                    {comment.content}
-                  </p>
-                </>
-              )}
-            </div>
+              comment={comment}
+              onEdit={setEditingComment}
+              onDelete={setDeletingComment}
+            />
           ))}
         </div>
       )}
+
+      <DeleteConfirmDialog
+        open={deletingComment !== null}
+        onOpenChange={(open) => { if (!open) setDeletingComment(null); }}
+        onConfirm={handleDelete}
+      />
     </section>
   );
 }

--- a/src/components/comments/Avatar.tsx
+++ b/src/components/comments/Avatar.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { OG_CATEGORY_HEX } from "@/lib/og-palette";
+
+// plan021 의 OG_CATEGORY_HEX 를 단일 소스로 재사용 — 색상 변경 시 OG/Avatar 일관성 보장.
+// record → array 변환은 hash 모듈로 안정적으로 인덱스화하기 위함.
+const AVATAR_PALETTE = Object.values(OG_CATEGORY_HEX);
+
+function hashNickname(nickname: string): number {
+  let h = 0;
+  for (const ch of nickname) {
+    h = (h * 31 + ch.charCodeAt(0)) | 0;
+  }
+  return Math.abs(h);
+}
+
+const SIZE_CLASS: Record<number, string> = {
+  28: "h-7 w-7",
+  36: "h-9 w-9",
+};
+
+export function Avatar({ nickname, size = 36 }: { nickname: string; size?: number }) {
+  const initial = nickname.trim().charAt(0).toUpperCase() || "?";
+  const color = AVATAR_PALETTE[hashNickname(nickname) % AVATAR_PALETTE.length];
+  const sizeClass = SIZE_CLASS[size] ?? "h-9 w-9";
+  return (
+    <div
+      role="img"
+      aria-label={`${nickname} 아바타`}
+      style={{ background: `${color}26`, color, borderColor: `${color}80` }}
+      className={`${sizeClass} flex items-center justify-center rounded-full border font-semibold select-none`}
+    >
+      {initial}
+    </div>
+  );
+}

--- a/src/components/comments/CommentForm.tsx
+++ b/src/components/comments/CommentForm.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+const createSchema = z.object({
+  nickname: z.string().min(1, "닉네임을 입력하세요").max(100),
+  password: z.string().min(4, "비밀번호는 4자 이상").max(255),
+  content: z.string().min(1, "내용을 입력하세요").max(5000),
+});
+const editSchema = createSchema.pick({ password: true, content: true });
+
+type CreateValues = z.infer<typeof createSchema>;
+type EditValues = z.infer<typeof editSchema>;
+export type CommentFormValues = CreateValues | EditValues;
+
+export type CommentFormProps =
+  | {
+      mode: "create";
+      onSubmit: (values: CreateValues) => Promise<void>;
+      onCancel?: () => void;
+    }
+  | {
+      mode: "edit";
+      initialContent: string;
+      initialNickname: string;
+      onSubmit: (values: EditValues) => Promise<void>;
+      onCancel?: () => void;
+    };
+
+export function CommentForm(props: CommentFormProps) {
+  const isEdit = props.mode === "edit";
+
+  const form = useForm<CreateValues | EditValues>({
+    resolver: zodResolver(isEdit ? editSchema : createSchema),
+    defaultValues: isEdit
+      ? { password: "", content: props.initialContent }
+      : { nickname: "", password: "", content: "" },
+  });
+
+  const isSubmitting = form.formState.isSubmitting;
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    if (props.mode === "edit") {
+      await props.onSubmit(values as EditValues);
+    } else {
+      await props.onSubmit(values as CreateValues);
+      form.reset();
+    }
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {isEdit ? (
+          <p className="text-sm text-[var(--color-fg-muted)]">
+            수정 중: <span className="font-medium text-[var(--color-fg-primary)]">{props.initialNickname}</span>
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              control={form.control}
+              name="nickname"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>닉네임</FormLabel>
+                  <FormControl>
+                    <Input placeholder="닉네임" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>비밀번호</FormLabel>
+                  <FormControl>
+                    <Input type="password" placeholder="비밀번호 (4자 이상)" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        )}
+
+        {isEdit && (
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>비밀번호 확인</FormLabel>
+                <FormControl>
+                  <Input type="password" placeholder="비밀번호" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>내용</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="댓글을 작성해주세요..."
+                  rows={4}
+                  className="resize-none"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex justify-end gap-2">
+          {props.onCancel && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={props.onCancel}
+              disabled={isSubmitting}
+            >
+              취소
+            </Button>
+          )}
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting && <Loader2 className="animate-spin" />}
+            {isEdit ? "수정" : "댓글 작성"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Edit2, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Avatar } from "@/components/comments/Avatar";
+import { formatRelativeTime } from "@/lib/format-time";
+import type { CommentData } from "@/components/comments/types";
+
+export interface CommentItemProps {
+  comment: CommentData;
+  onEdit: (comment: CommentData) => void;
+  onDelete: (comment: CommentData) => void;
+}
+
+export function CommentItem({ comment, onEdit, onDelete }: CommentItemProps) {
+  return (
+    <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] rounded-[12px] p-5">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2.5">
+          <Avatar nickname={comment.nickname} size={36} />
+          <span className="text-[var(--color-fg-primary)] font-medium">
+            {comment.nickname}
+          </span>
+          <span className="text-[var(--color-fg-muted)] text-sm">
+            {comment.createdAt ? formatRelativeTime(comment.createdAt) : ""}
+          </span>
+        </div>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="댓글 수정"
+            onClick={() => onEdit(comment)}
+          >
+            <Edit2 className="w-4 h-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="댓글 삭제"
+            onClick={() => onDelete(comment)}
+          >
+            <Trash2 className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+      <p className="text-[var(--color-fg-secondary)] leading-relaxed whitespace-pre-wrap">
+        {comment.content}
+      </p>
+    </div>
+  );
+}

--- a/src/components/comments/DeleteConfirmDialog.tsx
+++ b/src/components/comments/DeleteConfirmDialog.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+
+export interface DeleteConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (password: string) => Promise<void>;
+}
+
+export function DeleteConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: DeleteConfirmDialogProps) {
+  const [password, setPassword] = useState("");
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  const handleConfirm = async () => {
+    setIsConfirming(true);
+    try {
+      await onConfirm(password);
+      setPassword("");
+    } finally {
+      setIsConfirming(false);
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setPassword("");
+    onOpenChange(next);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>댓글 삭제</AlertDialogTitle>
+          <AlertDialogDescription>
+            댓글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          type="password"
+          placeholder="비밀번호 입력"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="current-password"
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isConfirming}>취소</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            disabled={isConfirming || password.length < 4}
+            onClick={handleConfirm}
+          >
+            {isConfirming ? "삭제 중..." : "삭제"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/comments/types.ts
+++ b/src/components/comments/types.ts
@@ -1,0 +1,9 @@
+// 클라이언트 컴포넌트에서 사용하는 댓글 타입 — Drizzle 스키마 직접 import 시 node:fs 번들 오염 방지
+export interface CommentData {
+  id: number;
+  postSlug: string;
+  nickname: string;
+  content: string;
+  createdAt: Date | string | null;
+  updatedAt: Date | string | null;
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,3 @@
-"use client"
-
-import * as React from "react"
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -48,7 +45,7 @@ function Button({
   variant = "default",
   size = "default",
   ...props
-}: React.ComponentProps<typeof ButtonPrimitive> & VariantProps<typeof buttonVariants>) {
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
   return (
     <ButtonPrimitive
       data-slot="button"

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import * as React from "react";
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+);
+
+function FormItem({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  );
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<"label">) {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      data-slot="form-label"
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+}
+
+function FormControl({ children }: { children: React.ReactElement<React.HTMLAttributes<HTMLElement>> }) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+
+  return React.cloneElement(children, {
+    id: formItemId,
+    "aria-describedby": !error
+      ? formDescriptionId
+      : `${formDescriptionId} ${formMessageId}`,
+    "aria-invalid": !!error,
+  } as React.HTMLAttributes<HTMLElement>);
+}
+
+function FormDescription({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function FormMessage({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message ?? "") : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/infra/db/repositories/CommentRepository.ts
+++ b/src/infra/db/repositories/CommentRepository.ts
@@ -2,6 +2,7 @@ import { eq, desc } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 import { comments } from "../schema";
 import { BaseRepository } from "./BaseRepository";
+import { escapeHtml } from "@/lib/escape-html";
 
 export interface CommentData {
   id: number;
@@ -46,7 +47,7 @@ export class CommentRepository extends BaseRepository {
       postSlug: input.postSlug,
       nickname: input.nickname,
       password: hashedPassword,
-      content: input.content,
+      content: escapeHtml(input.content),
     });
 
     const insertId = result[0].insertId;
@@ -87,7 +88,7 @@ export class CommentRepository extends BaseRepository {
       throw new Error("비밀번호가 일치하지 않습니다.");
     }
 
-    await this.db.update(comments).set({ content }).where(eq(comments.id, id));
+    await this.db.update(comments).set({ content: escapeHtml(content) }).where(eq(comments.id, id));
 
     const updated = await this.db
       .select({

--- a/src/lib/escape-html.test.ts
+++ b/src/lib/escape-html.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml } from "./escape-html";
+
+describe("escapeHtml", () => {
+  it("escapes script tags", () => {
+    expect(escapeHtml("<script>alert(1)</script>")).toBe(
+      "&lt;script&gt;alert(1)&lt;/script&gt;"
+    );
+  });
+
+  it("escapes ampersand", () => {
+    expect(escapeHtml("a&b")).toBe("a&amp;b");
+  });
+
+  it("escapes all 5 characters in one pass", () => {
+    expect(escapeHtml(`<>&"'`)).toBe("&lt;&gt;&amp;&quot;&#39;");
+  });
+
+  it("escapes consecutive duplicates", () => {
+    expect(escapeHtml("&&&")).toBe("&amp;&amp;&amp;");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(escapeHtml("")).toBe("");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(escapeHtml("안녕 hello world")).toBe("안녕 hello world");
+  });
+
+  it("escapes img onerror payload", () => {
+    expect(escapeHtml('<img onerror="x" src=y>')).toBe(
+      "&lt;img onerror=&quot;x&quot; src=y&gt;"
+    );
+  });
+});

--- a/src/lib/escape-html.ts
+++ b/src/lib/escape-html.ts
@@ -1,0 +1,11 @@
+const HTML_ESCAPE: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => HTML_ESCAPE[c]);
+}

--- a/src/lib/format-time.test.ts
+++ b/src/lib/format-time.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { formatRelativeTime } from "./format-time";
+
+describe("formatRelativeTime", () => {
+  const NOW = new Date("2026-05-07T12:00:00Z").getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 방금 전 for under 1 minute", () => {
+    expect(formatRelativeTime(new Date(NOW - 30_000))).toBe("방금 전");
+  });
+
+  it("returns N분 전 for 1-59 minutes", () => {
+    expect(formatRelativeTime(new Date(NOW - 60_000))).toBe("1분 전");
+    expect(formatRelativeTime(new Date(NOW - 59 * 60_000))).toBe("59분 전");
+  });
+
+  it("returns N시간 전 at exactly 60 minutes and within 24 hours", () => {
+    expect(formatRelativeTime(new Date(NOW - 90 * 60_000))).toBe("1시간 전");
+    expect(formatRelativeTime(new Date(NOW - 23 * 3600_000))).toBe("23시간 전");
+  });
+
+  it("returns N일 전 for 1-6 days", () => {
+    expect(formatRelativeTime(new Date(NOW - 24 * 3600_000))).toBe("1일 전");
+    expect(formatRelativeTime(new Date(NOW - 6 * 24 * 3600_000))).toBe("6일 전");
+  });
+
+  it("falls back to localized date for 7+ days", () => {
+    const result = formatRelativeTime(new Date(NOW - 7 * 24 * 3600_000));
+    expect(result).not.toBe("7일 전");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("accepts ISO string input (Drizzle JSON serialization)", () => {
+    expect(formatRelativeTime(new Date(NOW - 60_000).toISOString())).toBe("1분 전");
+  });
+
+  it("returns empty string for invalid date string", () => {
+    expect(formatRelativeTime("not-a-date")).toBe("");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(formatRelativeTime("")).toBe("");
+  });
+});

--- a/src/lib/format-time.ts
+++ b/src/lib/format-time.ts
@@ -1,0 +1,14 @@
+// Drizzle createdAt 이 ISO string 으로 직렬화될 가능성 대비 — Date | string 양쪽 수용
+export function formatRelativeTime(dateOrIso: Date | string): string {
+  const date = typeof dateOrIso === "string" ? new Date(dateOrIso) : dateOrIso;
+  if (Number.isNaN(date.getTime())) return "";
+  const diff = Date.now() - date.getTime();
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "방금 전";
+  if (min < 60) return `${min}분 전`;
+  const hour = Math.floor(min / 60);
+  if (hour < 24) return `${hour}시간 전`;
+  const day = Math.floor(hour / 24);
+  if (day < 7) return `${day}일 전`;
+  return date.toLocaleDateString("ko-KR");
+}

--- a/src/lib/og-palette.ts
+++ b/src/lib/og-palette.ts
@@ -1,0 +1,29 @@
+/**
+ * plan009 카테고리 토큰의 satori 호환 hex 매핑.
+ * 원본 oklch(0.74 0.09 H) — sRGB 변환은 culori(formatHex)로 사전 계산.
+ * satori 는 oklch 미지원이라 직접 hex 박아 넣음.
+ *
+ * og.ts(서버 전용)와 Avatar.tsx(클라이언트) 양쪽의 단일 소스.
+ */
+export const OG_CATEGORY_HEX: Record<string, string> = {
+  ai: "#a4a3e2",        // oklch(0.74 0.09 285)
+  algorithm: "#de958e", // oklch(0.74 0.09 25)
+  db: "#d79c73",        // oklch(0.74 0.09 55)
+  devops: "#87ba88",    // oklch(0.74 0.09 145)
+  java: "#64bead",      // oklch(0.74 0.09 180)
+  js: "#c1a966",        // oklch(0.74 0.09 90)
+  react: "#64b8d2",     // oklch(0.74 0.09 220)
+};
+
+export const OG_CATEGORY_DEFAULT_HEX = "#3fbac9"; // brand-400 fallback
+
+const OG_CATEGORY_ALIAS: Record<string, string> = {
+  database: "db",
+  javascript: "js",
+};
+
+export function getCategoryHex(category: string): string {
+  const raw = category.toLowerCase();
+  const key = OG_CATEGORY_ALIAS[raw] ?? raw;
+  return OG_CATEGORY_HEX[key] ?? OG_CATEGORY_DEFAULT_HEX;
+}

--- a/src/lib/og.ts
+++ b/src/lib/og.ts
@@ -71,42 +71,7 @@ export const OG_LAYOUT = {
   brandBarHeight: 4,
 } as const;
 
-/**
- * plan009 카테고리 토큰의 satori 호환 hex 매핑.
- * 원본 oklch(0.74 0.09 H) — sRGB 변환은 culori(formatHex)로 사전 계산.
- * satori 는 oklch 미지원이라 직접 hex 박아 넣음.
- *
- * 키는 정규화된 짧은 alias 기준. categoryIcons 의 풀네임(database/javascript)은
- * OG_CATEGORY_ALIAS 로 흡수. 미등록 카테고리(architecture/finance/git/go/html/http/internet/
- * interview/kafka/network/redis/resume/css/기술공유 등)는 OG_CATEGORY_DEFAULT_HEX(brand teal)
- * 로 fallback — 향후 plan 에서 도메인 친화 색을 점진 확장 예정.
- */
-export const OG_CATEGORY_HEX: Record<string, string> = {
-  ai: "#a4a3e2",        // oklch(0.74 0.09 285)
-  algorithm: "#de958e", // oklch(0.74 0.09 25)
-  db: "#d79c73",        // oklch(0.74 0.09 55)
-  devops: "#87ba88",    // oklch(0.74 0.09 145)
-  java: "#64bead",      // oklch(0.74 0.09 180)
-  js: "#c1a966",        // oklch(0.74 0.09 90)
-  react: "#64b8d2",     // oklch(0.74 0.09 220)
-};
-
-export const OG_CATEGORY_DEFAULT_HEX = "#3fbac9"; // brand-400 fallback
-
-/**
- * categoryIcons(src/infra/db/constants.ts) 의 풀네임을 짧은 alias 로 매핑.
- * lowercase 변환 후 1차 lookup → 매치 시 alias 키로 OG_CATEGORY_HEX 재조회.
- */
-const OG_CATEGORY_ALIAS: Record<string, string> = {
-  database: "db",
-  javascript: "js",
-};
-
-export function getCategoryHex(category: string): string {
-  const raw = category.toLowerCase();
-  const key = OG_CATEGORY_ALIAS[raw] ?? raw;
-  return OG_CATEGORY_HEX[key] ?? OG_CATEGORY_DEFAULT_HEX;
-}
+export { OG_CATEGORY_HEX, OG_CATEGORY_DEFAULT_HEX, getCategoryHex } from "@/lib/og-palette";
 
 const HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
 

--- a/tasks/plan022-comments-redesign/index.json
+++ b/tasks/plan022-comments-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan022-comments-redesign",
   "description": "댓글 영역 전면 리디자인 — shadcn (Form/Input/Textarea/Button/AlertDialog) + sonner Toast + react-hook-form + zod 도입. Nickname 이니셜 + plan021 OG 팔레트 7색 hash 기반 아바타 추가. Schema 변경 없음 (threading 미포함). plan020 SearchDialog 패턴 확장.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-06",
   "total_phases": 3,
   "related_docs": [
@@ -16,21 +16,21 @@
       "file": "phase-01.md",
       "title": "shadcn 컴포넌트 install + sonner Toaster 마운트 + Avatar/CommentItem 분리",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "Comments.tsx 리팩토링 — react-hook-form + zod + 아바타 + plan009 토큰",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "검증 + post-detail.md 갱신 + index.json status=completed",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan022-comments-redesign/index.json
+++ b/tasks/plan022-comments-redesign/index.json
@@ -1,6 +1,6 @@
 {
   "name": "plan022-comments-redesign",
-  "description": "댓글 영역 전면 리디자인 — shadcn (Form/Input/Textarea/Button/AlertDialog) + sonner Toast + react-hook-form + zod 도입. Nickname 이니셜 + plan009 카테고리 9색 hash 기반 아바타 추가. Schema 변경 없음 (threading 미포함). plan020 SearchDialog 패턴 확장.",
+  "description": "댓글 영역 전면 리디자인 — shadcn (Form/Input/Textarea/Button/AlertDialog) + sonner Toast + react-hook-form + zod 도입. Nickname 이니셜 + plan021 OG 팔레트 7색 hash 기반 아바타 추가. Schema 변경 없음 (threading 미포함). plan020 SearchDialog 패턴 확장.",
   "status": "pending",
   "created_at": "2026-05-06",
   "total_phases": 3,

--- a/tasks/plan022-comments-redesign/phase-01.md
+++ b/tasks/plan022-comments-redesign/phase-01.md
@@ -11,7 +11,7 @@
 - shadcn 컴포넌트는 `src/components/ui/` 에 자동 생성 (`pnpm dlx shadcn@latest add ...`)
 - 새 client component 는 "use client" 선언
 - Tailwind v4 + plan009 토큰 기준
-- "전면 리디자인" 결정 (사용자 2026-05-06): threading 미포함, avatar nickname 이니셜 + 9색 hash, full shadcn
+- "전면 리디자인" 결정 (사용자 2026-05-06): threading 미포함, avatar nickname 이니셜 + 7색 hash (OG 팔레트), full shadcn
 
 ## 작업 항목
 
@@ -59,7 +59,7 @@ import { Toaster } from "sonner";
 
 ### 3. `src/components/comments/Avatar.tsx` 신규
 
-Nickname 이니셜 + plan009 카테고리 9색 hash 자동 선택:
+Nickname 이니셜 + plan009 카테고리 hash 기반 자동 선택 (`OG_CATEGORY_HEX` 의 7색 팔레트 재사용):
 
 ```tsx
 import { OG_CATEGORY_HEX } from "@/lib/og";
@@ -132,6 +132,7 @@ export function CommentItem(_props: CommentItemProps) {
 ### 5. 검증
 
 ```bash
+# cwd: <repo root>
 pnpm lint
 pnpm type-check
 pnpm test --run
@@ -140,6 +141,7 @@ pnpm build
 
 자동 verification:
 ```bash
+# cwd: <repo root>
 test -f src/components/ui/input.tsx
 test -f src/components/ui/textarea.tsx
 test -f src/components/ui/form.tsx

--- a/tasks/plan022-comments-redesign/phase-02.md
+++ b/tasks/plan022-comments-redesign/phase-02.md
@@ -68,7 +68,15 @@ export type CommentFormProps =
 
 zod 의 `.max(5000)` 는 길이 검증만. content 가 HTML/script 를 포함하면 표시 시 위험. 두 면 가드:
 
-1. **저장 측**: `CommentRepository.createComment` / `updateComment` 호출 직전 `content` 를 escape 또는 strip-html. 기존 `src/infra/db/repositories/CommentRepository.ts` 의 write 메서드에 sanitization 가드가 없으면 phase-02 안에서 추가 (단순 `< → &lt; > → &gt; & → &amp;` escape 또는 `dompurify` 도입 결정). **executor 가 먼저 현재 구현 확인 후 보고** — 이미 가드 있으면 skip, 없으면 추가
+1. **저장 측**: `CommentRepository.createComment` / `updateComment` 호출 직전 `content` 를 escape. **team-lead 가 사전 검증으로 현재 가드 부재 확인됨** (line 49 / line 90 raw `content` insert/set). phase-02 안에서 단순 HTML escape 헬퍼 추가 (`& < > " '` → `&amp; &lt; &gt; &quot; &#39;` 5문자만, dompurify 같은 풀 라이브러리 도입 회피 — 댓글은 markdown 안 받고 plain text 라 5문자 escape 면 충분):
+```ts
+// src/lib/escape-html.ts (신규)
+const HTML_ESCAPE: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => HTML_ESCAPE[c]);
+}
+```
+`CommentRepository.createComment` / `updateComment` 의 `content` 인자에 escape 적용. 기존 댓글 read 시 별도 unescape 없음 (React 가 자동 escape 한 텍스트를 다시 escape 하지 않도록 — 단방향 저장 시점 escape).
 2. **표시 측**: `CommentItem.tsx` 가 `{comment.content}` 로 React 텍스트로 렌더 시 React 가 자동 escape — `dangerouslySetInnerHTML` 사용 금지. `whitespace-pre-wrap` 만 적용해 줄바꿈 보존
 
 ### 2. `src/components/comments/CommentItem.tsx` 본체 채우기
@@ -209,6 +217,7 @@ toast.error(USER_FRIENDLY_ERRORS[code] ?? "요청을 처리할 수 없습니다"
 ### 6. 자동 verification
 
 ```bash
+# cwd: <repo root>
 pnpm lint
 pnpm type-check
 pnpm test --run

--- a/tasks/plan022-comments-redesign/phase-03.md
+++ b/tasks/plan022-comments-redesign/phase-03.md
@@ -8,6 +8,7 @@
 ### 1. 통합 검증
 
 ```bash
+# cwd: <repo root>
 pnpm lint
 pnpm type-check
 pnpm test --run
@@ -22,7 +23,7 @@ pnpm build
 - 컴포넌트 분리: `Comments` (컨테이너) / `CommentForm` / `CommentItem` / `DeleteConfirmDialog` / `Avatar`
 - 폼 검증: react-hook-form + zod
 - 알림: sonner toast
-- 아바타: nickname hash 기반 9색 자동 선택
+- 아바타: nickname hash 기반 색상 자동 선택 (`OG_CATEGORY_HEX` 의 7색 팔레트 재사용 — plan021 단일 소스)
 - threading 미포함 (의도적 — schema 변경 회피)
 
 기존 내용이 자세히 들어가 있다면 짧게 (3~4줄) 압축. docs 작성 원칙 준수 — 컨텍스트 효율.
@@ -34,6 +35,7 @@ pnpm build
 ### 4. 자동 verification
 
 ```bash
+# cwd: <repo root>
 grep -n "plan022\|CommentForm\|Avatar" docs/pages/post-detail.md | head -5
 grep -n "\"completed\"" tasks/plan022-comments-redesign/index.json | wc -l  # 4 (top + 3 phases)
 ```


### PR DESCRIPTION
## Summary

댓글 영역 354줄 자체 구현 → shadcn + react-hook-form + zod + sonner 로 전면 리디자인. Avatar 컴포넌트 신규 (plan021 OG 팔레트 7색 hash). API contract / DB schema 변경 없음 (threading 미포함).

### 핵심 결정 (ADR-021)
- **Form**: rhf + zod, `createSchema` / `editSchema = createSchema.pick({password, content})` mode 분리 + props discriminated union
- **Toast**: sonner (ThemeProvider 바깥 mount), USER_FRIENDLY_ERRORS 화이트리스트로 서버 raw error 노출 차단
- **XSS**: `escapeHtml` 5문자 단방향 (`CommentRepository.create/update` 저장 시점만, React JSX 자동 escape 와 이중 escape 회피)
- **og-palette.ts 분리**: `og.ts` 가 `node:fs` import 하므로 client (Avatar) 직접 import 불가 → palette 데이터를 pure module 로 분리, `og.ts` 는 re-export. 단일 소스 유지하면서 번들 격리
- **comments/types.ts**: client component 가 Drizzle schema 직접 import 회피
- **API code 필드**: PUT/DELETE 403/404 응답에 `code: PASSWORD_MISMATCH | NOT_FOUND` 추가 — `USER_FRIENDLY_ERRORS` 매핑 정상 동작 (review-fix HIGH 1건)

### Build
- `pnpm lint` ✅
- `pnpm type-check` ✅
- `pnpm test` ✅ (21 files / 215 tests)
- `pnpm build` ✅ (20/20 static pages)

### Commits (5 atomic + 2 task chore)
| commit | 내용 |
|---|---|
| `chore(task)` v2 | critic minor (cwd / 7색 / XSS escape) 반영 |
| `refactor(og)` | og-palette.ts 분리 (client 번들 격리, scope 확장 ACCEPT) |
| `feat(comments)` | 핵심 구현 (shadcn ui + rhf + zod + sonner + Avatar + escape-html + format-time + Repository) |
| `fix(api/comments)` | error response code 필드 추가 (review-fix HIGH 1건) |
| `docs` | ADR-021 + ADR-017 7색 + CLAUDE.md tech/logging + post-detail.md |
| `chore(tasks)` | mark plan022 completed |

### Test plan
- [ ] 데스크톱: 댓글 작성 → toast 성공 메시지, Avatar 색상 nickname 별 차이
- [ ] 댓글 수정: edit 모드 nickname read-only, password + content 만 검증
- [ ] 삭제 dialog: ESC + 백드롭 + 비밀번호 < 4자 disabled 동작
- [ ] 잘못된 비밀번호 → "비밀번호가 일치하지 않습니다" toast (USER_FRIENDLY_ERRORS 매핑)
- [ ] 댓글 본문에 `<script>` 또는 `<img onerror>` 입력 → 저장 시 escape, 표시 시 plain text
- [ ] 다크/라이트 모드 양쪽 색상 자연스러움
- [ ] OG 이미지 카테고리 색은 동일 (og-palette 단일 소스 정합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)