### PR TITLE
feat(about): redesign /about per Claude Design mockup (plan023)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -420,3 +420,19 @@
 - **USER_FRIENDLY_ERRORS 화이트리스트**: 서버 raw error 노출은 SQL injection probe / 정보 노출 공격면 확장. code 필드 명시적 매핑이 모든 메시지의 단일 진입점
 
 **Scope 명시**: 이 ADR 의 정책은 댓글 영역 한정. 다른 client form (검색 dialog, 향후 로그인) 도입 시 이 결정을 ADR-021 의 패턴으로 따른다 (rhf + zod + sonner + USER_FRIENDLY_ERRORS).
+
+## ADR-022. About 페이지 — co-located CSS + 2-stage avatar (plan023)
+
+**Context**: plan023 에서 `/about` 을 Claude Design mockup 시각 사양으로 전면 리디자인. 기존 Tailwind utility-first 컨벤션과 다른 CSS 전략 + GitHub avatar 표시 방식 두 결정이 비자명.
+
+**Decision**:
+
+1. **co-located CSS (`src/app/about/about.css`)**: `import "./about.css"` 로 page.tsx 에 주입. `.ab-*` BEM-ish prefix 클래스 사용. Tailwind utility 가 아닌 CSS 파일로 분리.
+2. **2-stage avatar**: `.ab-avatar` 컨테이너에 항상 이니셜 (`<span className="ab-avatar-initial">`) 렌더 → GitHub `avatarUrl` 있으면 그 위에 `<Image className="ab-avatar-img" position:absolute inset:0>` 로 덮음. fetch 실패 / 부재 시 이니셜이 그대로 보임.
+
+**Why**:
+
+- **co-located CSS**: mockup 의 `::before`/`::after` 로 그리는 hairline 액센트, `@keyframes ab-pulse` (LAST SYNC 카드 발광), `oklch(0.74 0.09 ${hue})` 동적 chip dot 색은 Tailwind arbitrary value 만으로 표현이 어색하거나 불가능. about 한 페이지 한정이라 globals.css 오염 회피 + 모듈 단위 격리 효과. 향후 다른 페이지가 비슷한 패턴이면 ADR 갱신 후 일반 utility 화 검토.
+- **2-stage avatar**: GitHub API 일시 장애 / rate limit 시 페이지 그래픽 깨짐 방지. fallback 분기를 ProfileCard 안에 if/else 로 두는 대신 디자인 자체가 두 표시 상태를 항상 처리하도록 설계 — default (이니셜) → enhanced (사진 덮음). mockup 의 gradient + initial 컨테이너는 fallback 이 아니라 base layer 라는 의도.
+
+**Scope 명시**: 이 ADR 의 결정은 about 페이지 한정. 다른 페이지가 동일 패턴 도입 시 본 ADR 의 근거 (`::after` hairline / `@keyframes` / 동적 oklch / API 폴백) 가 모두 해당하는지 재검토.

--- a/docs/pages/about.md
+++ b/docs/pages/about.md
@@ -1,0 +1,24 @@
+# /about — About 페이지
+
+## 컴포넌트 구성
+
+| 컴포넌트 | 데이터 소스 |
+|---|---|
+| `ProfileCard` | GitHub API (`/users/jon890`, `Authorization: Bearer`, `revalidate=3600`). 2-stage avatar — `ab-avatar-initial` 베이스 위에 `next/image` (`ab-avatar-img`) 가 `inset:0` 로 덮음 (ADR-022) |
+| `SiteStats` | `StatsService.getAboutStats()` — DB 직접 조회 |
+| `StackGrid` | 정적 상수 (`STACK`) |
+| `LinksGrid` | 정적 상수 (`LINKS`), lucide-react 아이콘 |
+
+## 레이아웃
+
+container max-width 1180px, plan009 CSS 변수 (`--color-*`), numbered 섹션 헤더 (`01`–`04`). CSS: `src/app/about/about.css` (co-located) — `::before`/`::after` hairline, `@keyframes ab-pulse`, `oklch(... ${hue})` 동적 chip 색을 처리.
+
+## 데이터
+
+- `postCount` = `COUNT(*) WHERE isActive=true`
+- `categoryCount` = `COUNT(DISTINCT posts.category) WHERE isActive=true`
+- `lastSyncAt` = `MAX(posts.updatedAt) WHERE isActive=true`
+
+## revalidate
+
+`export const revalidate = 3600` (ISR 1시간). GitHub fetch 도 동일 `revalidate` 적용.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,6 @@ export default [
     },
   },
   {
-    ignores: [".next/**", "node_modules/**", "out/**", "build/**", "dist/**"],
+    ignores: [".next/**", "node_modules/**", "out/**", "build/**", "dist/**", "tasks/**", ".claude/**"],
   },
 ];

--- a/src/app/about/about.css
+++ b/src/app/about/about.css
@@ -1,0 +1,440 @@
+/* fos-blog /about — profile-as-spec layout */
+
+.ab-shell {
+  background: var(--color-bg-base);
+  color: var(--color-fg-primary);
+  font-family: var(--font-sans);
+  width: 100%; height: 100%;
+  overflow-y: auto;
+  font-size: 14px;
+}
+
+.ab-shell a { color: inherit; text-decoration: none; }
+
+.ab-container {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+@media (max-width: 640px) {
+  .ab-container { padding: 0 20px; }
+}
+
+/* ---------- Sub-hero ---------- */
+.ab-subhero {
+  position: relative;
+  padding: 64px 0 32px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+@media (max-width: 640px) {
+  .ab-subhero { padding: 36px 0 22px; }
+}
+
+.ab-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-brand-400);
+  display: inline-flex; align-items: center; gap: 10px;
+  margin-bottom: 20px;
+}
+.ab-eyebrow::before {
+  content: "";
+  width: 24px; height: 1px;
+  background: var(--color-brand-400);
+}
+
+.ab-title {
+  font-size: clamp(36px, 4.6vw, 56px);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--color-fg-primary);
+  margin-bottom: 18px;
+}
+
+@media (max-width: 640px) {
+  .ab-title { font-size: 32px; margin-bottom: 14px; }
+}
+
+.ab-meta {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--color-fg-secondary);
+  letter-spacing: -0.005em;
+  max-width: 56ch;
+}
+
+@media (max-width: 640px) {
+  .ab-meta { font-size: 14px; }
+}
+
+/* ---------- shared card ---------- */
+.ab-card {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  padding: 32px;
+  position: relative;
+}
+
+@media (max-width: 640px) {
+  .ab-card { padding: 20px; border-radius: 12px; }
+}
+
+/* section spacing */
+.ab-section {
+  margin-top: 64px;
+}
+
+@media (max-width: 640px) {
+  .ab-section { margin-top: 40px; }
+}
+
+.ab-section-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 20px;
+}
+.ab-section-head .h2 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-fg-muted);
+  display: inline-flex; align-items: center; gap: 10px;
+}
+.ab-section-head .h2 .idx {
+  color: var(--color-fg-faint);
+  font-size: 10px;
+}
+.ab-section-head .h2::after {
+  content: "";
+  display: inline-block;
+  width: 80px; height: 1px;
+  background: var(--color-border-subtle);
+  margin-left: 4px;
+}
+
+/* ---------- ProfileCard ---------- */
+.ab-profile {
+  display: grid;
+  grid-template-columns: 128px 1fr;
+  gap: 32px;
+  align-items: start;
+  padding: 36px;
+}
+
+@media (max-width: 640px) {
+  .ab-profile {
+    grid-template-columns: 1fr;
+    gap: 20px;
+    padding: 24px;
+  }
+}
+
+.ab-avatar {
+  width: 128px; height: 128px;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 30% 30%, oklch(0.78 0.13 195 / 0.6), transparent 60%),
+    radial-gradient(circle at 70% 70%, oklch(0.65 0.18 280 / 0.5), transparent 60%),
+    var(--color-bg-overlay);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  flex: none;
+  display: grid; place-items: center;
+  font-family: var(--font-mono);
+  font-size: 44px;
+  font-weight: 500;
+  color: var(--color-fg-primary);
+  letter-spacing: -0.04em;
+}
+.ab-avatar::after {
+  content: "";
+  position: absolute; inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, transparent 50%, rgb(255 255 255 / 0.06));
+  pointer-events: none;
+}
+
+@media (max-width: 640px) {
+  .ab-avatar { width: 96px; height: 96px; font-size: 32px; }
+}
+
+.ab-avatar-initial { position: relative; z-index: 0; }
+.ab-avatar-img { position: absolute; inset: 0; object-fit: cover; z-index: 1; border-radius: inherit; }
+
+.ab-profile-body {
+  display: flex; flex-direction: column;
+  gap: 14px;
+}
+.ab-profile-name {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  color: var(--color-fg-primary);
+  display: flex; align-items: baseline; gap: 12px;
+  flex-wrap: wrap;
+}
+.ab-profile-name .handle {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--color-fg-muted);
+  letter-spacing: 0;
+}
+
+@media (max-width: 640px) {
+  .ab-profile-name { font-size: 22px; }
+  .ab-profile-name .handle { font-size: 12px; }
+}
+
+.ab-profile-bio {
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--color-fg-secondary);
+  letter-spacing: -0.005em;
+  max-width: 56ch;
+}
+
+@media (max-width: 640px) {
+  .ab-profile-bio { font-size: 13px; }
+}
+
+.ab-profile-stats {
+  display: inline-flex; align-items: center;
+  gap: 0;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  background: var(--color-bg-base);
+  width: fit-content;
+}
+.ab-profile-stats .stat {
+  padding: 8px 14px;
+  display: inline-flex; align-items: baseline; gap: 6px;
+  border-right: 1px solid var(--color-border-subtle);
+}
+.ab-profile-stats .stat:last-child { border-right: none; }
+.ab-profile-stats .stat .num {
+  color: var(--color-fg-primary);
+  font-weight: 500;
+  font-size: 13px;
+  letter-spacing: -0.005em;
+}
+.ab-profile-stats .stat .lbl {
+  color: var(--color-fg-muted);
+  font-size: 11px;
+}
+
+.ab-profile-cta {
+  display: inline-flex; align-items: center; gap: 8px;
+  margin-top: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  background: var(--color-bg-base);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-fg-secondary);
+  letter-spacing: -0.005em;
+  width: fit-content;
+  transition: border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms;
+}
+.ab-profile-cta:hover {
+  border-color: var(--color-brand-400);
+  color: var(--color-brand-400);
+}
+.ab-profile-cta .arr { color: var(--color-fg-faint); margin-left: 2px; }
+.ab-profile-cta:hover .arr { color: var(--color-brand-400); }
+
+/* ---------- SiteStats ---------- */
+.ab-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .ab-stats {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+}
+
+.ab-stat {
+  padding: 24px;
+}
+
+@media (max-width: 640px) {
+  .ab-stat { padding: 18px; }
+}
+
+.ab-stat-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-fg-muted);
+  margin-bottom: 16px;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.ab-stat-eyebrow .right {
+  color: var(--color-fg-faint);
+  font-size: 10px;
+}
+.ab-stat-num {
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  color: var(--color-fg-primary);
+  line-height: 1;
+  font-feature-settings: "tnum";
+}
+
+@media (max-width: 640px) {
+  .ab-stat-num { font-size: 32px; }
+}
+
+.ab-stat-num .unit {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--color-fg-muted);
+  margin-left: 4px;
+  letter-spacing: 0;
+}
+.ab-stat-sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-fg-muted);
+  margin-top: 8px;
+  display: flex; align-items: center; gap: 6px;
+}
+.ab-stat-sub .pulse {
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: var(--color-brand-400);
+  box-shadow: 0 0 8px var(--color-brand-400);
+  animation: ab-pulse 1.6s ease-in-out infinite;
+}
+@keyframes ab-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* ---------- Chip grid (Stack + Links shared) ---------- */
+.ab-chip-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+.ab-chip-grid.col3 { grid-template-columns: repeat(3, 1fr); }
+.ab-chip-grid.col2 { grid-template-columns: repeat(2, 1fr); }
+
+@media (max-width: 640px) {
+  .ab-chip-grid { grid-template-columns: repeat(2, 1fr); gap: 6px; }
+}
+
+.ab-chip {
+  padding: 12px 14px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  background: var(--color-bg-elevated);
+  display: flex; align-items: center; gap: 10px;
+  font-size: 13px;
+  color: var(--color-fg-secondary);
+  letter-spacing: -0.005em;
+  transition: all 150ms cubic-bezier(0.22, 1, 0.36, 1);
+  cursor: pointer;
+  min-width: 0;
+}
+.ab-chip:hover {
+  border-color: var(--color-border-default);
+  color: var(--color-fg-primary);
+  transform: translateY(-1px);
+}
+.ab-chip .dot {
+  width: 8px; height: 8px;
+  border-radius: 999px;
+  background: var(--cat-color, var(--color-brand-400));
+  flex: none;
+}
+.ab-chip .key {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-fg-faint);
+  margin-left: auto;
+  letter-spacing: 0;
+}
+
+.ab-chip-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* link variant */
+.ab-chip.link:hover { border-color: var(--color-brand-400); color: var(--color-brand-400); }
+.ab-chip.link:hover .dot {
+  background: var(--color-brand-400) !important;
+  box-shadow: 0 0 8px var(--color-brand-400);
+}
+.ab-chip.link:hover .key { color: var(--color-brand-400); opacity: 0.7; }
+.ab-chip.link .ico {
+  width: 16px; height: 16px;
+  flex: none;
+  display: grid; place-items: center;
+  color: var(--color-fg-muted);
+}
+.ab-chip.link:hover .ico { color: var(--color-brand-400); }
+.ab-chip.link .ttl {
+  font-size: 13px;
+  color: var(--color-fg-primary);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+.ab-chip.link .sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-fg-muted);
+  letter-spacing: 0;
+  display: block; margin-top: 2px;
+}
+.ab-chip.link:hover .sub { color: color-mix(in oklch, var(--color-brand-400), transparent 30%); }
+
+.ab-chip-link-body {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ---------- footer note ---------- */
+.ab-end {
+  margin-top: 80px;
+  padding: 32px 0 64px;
+  border-top: 1px solid var(--color-border-subtle);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-fg-faint);
+  display: flex; justify-content: space-between;
+  flex-wrap: wrap; gap: 12px;
+  letter-spacing: 0;
+}
+
+@media (max-width: 640px) {
+  .ab-end {
+    margin-top: 48px;
+    padding: 20px 0 40px;
+    flex-direction: column;
+  }
+}

--- a/src/app/about/about.css
+++ b/src/app/about/about.css
@@ -117,6 +117,12 @@
   background: var(--color-border-subtle);
   margin-left: 4px;
 }
+.ab-section-head .right {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0;
+  color: var(--color-fg-faint);
+}
 
 /* ---------- ProfileCard ---------- */
 .ab-profile {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import { env } from "@/env";
 import logger from "@/lib/logger";
-import { getRepositories } from "@/infra/db/repositories";
-import { createStatsService } from "@/services/StatsService";
+import { createDefaultStatsService } from "@/services/StatsService";
 import { ProfileCard } from "@/components/about/ProfileCard";
 import { SiteStats } from "@/components/about/SiteStats";
 import { StackGrid, STACK } from "@/components/about/StackGrid";
@@ -116,18 +115,7 @@ function Section({ idx, label, right, children }: SectionProps) {
           <span className="idx">{idx}</span>
           <span>{label}</span>
         </span>
-        {right && (
-          <span
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: 11,
-              color: "var(--color-fg-faint)",
-              letterSpacing: 0,
-            }}
-          >
-            {right}
-          </span>
-        )}
+        {right && <span className="right">{right}</span>}
       </div>
       {children}
     </section>
@@ -136,7 +124,7 @@ function Section({ idx, label, right, children }: SectionProps) {
 
 async function fetchSiteStats() {
   try {
-    return await createStatsService(getRepositories()).getAboutStats();
+    return await createDefaultStatsService().getAboutStats();
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     log.warn({ component: "about", operation: "site-stats", err }, "site stats fetch failed, using fallback");

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import { env } from "@/env";
 import logger from "@/lib/logger";
+import { getRepositories } from "@/infra/db/repositories";
+import { createStatsService } from "@/services/StatsService";
+import { ProfileCard } from "@/components/about/ProfileCard";
+import { SiteStats } from "@/components/about/SiteStats";
+import { StackGrid, STACK } from "@/components/about/StackGrid";
+import { LinksGrid } from "@/components/about/LinksGrid";
+import "./about.css";
 
 const log = logger.child({ module: "app/about" });
 
@@ -38,6 +44,7 @@ interface GitHubProfile {
 
 interface ProfileData {
   name: string;
+  handle: string;
   avatarUrl: string | null;
   bio: string;
   htmlUrl: string;
@@ -48,8 +55,11 @@ interface ProfileData {
 async function fetchGitHubProfile(): Promise<ProfileData> {
   try {
     const res = await fetch("https://api.github.com/users/jon890", {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+      },
       next: { revalidate: 3600 },
-      headers: { Accept: "application/vnd.github+json" },
     });
 
     if (!res.ok) {
@@ -57,6 +67,7 @@ async function fetchGitHubProfile(): Promise<ProfileData> {
       log.warn({ component: "about", operation: "github-profile", err, status: res.status }, "github profile fetch failed");
       return {
         name: "jon890",
+        handle: "@jon890",
         avatarUrl: null,
         bio: "",
         htmlUrl: "https://github.com/jon890",
@@ -68,6 +79,7 @@ async function fetchGitHubProfile(): Promise<ProfileData> {
     const data: GitHubProfile = await res.json();
     return {
       name: data.name ?? "jon890",
+      handle: "@jon890",
       avatarUrl: data.avatar_url,
       bio: data.bio ?? "",
       htmlUrl: data.html_url,
@@ -79,6 +91,7 @@ async function fetchGitHubProfile(): Promise<ProfileData> {
     log.warn({ component: "about", operation: "github-profile", err, status: 0 }, "github profile fetch failed");
     return {
       name: "jon890",
+      handle: "@jon890",
       avatarUrl: null,
       bio: "",
       htmlUrl: "https://github.com/jon890",
@@ -88,124 +101,85 @@ async function fetchGitHubProfile(): Promise<ProfileData> {
   }
 }
 
+interface SectionProps {
+  idx: string;
+  label: string;
+  right?: string;
+  children: React.ReactNode;
+}
+
+function Section({ idx, label, right, children }: SectionProps) {
+  return (
+    <section className="ab-section">
+      <div className="ab-section-head">
+        <span className="h2">
+          <span className="idx">{idx}</span>
+          <span>{label}</span>
+        </span>
+        {right && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color: "var(--color-fg-faint)",
+              letterSpacing: 0,
+            }}
+          >
+            {right}
+          </span>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+async function fetchSiteStats() {
+  try {
+    return await createStatsService(getRepositories()).getAboutStats();
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    log.warn({ component: "about", operation: "site-stats", err }, "site stats fetch failed, using fallback");
+    return { postCount: 0, categoryCount: 0, lastSyncAt: null };
+  }
+}
+
 export default async function AboutPage() {
-  const profile = await fetchGitHubProfile();
+  const [profile, stats] = await Promise.all([
+    fetchGitHubProfile(),
+    fetchSiteStats(),
+  ]);
 
   return (
-    <div className="container mx-auto px-4 py-6 md:py-12">
-      <div className="max-w-3xl mx-auto">
-        {/* Profile Card */}
-        <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 p-6 rounded-lg border border-gray-200 dark:border-gray-700 mb-10">
-          {profile.avatarUrl && (
-            <Image
-              src={profile.avatarUrl}
-              alt={`${profile.name} GitHub 프로필 사진`}
-              width={96}
-              height={96}
-              className="rounded-full"
-            />
-          )}
-          <div className="text-center sm:text-left">
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">
-              {profile.name}
-            </h1>
-            {profile.bio && (
-              <p className="text-gray-600 dark:text-gray-400 mb-3">
-                {profile.bio}
-              </p>
-            )}
-            <div className="flex flex-wrap justify-center sm:justify-start gap-4 text-sm text-gray-500 dark:text-gray-400 mb-3">
-              {profile.publicRepos > 0 && (
-                <span>공개 저장소 {profile.publicRepos}개</span>
-              )}
-              {profile.followers > 0 && (
-                <span>팔로워 {profile.followers}명</span>
-              )}
-            </div>
-            <a
-              href={profile.htmlUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`${profile.name} GitHub 프로필 열기 (새 탭)`}
-              className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium"
-            >
-              GitHub 프로필 →
-            </a>
-          </div>
+    <div className="ab-shell">
+      <header className="ab-subhero">
+        <div className="ab-container">
+          <span className="ab-eyebrow">ABOUT</span>
+          <h1 className="ab-title">FOS Study</h1>
+          <p className="ab-meta">
+            한 명의 백엔드 엔지니어가 매일 쌓는 학습 노트.
+            공부하면서 기록하고, 기록하면서 다시 배웁니다.
+          </p>
         </div>
-
-        {/* Blog Introduction */}
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
-            블로그 소개
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            FOS Study는 개발 학습 과정에서 익힌 내용을 기록하는 블로그입니다.
-            알고리즘 풀이, 자료구조 정리, 다양한 기술 스택 학습 내용을
-            꾸준히 업로드합니다.
-          </p>
-        </section>
-
-        {/* Topics */}
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
-            다루는 주제
-          </h2>
-          <ul className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-            {[
-              "AI",
-              "알고리즘",
-              "자료구조",
-              "데이터베이스",
-              "DevOps",
-              "Java / Spring",
-              "JavaScript / TypeScript",
-              "React",
-              "Next.js",
-            ].map((topic) => (
-              <li
-                key={topic}
-                className="px-3 py-2 rounded-md bg-gray-100 dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300"
-              >
-                {topic}
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        {/* Tech Stack */}
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
-            블로그 기술 스택
-          </h2>
-          <ul className="space-y-1 text-gray-600 dark:text-gray-400">
-            <li>Next.js 16 (App Router)</li>
-            <li>TypeScript</li>
-            <li>MySQL + Drizzle ORM</li>
-            <li>Tailwind CSS 4</li>
-          </ul>
-        </section>
-
-        {/* Content Source */}
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
-            콘텐츠 소스
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            이 블로그의 글은{" "}
-            <a
-              href="https://github.com/jon890/fos-study"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 dark:text-blue-400 hover:underline"
-            >
-              jon890/fos-study
-            </a>{" "}
-            리포지터리에서 자동으로 동기화됩니다. Markdown 파일이 업데이트되면
-            블로그에 자동 반영됩니다.
-          </p>
-        </section>
-      </div>
+      </header>
+      <main className="ab-container">
+        <Section idx="01" label="profile">
+          <ProfileCard {...profile} />
+        </Section>
+        <Section idx="02" label="site stats" right="snapshot">
+          <SiteStats {...stats} />
+        </Section>
+        <Section idx="03" label="stack" right={`${STACK.length} packages`}>
+          <StackGrid />
+        </Section>
+        <Section idx="04" label="links" right="external">
+          <LinksGrid />
+        </Section>
+        <div className="ab-end">
+          <span>fos-blog · /about</span>
+          <span>© {new Date().getFullYear()} jon890</span>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/components/about/LinksGrid.tsx
+++ b/src/components/about/LinksGrid.tsx
@@ -1,0 +1,38 @@
+import { Github, Code } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+const LINKS: Array<{
+  ttl: string;
+  sub: string;
+  href: string;
+  ico: LucideIcon;
+}> = [
+  { ttl: "GitHub",  sub: "@jon890",          href: "https://github.com/jon890",           ico: Github },
+  { ttl: "Source",  sub: "jon890/fos-blog",  href: "https://github.com/jon890/fos-blog",  ico: Code },
+  { ttl: "Content", sub: "jon890/fos-study", href: "https://github.com/jon890/fos-study", ico: Code },
+] as const;
+
+export function LinksGrid() {
+  return (
+    <div className="ab-chip-grid col3">
+      {LINKS.map((l) => (
+        <a
+          key={l.ttl}
+          className="ab-chip link"
+          href={l.href}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span className="ico">
+            <l.ico size={16} />
+          </span>
+          <span className="ab-chip-link-body">
+            <span className="ttl">{l.ttl}</span>
+            <span className="sub">{l.sub}</span>
+          </span>
+          <span className="key">↗</span>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/components/about/ProfileCard.tsx
+++ b/src/components/about/ProfileCard.tsx
@@ -1,0 +1,64 @@
+import Image from "next/image";
+
+interface ProfileCardProps {
+  name: string;
+  handle: string;
+  bio: string;
+  avatarUrl: string | null;
+  htmlUrl: string;
+  publicRepos: number;
+  followers: number;
+}
+
+export function ProfileCard({
+  name,
+  handle,
+  bio,
+  avatarUrl,
+  htmlUrl,
+  publicRepos,
+  followers,
+}: ProfileCardProps) {
+  return (
+    <article className="ab-card ab-profile">
+      <div className="ab-avatar">
+        <span className="ab-avatar-initial">{name.charAt(0).toUpperCase()}</span>
+        {avatarUrl && (
+          <Image
+            src={avatarUrl}
+            alt={name}
+            fill
+            sizes="128px"
+            className="ab-avatar-img"
+          />
+        )}
+      </div>
+      <div className="ab-profile-body">
+        <h2 className="ab-profile-name">
+          {name}
+          <span className="handle">{handle}</span>
+        </h2>
+        <p className="ab-profile-bio">{bio}</p>
+        <div className="ab-profile-stats">
+          <span className="stat">
+            <span className="num">{publicRepos}</span>
+            <span className="lbl">repos</span>
+          </span>
+          <span className="stat">
+            <span className="num">{followers}</span>
+            <span className="lbl">followers</span>
+          </span>
+        </div>
+        <a
+          className="ab-profile-cta"
+          href={htmlUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span>{htmlUrl.replace(/^https?:\/\//, "")}</span>
+          <span className="arr">↗</span>
+        </a>
+      </div>
+    </article>
+  );
+}

--- a/src/components/about/SiteStats.tsx
+++ b/src/components/about/SiteStats.tsx
@@ -1,0 +1,55 @@
+import { formatRelativeTime } from "@/lib/format-time";
+
+interface SiteStatsProps {
+  postCount: number;
+  categoryCount: number;
+  lastSyncAt: Date | null;
+}
+
+export function SiteStats({ postCount, categoryCount, lastSyncAt }: SiteStatsProps) {
+  return (
+    <div className="ab-stats">
+      <div className="ab-card ab-stat">
+        <div className="ab-stat-eyebrow">
+          <span>POSTS</span>
+          <span className="right">total</span>
+        </div>
+        <div className="ab-stat-num">
+          {postCount}
+          <span className="unit">posts</span>
+        </div>
+        <div className="ab-stat-sub">{categoryCount} categories</div>
+      </div>
+
+      <div className="ab-card ab-stat">
+        <div className="ab-stat-eyebrow">
+          <span>CATEGORIES</span>
+          <span className="right">active</span>
+        </div>
+        <div className="ab-stat-num">
+          {categoryCount}
+          <span className="unit">paths</span>
+        </div>
+        <div className="ab-stat-sub">distinct category</div>
+      </div>
+
+      <div className="ab-card ab-stat">
+        <div className="ab-stat-eyebrow">
+          <span>LAST SYNC</span>
+          <span className="right">db</span>
+        </div>
+        <div className="ab-stat-num">
+          {lastSyncAt ? formatRelativeTime(lastSyncAt) : "—"}
+        </div>
+        <div className="ab-stat-sub">
+          <span className="pulse" />
+          <span>
+            {lastSyncAt
+              ? new Date(lastSyncAt).toISOString().slice(0, 10)
+              : "no sync yet"}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/about/StackGrid.tsx
+++ b/src/components/about/StackGrid.tsx
@@ -1,0 +1,34 @@
+const STACK = [
+  { label: "Next.js 16",         hue: 0,   key: "framework" },
+  { label: "TypeScript",         hue: 220, key: "language" },
+  { label: "Tailwind v4",        hue: 195, key: "styling" },
+  { label: "Drizzle ORM",        hue: 90,  key: "data" },
+  { label: "MySQL 8",            hue: 55,  key: "db" },
+  { label: "Docker",             hue: 230, key: "infra" },
+  { label: "Octokit",            hue: 145, key: "github" },
+  { label: "rehype-pretty-code", hue: 250, key: "syntax" },
+  { label: "mermaid",            hue: 175, key: "diagram" },
+  { label: "Vitest",             hue: 120, key: "test" },
+  { label: "pino",               hue: 35,  key: "log" },
+  { label: "shadcn/ui",          hue: 280, key: "ui" },
+] as const;
+
+export { STACK };
+
+export function StackGrid() {
+  return (
+    <div className="ab-chip-grid">
+      {STACK.map((s) => (
+        <span
+          key={s.key}
+          className="ab-chip"
+          style={{ "--cat-color": `oklch(0.74 0.09 ${s.hue})` } as React.CSSProperties}
+        >
+          <span className="dot" />
+          <span className="ab-chip-label">{s.label}</span>
+          <span className="key">{s.key}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -300,6 +300,22 @@ export class PostRepository extends BaseRepository {
       .from(posts);
   }
 
+  async getDistinctActiveCategoryCount(): Promise<number> {
+    const result = await this.db
+      .select({ count: sql<string>`COUNT(DISTINCT ${posts.category})` })
+      .from(posts)
+      .where(eq(posts.isActive, true));
+    return Number(result[0]?.count ?? 0);
+  }
+
+  async getLastActiveUpdatedAt(): Promise<Date | null> {
+    const result = await this.db
+      .select({ maxUpdatedAt: sql<Date | null>`MAX(${posts.updatedAt})` })
+      .from(posts)
+      .where(eq(posts.isActive, true));
+    return result[0]?.maxUpdatedAt ?? null;
+  }
+
   async getAllWithContent(): Promise<
     Array<{ id: number; path: string; title: string; content: string | null }>
   > {

--- a/src/services/StatsService.test.ts
+++ b/src/services/StatsService.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+import { createStatsService } from "./StatsService";
+
+function makePostRepo(overrides: {
+  getActivePostCount?: () => Promise<number>;
+  getDistinctActiveCategoryCount?: () => Promise<number>;
+  getLastActiveUpdatedAt?: () => Promise<Date | null>;
+}) {
+  return {
+    getActivePostCount: overrides.getActivePostCount ?? vi.fn().mockResolvedValue(0),
+    getDistinctActiveCategoryCount: overrides.getDistinctActiveCategoryCount ?? vi.fn().mockResolvedValue(0),
+    getLastActiveUpdatedAt: overrides.getLastActiveUpdatedAt ?? vi.fn().mockResolvedValue(null),
+  };
+}
+
+describe("StatsService.getAboutStats", () => {
+  it("빈 DB일 때 기본값 반환", async () => {
+    const service = createStatsService({ post: makePostRepo({}) as unknown as PostRepository });
+    const stats = await service.getAboutStats();
+    expect(stats).toEqual({ postCount: 0, categoryCount: 0, lastSyncAt: null });
+  });
+
+  it("정상 데이터 반환", async () => {
+    const lastSync = new Date("2026-05-01T00:00:00Z");
+    const post = makePostRepo({
+      getActivePostCount: vi.fn().mockResolvedValue(42),
+      getDistinctActiveCategoryCount: vi.fn().mockResolvedValue(7),
+      getLastActiveUpdatedAt: vi.fn().mockResolvedValue(lastSync),
+    });
+    const service = createStatsService({ post: post as unknown as PostRepository });
+    const stats = await service.getAboutStats();
+    expect(stats).toEqual({ postCount: 42, categoryCount: 7, lastSyncAt: lastSync });
+  });
+});

--- a/src/services/StatsService.test.ts
+++ b/src/services/StatsService.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import type { PostRepository } from "@/infra/db/repositories/PostRepository";
 import { createStatsService } from "./StatsService";
 
 function makePostRepo(overrides: {
@@ -16,7 +15,7 @@ function makePostRepo(overrides: {
 
 describe("StatsService.getAboutStats", () => {
   it("빈 DB일 때 기본값 반환", async () => {
-    const service = createStatsService({ post: makePostRepo({}) as unknown as PostRepository });
+    const service = createStatsService({ post: makePostRepo({}) });
     const stats = await service.getAboutStats();
     expect(stats).toEqual({ postCount: 0, categoryCount: 0, lastSyncAt: null });
   });
@@ -28,7 +27,7 @@ describe("StatsService.getAboutStats", () => {
       getDistinctActiveCategoryCount: vi.fn().mockResolvedValue(7),
       getLastActiveUpdatedAt: vi.fn().mockResolvedValue(lastSync),
     });
-    const service = createStatsService({ post: post as unknown as PostRepository });
+    const service = createStatsService({ post });
     const stats = await service.getAboutStats();
     expect(stats).toEqual({ postCount: 42, categoryCount: 7, lastSyncAt: lastSync });
   });

--- a/src/services/StatsService.ts
+++ b/src/services/StatsService.ts
@@ -1,4 +1,4 @@
-import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+import { getRepositories } from "@/infra/db/repositories";
 
 export interface SiteStats {
   postCount: number;
@@ -6,8 +6,14 @@ export interface SiteStats {
   lastSyncAt: Date | null;
 }
 
+interface StatsPostRepository {
+  getActivePostCount(): Promise<number>;
+  getDistinctActiveCategoryCount(): Promise<number>;
+  getLastActiveUpdatedAt(): Promise<Date | null>;
+}
+
 interface StatsRepositories {
-  post: PostRepository;
+  post: StatsPostRepository;
 }
 
 export function createStatsService(repos: StatsRepositories) {
@@ -22,4 +28,8 @@ export function createStatsService(repos: StatsRepositories) {
       return { postCount, categoryCount, lastSyncAt };
     },
   };
+}
+
+export function createDefaultStatsService() {
+  return createStatsService(getRepositories());
 }

--- a/src/services/StatsService.ts
+++ b/src/services/StatsService.ts
@@ -1,0 +1,25 @@
+import type { PostRepository } from "@/infra/db/repositories/PostRepository";
+
+export interface SiteStats {
+  postCount: number;
+  categoryCount: number;
+  lastSyncAt: Date | null;
+}
+
+interface StatsRepositories {
+  post: PostRepository;
+}
+
+export function createStatsService(repos: StatsRepositories) {
+  return {
+    async getAboutStats(): Promise<SiteStats> {
+      const [postCount, categoryCount, lastSyncAt] = await Promise.all([
+        repos.post.getActivePostCount(),
+        repos.post.getDistinctActiveCategoryCount(),
+        repos.post.getLastActiveUpdatedAt(),
+      ]);
+
+      return { postCount, categoryCount, lastSyncAt };
+    },
+  };
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -35,3 +35,5 @@ export { PostSyncService } from "./PostSyncService";
 export { MetadataSyncService } from "./MetadataSyncService";
 export { SyncService } from "./SyncService";
 export { PostService } from "./PostService";
+export { createStatsService } from "./StatsService";
+export type { SiteStats } from "./StatsService";

--- a/tasks/plan023-about-redesign/design-about.css
+++ b/tasks/plan023-about-redesign/design-about.css
@@ -1,0 +1,388 @@
+/* fos-blog /about — profile-as-spec layout */
+
+.ab-shell {
+  background: var(--bg-base);
+  color: var(--fg-primary);
+  font-family: var(--font-sans);
+  width: 100%; height: 100%;
+  overflow-y: auto;
+  font-size: 14px;
+}
+.ab-shell.light {
+  --bg-base: #f7f7f8;
+  --bg-subtle: #ffffff;
+  --bg-elevated: #ffffff;
+  --bg-overlay: #ededef;
+  --fg-primary: #0a0a0b;
+  --fg-secondary: #3f3f46;
+  --fg-muted: #71717a;
+  --fg-faint: #a1a1aa;
+  --border-subtle: #ececee;
+  --border-default: #d4d4d8;
+}
+
+.ab-shell a { color: inherit; text-decoration: none; }
+
+.ab-container {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+.ab-shell.mobile .ab-container { padding: 0 20px; }
+
+/* ---------- Sub-hero ---------- */
+.ab-subhero {
+  position: relative;
+  padding: 64px 0 32px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.ab-shell.mobile .ab-subhero { padding: 36px 0 22px; }
+
+.ab-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--brand);
+  display: inline-flex; align-items: center; gap: 10px;
+  margin-bottom: 20px;
+}
+.ab-eyebrow::before {
+  content: "";
+  width: 24px; height: 1px;
+  background: var(--brand);
+}
+
+.ab-title {
+  font-size: clamp(36px, 4.6vw, 56px);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--fg-primary);
+  margin-bottom: 18px;
+}
+.ab-shell.mobile .ab-title { font-size: 32px; margin-bottom: 14px; }
+
+.ab-meta {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--fg-secondary);
+  letter-spacing: -0.005em;
+  max-width: 56ch;
+}
+.ab-shell.mobile .ab-meta { font-size: 14px; }
+
+/* ---------- shared card ---------- */
+.ab-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 32px;
+  position: relative;
+}
+.ab-shell.mobile .ab-card { padding: 20px; border-radius: 12px; }
+
+/* section spacing */
+.ab-section {
+  margin-top: 64px;
+}
+.ab-shell.mobile .ab-section { margin-top: 40px; }
+
+.ab-section-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 20px;
+}
+.ab-section-head .h2 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  display: inline-flex; align-items: center; gap: 10px;
+}
+.ab-section-head .h2 .idx {
+  color: var(--fg-faint);
+  font-size: 10px;
+}
+.ab-section-head .h2::after {
+  content: "";
+  display: inline-block;
+  width: 80px; height: 1px;
+  background: var(--border-subtle);
+  margin-left: 4px;
+}
+
+/* ---------- ProfileCard ---------- */
+.ab-profile {
+  display: grid;
+  grid-template-columns: 128px 1fr;
+  gap: 32px;
+  align-items: start;
+  padding: 36px;
+}
+.ab-shell.mobile .ab-profile {
+  grid-template-columns: 1fr;
+  gap: 20px;
+  padding: 24px;
+}
+
+.ab-avatar {
+  width: 128px; height: 128px;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 30% 30%, oklch(0.78 0.13 195 / 0.6), transparent 60%),
+    radial-gradient(circle at 70% 70%, oklch(0.65 0.18 280 / 0.5), transparent 60%),
+    var(--bg-overlay);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  flex: none;
+  display: grid; place-items: center;
+  font-family: var(--font-mono);
+  font-size: 44px;
+  font-weight: 500;
+  color: var(--fg-primary);
+  letter-spacing: -0.04em;
+}
+.ab-avatar::after {
+  content: "";
+  position: absolute; inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, transparent 50%, rgb(255 255 255 / 0.06));
+  pointer-events: none;
+}
+.ab-shell.mobile .ab-avatar { width: 96px; height: 96px; font-size: 32px; }
+
+.ab-profile-body {
+  display: flex; flex-direction: column;
+  gap: 14px;
+}
+.ab-profile-name {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  color: var(--fg-primary);
+  display: flex; align-items: baseline; gap: 12px;
+  flex-wrap: wrap;
+}
+.ab-profile-name .handle {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--fg-muted);
+  letter-spacing: 0;
+}
+.ab-shell.mobile .ab-profile-name { font-size: 22px; }
+.ab-shell.mobile .ab-profile-name .handle { font-size: 12px; }
+
+.ab-profile-bio {
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--fg-secondary);
+  letter-spacing: -0.005em;
+  max-width: 56ch;
+}
+.ab-shell.mobile .ab-profile-bio { font-size: 13px; }
+
+.ab-profile-stats {
+  display: inline-flex; align-items: center;
+  gap: 0;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-base);
+  width: fit-content;
+}
+.ab-profile-stats .stat {
+  padding: 8px 14px;
+  display: inline-flex; align-items: baseline; gap: 6px;
+  border-right: 1px solid var(--border-subtle);
+}
+.ab-profile-stats .stat:last-child { border-right: none; }
+.ab-profile-stats .stat .num {
+  color: var(--fg-primary);
+  font-weight: 500;
+  font-size: 13px;
+  letter-spacing: -0.005em;
+}
+.ab-profile-stats .stat .lbl {
+  color: var(--fg-muted);
+  font-size: 11px;
+}
+
+.ab-profile-cta {
+  display: inline-flex; align-items: center; gap: 8px;
+  margin-top: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-base);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-secondary);
+  letter-spacing: -0.005em;
+  width: fit-content;
+  transition: border-color 150ms cubic-bezier(0.22, 1, 0.36, 1), color 150ms;
+}
+.ab-profile-cta:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+.ab-profile-cta .arr { color: var(--fg-faint); margin-left: 2px; }
+.ab-profile-cta:hover .arr { color: var(--brand); }
+
+/* ---------- SiteStats ---------- */
+.ab-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.ab-shell.mobile .ab-stats {
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+.ab-stat {
+  padding: 24px;
+}
+.ab-shell.mobile .ab-stat { padding: 18px; }
+.ab-stat-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-bottom: 16px;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.ab-stat-eyebrow .right {
+  color: var(--fg-faint);
+  font-size: 10px;
+}
+.ab-stat-num {
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  color: var(--fg-primary);
+  line-height: 1;
+  font-feature-settings: "tnum";
+}
+.ab-shell.mobile .ab-stat-num { font-size: 32px; }
+.ab-stat-num .unit {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--fg-muted);
+  margin-left: 4px;
+  letter-spacing: 0;
+}
+.ab-stat-sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  margin-top: 8px;
+  display: flex; align-items: center; gap: 6px;
+}
+.ab-stat-sub .pulse {
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: var(--brand);
+  box-shadow: 0 0 8px var(--brand);
+  animation: ab-pulse 1.6s ease-in-out infinite;
+}
+@keyframes ab-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* ---------- Chip grid (Stack + Links shared) ---------- */
+.ab-chip-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+.ab-chip-grid.col3 { grid-template-columns: repeat(3, 1fr); }
+.ab-chip-grid.col2 { grid-template-columns: repeat(2, 1fr); }
+.ab-shell.mobile .ab-chip-grid { grid-template-columns: repeat(2, 1fr); gap: 6px; }
+
+.ab-chip {
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  display: flex; align-items: center; gap: 10px;
+  font-size: 13px;
+  color: var(--fg-secondary);
+  letter-spacing: -0.005em;
+  transition: all 150ms cubic-bezier(0.22, 1, 0.36, 1);
+  cursor: pointer;
+  min-width: 0;
+}
+.ab-chip:hover {
+  border-color: var(--border-default);
+  color: var(--fg-primary);
+  transform: translateY(-1px);
+}
+.ab-chip .dot {
+  width: 8px; height: 8px;
+  border-radius: 999px;
+  background: var(--cat-color, var(--brand));
+  flex: none;
+}
+.ab-chip .key {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  margin-left: auto;
+  letter-spacing: 0;
+}
+
+/* link variant */
+.ab-chip.link:hover { border-color: var(--brand); color: var(--brand); }
+.ab-chip.link:hover .dot {
+  background: var(--brand) !important;
+  box-shadow: 0 0 8px var(--brand);
+}
+.ab-chip.link:hover .key { color: var(--brand); opacity: 0.7; }
+.ab-chip.link .ico {
+  width: 16px; height: 16px;
+  flex: none;
+  display: grid; place-items: center;
+  color: var(--fg-muted);
+}
+.ab-chip.link:hover .ico { color: var(--brand); }
+.ab-chip.link .ttl {
+  font-size: 13px;
+  color: var(--fg-primary);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+.ab-chip.link .sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  letter-spacing: 0;
+  display: block; margin-top: 2px;
+}
+.ab-chip.link:hover .sub { color: color-mix(in oklch, var(--brand), transparent 30%); }
+
+/* ---------- footer note ---------- */
+.ab-end {
+  margin-top: 80px;
+  padding: 32px 0 64px;
+  border-top: 1px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  display: flex; justify-content: space-between;
+  flex-wrap: wrap; gap: 12px;
+  letter-spacing: 0;
+}
+.ab-shell.mobile .ab-end {
+  margin-top: 48px;
+  padding: 20px 0 40px;
+  flex-direction: column;
+}

--- a/tasks/plan023-about-redesign/design-about.jsx
+++ b/tasks/plan023-about-redesign/design-about.jsx
@@ -1,0 +1,167 @@
+/* global React */
+
+const STACK = [
+  { label: "Next.js 16",     hue: 0,   key: "framework" },
+  { label: "TypeScript",     hue: 220, key: "language" },
+  { label: "Tailwind v4",    hue: 195, key: "styling" },
+  { label: "Drizzle ORM",    hue: 90,  key: "data" },
+  { label: "MySQL 8",        hue: 55,  key: "db" },
+  { label: "Redis",          hue: 25,  key: "cache" },
+  { label: "Docker",         hue: 230, key: "infra" },
+  { label: "GitHub Actions", hue: 145, key: "ci/cd" },
+  { label: "Vercel",         hue: 280, key: "hosting" },
+  { label: "MDX",            hue: 180, key: "content" },
+  { label: "shiki",          hue: 250, key: "syntax" },
+  { label: "Geist · Pretendard", hue: 195, key: "type" },
+];
+
+const LINKS = [
+  { ttl: "GitHub",     sub: "@jon890",                ico: "github" },
+  { ttl: "Source",     sub: "jon890/fos-study",       ico: "code" },
+  { ttl: "RSS",        sub: "/rss.xml",               ico: "rss" },
+  { ttl: "Email",      sub: "hi@fos-blog.dev",        ico: "mail" },
+  { ttl: "Newsletter", sub: "weekly · 1 post",        ico: "send" },
+  { ttl: "X / Twitter",sub: "@jon890_dev",            ico: "x" },
+];
+
+const ICO = {
+  github: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>,
+  code:   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>,
+  rss:    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>,
+  mail:   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>,
+  send:   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></svg>,
+  x:      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 4l11.733 16h4.267l-11.733 -16z"/><path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772"/></svg>,
+};
+const catC = (h) => `oklch(0.74 0.09 ${h})`;
+
+function About({ theme = "dark", mobile = false }) {
+  const cls = "ab-shell" + (theme === "light" ? " light" : "") + (mobile ? " mobile" : "");
+
+  return (
+    <div className={cls}>
+
+      {/* Sub-hero */}
+      <header className="ab-subhero">
+        <div className="ab-container">
+          <span className="ab-eyebrow">ABOUT</span>
+          <h1 className="ab-title">FOS Study</h1>
+          <p className="ab-meta">
+            한 명의 백엔드 엔지니어가 매일 쌓는 학습 노트.
+            공부하면서 기록하고, 기록하면서 다시 배웁니다.
+          </p>
+        </div>
+      </header>
+
+      <main className="ab-container">
+
+        {/* ProfileCard */}
+        <section className="ab-section" style={{ marginTop: mobile ? 32 : 48 }}>
+          <div className="ab-section-head">
+            <span className="h2"><span className="idx">01</span><span>profile</span></span>
+          </div>
+          <article className="ab-card ab-profile">
+            <div className="ab-avatar">J</div>
+            <div className="ab-profile-body">
+              <h2 className="ab-profile-name">
+                Jon Choi
+                <span className="handle">@jon890</span>
+              </h2>
+              <p className="ab-profile-bio">
+                Backend engineer · Seoul. Java/Spring 위에서 결제·쿠폰·재고를 다룹니다.
+                밤에는 Postgres, RAG, 한국어 검색 같은 곁가지 주제를 만지면서 노트를 정리합니다.
+                무조건 빠른 코드보다는 다섯 명이 함께 읽기 편한 코드를 좋아합니다.
+              </p>
+              <div className="ab-profile-stats">
+                <span className="stat"><span className="num">42</span><span className="lbl">repos</span></span>
+                <span className="stat"><span className="num">328</span><span className="lbl">followers</span></span>
+                <span className="stat"><span className="num">7y</span><span className="lbl">writing</span></span>
+              </div>
+              <a className="ab-profile-cta">
+                <span>github.com/jon890</span>
+                <span className="arr">↗</span>
+              </a>
+            </div>
+          </article>
+        </section>
+
+        {/* SiteStats */}
+        <section className="ab-section">
+          <div className="ab-section-head">
+            <span className="h2"><span className="idx">02</span><span>site stats</span></span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--fg-faint)", letterSpacing: 0 }}>
+              snapshot · 2026.05.07
+            </span>
+          </div>
+          <div className="ab-stats">
+            <div className="ab-card ab-stat">
+              <div className="ab-stat-eyebrow"><span>POSTS</span><span className="right">total</span></div>
+              <div className="ab-stat-num">200<span className="unit">.mdx</span></div>
+              <div className="ab-stat-sub">9 categories · 12 series</div>
+            </div>
+            <div className="ab-card ab-stat">
+              <div className="ab-stat-eyebrow"><span>CATEGORIES</span><span className="right">active</span></div>
+              <div className="ab-stat-num">9<span className="unit">/ 12</span></div>
+              <div className="ab-stat-sub">3 are draft-only</div>
+            </div>
+            <div className="ab-card ab-stat">
+              <div className="ab-stat-eyebrow"><span>LAST SYNC</span><span className="right">git</span></div>
+              <div className="ab-stat-num">2<span className="unit">시간 전</span></div>
+              <div className="ab-stat-sub">
+                <span className="pulse" />
+                <span>main · #a3f9c1</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* StackGrid */}
+        <section className="ab-section">
+          <div className="ab-section-head">
+            <span className="h2"><span className="idx">03</span><span>stack</span></span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--fg-faint)", letterSpacing: 0 }}>
+              {STACK.length} packages
+            </span>
+          </div>
+          <div className={"ab-chip-grid" + (mobile ? "" : "")}>
+            {STACK.map((s, i) => (
+              <span key={i} className="ab-chip" style={{ "--cat-color": catC(s.hue) }}>
+                <span className="dot" />
+                <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.label}</span>
+                <span className="key">{s.key}</span>
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {/* LinksGrid */}
+        <section className="ab-section">
+          <div className="ab-section-head">
+            <span className="h2"><span className="idx">04</span><span>links</span></span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--fg-faint)", letterSpacing: 0 }}>
+              external
+            </span>
+          </div>
+          <div className={"ab-chip-grid col3"}>
+            {LINKS.map((l, i) => (
+              <a key={i} className="ab-chip link">
+                <span className="ico">{ICO[l.ico]}</span>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span className="ttl">{l.ttl}</span>
+                  <span className="sub">{l.sub}</span>
+                </span>
+                <span className="key">↗</span>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <div className="ab-end">
+          <span>fos-blog · /about · last build 2026.05.07 · v0.1</span>
+          <span>© 2026 FOS Study · MIT</span>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+Object.assign(window, { About });

--- a/tasks/plan023-about-redesign/index.json
+++ b/tasks/plan023-about-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan023-about-redesign",
   "description": "About 페이지 전면 리디자인 — Claude Design mockup (`design-about.{css,jsx}`) 시각 사양 그대로 구현. plan009 토큰 + numbered 섹션 헤더 + ProfileCard (gradient avatar + inline pill stats + CTA) + SiteStats (3-card with pulse) + StackGrid (chip + cat-color dot) + LinksGrid (lucide icon chip). 실제 GitHub fetch + DB 통계 통합.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-06",
   "total_phases": 2,
   "related_docs": [
@@ -17,14 +17,14 @@
       "file": "phase-01.md",
       "title": "AboutSubHero + 프로필 카드 + 사이트 통계 + 스택 grid + 링크 grid 재구성",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + about.md 신규 docs + index.json 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan023-about-redesign/index.json
+++ b/tasks/plan023-about-redesign/index.json
@@ -1,6 +1,6 @@
 {
   "name": "plan023-about-redesign",
-  "description": "About 페이지 전면 리디자인 — plan009 토큰 + sub-hero (PostsListSubHero 패턴) + 프로필 카드 + 사이트 통계 + 기술 스택 grid + 링크 grid. GitHub 프로필 fetch 유지, 신규로 사이트 통계 (총 글 수 / 카테고리 수 / 최근 sync). Claude Design mockup 도착 시 phase 1 디자인 영역 갱신 가능.",
+  "description": "About 페이지 전면 리디자인 — Claude Design mockup (`design-about.{css,jsx}`) 시각 사양 그대로 구현. plan009 토큰 + numbered 섹션 헤더 + ProfileCard (gradient avatar + inline pill stats + CTA) + SiteStats (3-card with pulse) + StackGrid (chip + cat-color dot) + LinksGrid (lucide icon chip). 실제 GitHub fetch + DB 통계 통합.",
   "status": "pending",
   "created_at": "2026-05-06",
   "total_phases": 2,

--- a/tasks/plan023-about-redesign/phase-01.md
+++ b/tasks/plan023-about-redesign/phase-01.md
@@ -61,9 +61,9 @@ mockup 의 가짜 통계/리스트는 실제 fos-blog 값으로 치환:
   ] as const;
   ```
 - **ProfileCard 통계**: GitHub API 의 `public_repos`, `followers` 두 개만 (mockup 의 `7y writing` 같은 임의값 제거)
-- **SiteStats**: 실 DB 조회 값
+- **SiteStats**: 실 DB 조회 값 (schema 확인: `posts.category` (varchar notnull), `posts.subcategory` (nullable), `posts.folders` (json array). `categoryPath` 컬럼은 없음)
   - `POSTS .total`: `posts.isActive=true` count
-  - `CATEGORIES .active`: distinct `categoryPath` count (schema 컬럼명 확인 후)
+  - `CATEGORIES .active`: `COUNT(DISTINCT category) WHERE isActive=true` (단순. sub 라인 `"distinct category"`)
   - `LAST SYNC .db`: `MAX(posts.updatedAt)` → `formatRelativeTime`. null 이면 큰 숫자 영역에 `—`, sub 라인에 `no sync yet`
 
 ## 컨벤션 / 기술 결정
@@ -73,7 +73,7 @@ mockup 의 가짜 통계/리스트는 실제 fos-blog 값으로 치환:
   - `.ab-avatar` 컨테이너에 radial gradient + initial 텍스트는 항상 존재
   - `next/image` 는 `.ab-avatar` 자식으로 absolute 배치 (mockup `position: relative` 컨테이너 활용)
 - **CSS 전략**: `::before`/`::after` hairline, `@keyframes ab-pulse`, `oklch(... ${hue})` 동적 색은 Tailwind arbitrary value 만으로 어색 → **`src/app/about/about.css` co-located CSS 파일** 신규 + `import "./about.css"` 로 page.tsx 에 주입. 클래스 prefix `ab-` 유지 (mockup 과 1:1 비교 용이).
-  - mockup 의 `.ab-shell.light { ... }` 토큰 재정의 블록은 제거 (plan009 가 `:root` / `[data-theme]` 으로 이미 처리)
+  - mockup 의 `.ab-shell.light { ... }` 토큰 재정의 블록은 제거 (plan009 가 `:root` (default = dark) / `:root:not(.dark)` (light override) 로 이미 처리. `[data-theme]` selector 도입 금지)
   - mockup 의 `.ab-shell.mobile` 클래스 분기는 `@media (max-width: 640px)` 로 변환 (page.tsx 가 `mobile` prop 안 넘김)
   - `--cat-color` 인라인 변수 패턴은 유지 (chip dot 색)
 - container max-width 1180px, padding `0 32px` (모바일 `0 20px`)
@@ -84,11 +84,17 @@ mockup 의 가짜 통계/리스트는 실제 fos-blog 값으로 치환:
 
 ### 1. `src/app/about/about.css` 신규
 
-`tasks/plan023-about-redesign/design-about.css` 를 베이스로 위 토큰 매핑 표대로 sed 수준 일괄 치환. 변경 사항:
-- `.ab-shell.light { ... }` 블록 제거
+`tasks/plan023-about-redesign/design-about.css` 를 베이스로 위 토큰 매핑 표대로 일괄 치환. 변경 사항:
+- `.ab-shell.light { ... }` 블록 제거 (plan009 의 `:root:not(.dark)` 가 처리)
 - `.ab-shell.mobile ...` 분기를 `@media (max-width: 640px) { ... }` 로 변환
 - 모든 색은 plan009 변수 직접 참조
 - `@keyframes ab-pulse` 그대로 유지
+- **신규 룰 추가** (mockup 에 부재 — `next/image` 자식 배치용):
+  ```css
+  .ab-avatar-initial { position: relative; z-index: 0; }
+  .ab-avatar-img { position: absolute; inset: 0; object-fit: cover; z-index: 1; border-radius: inherit; }
+  ```
+  `.ab-avatar` 의 grid + font 룰은 그대로 두고 (이니셜 위치 잡이용), 사진은 `inset:0` 으로 이니셜을 덮음.
 
 ### 2. `src/services/StatsService.ts` + 테스트 + factory 등록
 
@@ -157,7 +163,7 @@ mockup `.ab-profile` 그대로. props: `name`, `handle`, `bio`, `avatarUrl`, `ht
   <div className="ab-card ab-stat">
     <div className="ab-stat-eyebrow"><span>CATEGORIES</span><span className="right">active</span></div>
     <div className="ab-stat-num">{categoryCount}<span className="unit">paths</span></div>
-    <div className="ab-stat-sub">distinct category_path</div>
+    <div className="ab-stat-sub">distinct category</div>
   </div>
   <div className="ab-card ab-stat">
     <div className="ab-stat-eyebrow"><span>LAST SYNC</span><span className="right">db</span></div>
@@ -195,6 +201,18 @@ mockup `.ab-profile` 그대로. props: `name`, `handle`, `bio`, `avatarUrl`, `ht
   <span className="key">↗</span>
 </a>
 ```
+
+**`fetchGitHubProfile()` 추출 + 인증 헤더 추가** (현 `src/app/about/page.tsx:48` 의 함수가 unauthenticated 60/h 한계 → 5000/h 로):
+```ts
+async function fetchGitHubProfile() {
+  const res = await fetch("https://api.github.com/users/jon890", {
+    headers: { Authorization: `Bearer ${env.GITHUB_TOKEN}` },
+    next: { revalidate: 3600 },
+  });
+  // ...
+}
+```
+`env` 는 `@/env` 에서 import (이미 `GITHUB_TOKEN` required 등록됨).
 
 **`page.tsx` 통합** (Server Component):
 
@@ -244,48 +262,7 @@ export default async function AboutPage() {
 
 `<Section>` 은 page.tsx 안의 helper (별도 component 분리 X). `fetchGitHubProfile()` 는 기존 about/page.tsx 에 이미 있는 fetch 로직을 함수 추출 (인증 헤더 + revalidate=3600). 메타데이터 객체는 그대로 유지.
 
-### 6. 자동 verification
-
-```bash
-# cwd: <worktree root>
-pnpm lint
-pnpm type-check
-pnpm test --run
-pnpm build
-
-# 신규 파일
-test -f src/app/about/about.css
-test -f src/components/about/ProfileCard.tsx
-test -f src/components/about/SiteStats.tsx
-test -f src/components/about/StackGrid.tsx
-test -f src/components/about/LinksGrid.tsx
-test -f src/services/StatsService.ts
-test -f src/services/StatsService.test.ts
-
-# 하드코딩 색 0줄 (about 영역)
-! grep -nE "bg-white|bg-gray-|bg-blue-|text-gray-|text-blue-|text-white|border-gray-|focus:ring-blue|#[0-9a-fA-F]{3,6}\b" src/app/about/page.tsx src/components/about/*.tsx
-# about.css 는 plan009 var + oklch 만 (raw hex 0건)
-! grep -nE "#[0-9a-fA-F]{3,6}\b" src/app/about/about.css
-
-# Service factory 등록
-grep -n "createStatsService" src/services/index.ts
-
-# lucide 아이콘 사용 (mockup 인라인 SVG 가 아닌)
-grep -n 'from "lucide-react"' src/components/about/LinksGrid.tsx
-
-# RSS / Newsletter / X 링크 부재 (실 데이터만)
-! grep -nE "rss\.xml|newsletter|twitter" src/components/about/LinksGrid.tsx
-
-# Vercel / MDX / Redis 부재 (mockup placeholder 제거)
-! grep -nE "Vercel|\\bMDX\\b|Redis" src/components/about/StackGrid.tsx
-```
-
-수동 smoke (사용자 안내):
-- `pnpm dev` → `/about` 진입 → 다크/라이트 모드 양쪽에서 mockup 과 1:1 비교
-- pulse 애니메이션 (LAST SYNC 카드) 동작
-- chip hover transition (`translateY(-1px)` + border-color 변화)
-- LinksGrid hover 시 brand-400 으로 color shift + dot 발광
-- GitHub avatar 정상 로드 확인 (이니셜이 사진 뒤에 가려져 있으면 OK)
+> **검증/lint/build 게이트는 phase-02 로 통합** — phase-02 의 verification 섹션 참조. phase-01 은 코드 작성에 집중.
 
 ## Critical Files
 

--- a/tasks/plan023-about-redesign/phase-01.md
+++ b/tasks/plan023-about-redesign/phase-01.md
@@ -1,165 +1,318 @@
-# Phase 01 — About 페이지 전면 리디자인
+# Phase 01 — About 페이지 전면 리디자인 (Claude Design mockup 반영)
 
 **Model**: sonnet
-**Goal**: `/about` 페이지를 plan009 디자인 시스템 + plan016 sub-hero 패턴으로 재구성. GitHub 프로필 fetch 유지, 신규로 사이트 통계 카드 추가.
+**Goal**: `/about` 페이지를 Claude Design mockup (`tasks/plan023-about-redesign/design-about.{css,jsx}`) 의 시각 사양 그대로 재구성. plan009 토큰 + plan016 sub-hero 패턴 유지. GitHub 프로필 fetch + DB 사이트 통계 양쪽 통합.
 
-## Context (자기완결)
+## 시각 레퍼런스 (필수 — 구현 전 반드시 읽기)
 
-`src/app/about/page.tsx` 211줄, plan009 단절 (`text-gray-*`, `text-blue-*`, `bg-gray-*`, `border-gray-*` 전반). GitHub API fetch (`https://api.github.com/users/jon890`) 로 name/avatar/bio/repos/followers 받아 표시.
+- `tasks/plan023-about-redesign/design-about.jsx` — 마크업 구조 + 데이터 형태
+- `tasks/plan023-about-redesign/design-about.css` — 정확한 spec (간격, 폰트 크기, transition, keyframe)
 
-**플젝 컨벤션**:
-- Server Component (`revalidate = 3600`) 유지
-- `next/image` 로 avatar
-- plan009 토큰만 사용 (`bg-[var(--color-bg-elevated)]`, `text-[var(--color-fg-primary|secondary|muted)]`, `border-[var(--color-border-subtle)]`, `text-[var(--color-brand-400)]`)
-- container max-width: `1180px` (plan016 컨벤션과 정합)
-- 하드코딩 색상 0줄 목표
+mockup 의 짧은 토큰명을 plan009 토큰으로 일괄 치환:
+
+| mockup | plan009 |
+|---|---|
+| `var(--bg-base)` | `var(--color-bg-base)` |
+| `var(--bg-elevated)` | `var(--color-bg-elevated)` |
+| `var(--bg-overlay)` | `var(--color-bg-overlay)` |
+| `var(--fg-primary)` | `var(--color-fg-primary)` |
+| `var(--fg-secondary)` | `var(--color-fg-secondary)` |
+| `var(--fg-muted)` | `var(--color-fg-muted)` |
+| `var(--fg-faint)` | `var(--color-fg-faint)` |
+| `var(--border-subtle)` | `var(--color-border-subtle)` |
+| `var(--border-default)` | `var(--color-border-default)` |
+| `var(--brand)` | `var(--color-brand-400)` |
+
+## 프로젝트 환경 (사전 확인 완료)
+
+- `lucide-react@^0.469.0` 설치됨 → `Github`, `Code`, `Mail` 아이콘 import 사용 (mockup 의 inline SVG 대신)
+- `next.config.ts` 의 `images.remotePatterns` 에 `avatars.githubusercontent.com` 이미 등록됨 → 추가 작업 없음
+- `formatRelativeTime` 은 `@/lib/format-time` 존재 (plan022)
+- RSS 라우트 부재 → LinksGrid 에서 제외 (Newsletter / X 도 미구현이라 제외)
+- `LICENSE` 파일 부재 → footer 에 "MIT" 문구 금지 (단순 `© ${year} jon890`)
+
+## 데이터 정합 (mockup placeholder → 실 데이터)
+
+mockup 의 가짜 통계/리스트는 실제 fos-blog 값으로 치환:
+
+- **STACK 리스트** (mockup 의 "Vercel / MDX / Redis" 는 본 프로젝트 무관 — 실 스택만):
+  ```ts
+  const STACK = [
+    { label: "Next.js 16",         hue: 0,   key: "framework" },
+    { label: "TypeScript",         hue: 220, key: "language" },
+    { label: "Tailwind v4",        hue: 195, key: "styling" },
+    { label: "Drizzle ORM",        hue: 90,  key: "data" },
+    { label: "MySQL 8",            hue: 55,  key: "db" },
+    { label: "Docker",             hue: 230, key: "infra" },
+    { label: "Octokit",            hue: 145, key: "github" },
+    { label: "rehype-pretty-code", hue: 250, key: "syntax" },
+    { label: "mermaid",            hue: 175, key: "diagram" },
+    { label: "Vitest",             hue: 120, key: "test" },
+    { label: "pino",               hue: 35,  key: "log" },
+    { label: "shadcn/ui",          hue: 280, key: "ui" },
+  ] as const;
+  ```
+- **LINKS** (실재하는 링크만):
+  ```ts
+  const LINKS = [
+    { ttl: "GitHub",  sub: "@jon890",          href: "https://github.com/jon890",            ico: Github },
+    { ttl: "Source",  sub: "jon890/fos-blog",  href: "https://github.com/jon890/fos-blog",   ico: Code },
+    { ttl: "Content", sub: "jon890/fos-study", href: "https://github.com/jon890/fos-study",  ico: Code },
+  ] as const;
+  ```
+- **ProfileCard 통계**: GitHub API 의 `public_repos`, `followers` 두 개만 (mockup 의 `7y writing` 같은 임의값 제거)
+- **SiteStats**: 실 DB 조회 값
+  - `POSTS .total`: `posts.isActive=true` count
+  - `CATEGORIES .active`: distinct `categoryPath` count (schema 컬럼명 확인 후)
+  - `LAST SYNC .db`: `MAX(posts.updatedAt)` → `formatRelativeTime`. null 이면 큰 숫자 영역에 `—`, sub 라인에 `no sync yet`
+
+## 컨벤션 / 기술 결정
+
+- **Server Component** (`revalidate = 3600`) 유지
+- **Avatar 두 상태는 디자인의 일부** — mockup 의 gradient + 이니셜 컨테이너는 항상 렌더링되며, GitHub 프로필 fetch 가 성공하면 그 위에 `next/image` 가 채워진다. fetch 실패 / `avatarUrl` 부재 시 이니셜이 그대로 보이는 구조.
+  - `.ab-avatar` 컨테이너에 radial gradient + initial 텍스트는 항상 존재
+  - `next/image` 는 `.ab-avatar` 자식으로 absolute 배치 (mockup `position: relative` 컨테이너 활용)
+- **CSS 전략**: `::before`/`::after` hairline, `@keyframes ab-pulse`, `oklch(... ${hue})` 동적 색은 Tailwind arbitrary value 만으로 어색 → **`src/app/about/about.css` co-located CSS 파일** 신규 + `import "./about.css"` 로 page.tsx 에 주입. 클래스 prefix `ab-` 유지 (mockup 과 1:1 비교 용이).
+  - mockup 의 `.ab-shell.light { ... }` 토큰 재정의 블록은 제거 (plan009 가 `:root` / `[data-theme]` 으로 이미 처리)
+  - mockup 의 `.ab-shell.mobile` 클래스 분기는 `@media (max-width: 640px)` 로 변환 (page.tsx 가 `mobile` prop 안 넘김)
+  - `--cat-color` 인라인 변수 패턴은 유지 (chip dot 색)
+- container max-width 1180px, padding `0 32px` (모바일 `0 20px`)
+- **하드코딩 색 0줄** — `#`, `rgb(...)`, `text-gray-*`, `bg-blue-*` 등 0건. 단 `oklch(0.74 0.09 ${hue})` 인라인 `--cat-color` 는 디자인 의도라 허용
+- **GitHub API**: `Authorization: Bearer ${process.env.GITHUB_TOKEN}` 헤더 + `next: { revalidate: 3600 }`. 인증 시 한도 5000/hour. 본 프로젝트 모든 GitHub fetch 와 동일한 패턴.
 
 ## 작업 항목
 
-### 1. `src/components/AboutSubHero.tsx` 신규
+### 1. `src/app/about/about.css` 신규
 
-`PostsListSubHero` 와 같은 톤의 sub-hero. props:
-- `eyebrow`: "ABOUT"
-- `title`: "FOS Study" 또는 "fos-blog"
-- `meta`: 한 줄 설명 (예: "한 명의 백엔드 엔지니어가 매일 쌓는 학습 노트")
+`tasks/plan023-about-redesign/design-about.css` 를 베이스로 위 토큰 매핑 표대로 sed 수준 일괄 치환. 변경 사항:
+- `.ab-shell.light { ... }` 블록 제거
+- `.ab-shell.mobile ...` 분기를 `@media (max-width: 640px) { ... }` 로 변환
+- 모든 색은 plan009 변수 직접 참조
+- `@keyframes ab-pulse` 그대로 유지
 
-레이아웃 동일 패턴:
+### 2. `src/services/StatsService.ts` + 테스트 + factory 등록
+
+```ts
+export interface SiteStats {
+  postCount: number;
+  categoryCount: number;
+  lastSyncAt: Date | null;
+}
+
+export function createStatsService(repos: Repositories) {
+  return {
+    async getAboutStats(): Promise<SiteStats> {
+      // posts.isActive=true count, distinct categoryPath count, MAX(updatedAt)
+    },
+  };
+}
+```
+
+- DB 조회 3개 쿼리 (드리즐). 빈 DB → `{ postCount: 0, categoryCount: 0, lastSyncAt: null }`.
+- `src/services/index.ts` 에 factory 등록 (기존 PostService 패턴 그대로)
+- `src/services/StatsService.test.ts`: vitest mock repositories — 빈 결과 / 정상 결과 두 케이스
+
+### 3. `src/components/about/ProfileCard.tsx` 신규
+
+mockup `.ab-profile` 그대로. props: `name`, `handle`, `bio`, `avatarUrl`, `htmlUrl`, `publicRepos`, `followers`.
+
 ```tsx
-<div className="py-10 md:py-14">
-  <div className="flex items-center gap-3">
-    <span className="h-px w-6 bg-[var(--color-brand-400)]" />
-    <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-[var(--color-fg-muted)]">
-      {eyebrow}
-    </span>
+<article className="ab-card ab-profile">
+  <div className="ab-avatar">
+    <span className="ab-avatar-initial">{name.charAt(0).toUpperCase()}</span>
+    {avatarUrl && (
+      <Image src={avatarUrl} alt={name} fill sizes="128px" className="ab-avatar-img" />
+    )}
   </div>
-  <h1 className="mt-4 text-[28px] md:text-[40px] font-semibold leading-[1.1] tracking-tight text-[var(--color-fg-primary)]">
-    {title}
-  </h1>
-  <p className="mt-3 font-mono text-[12px] uppercase tracking-[0.06em] text-[var(--color-fg-muted)]">
-    {meta}
-  </p>
-  <div className="mt-8 h-px bg-[var(--color-border-subtle)]" />
+  <div className="ab-profile-body">
+    <h2 className="ab-profile-name">
+      {name}<span className="handle">{handle}</span>
+    </h2>
+    <p className="ab-profile-bio">{bio}</p>
+    <div className="ab-profile-stats">
+      <span className="stat"><span className="num">{publicRepos}</span><span className="lbl">repos</span></span>
+      <span className="stat"><span className="num">{followers}</span><span className="lbl">followers</span></span>
+    </div>
+    <a className="ab-profile-cta" href={htmlUrl} target="_blank" rel="noopener noreferrer">
+      <span>{htmlUrl.replace(/^https?:\/\//, "")}</span>
+      <span className="arr">↗</span>
+    </a>
+  </div>
+</article>
+```
+
+`.ab-avatar-img` 는 `position: absolute; inset: 0;` 로 이니셜 위에 덮음. `avatarUrl` 없으면 이니셜만 보임 (디자인 명시 상태).
+
+### 4. `src/components/about/SiteStats.tsx` 신규
+
+3-card grid. props: `{ postCount, categoryCount, lastSyncAt }`.
+
+```tsx
+<div className="ab-stats">
+  <div className="ab-card ab-stat">
+    <div className="ab-stat-eyebrow"><span>POSTS</span><span className="right">total</span></div>
+    <div className="ab-stat-num">{postCount}<span className="unit">posts</span></div>
+    <div className="ab-stat-sub">{categoryCount} categories</div>
+  </div>
+  <div className="ab-card ab-stat">
+    <div className="ab-stat-eyebrow"><span>CATEGORIES</span><span className="right">active</span></div>
+    <div className="ab-stat-num">{categoryCount}<span className="unit">paths</span></div>
+    <div className="ab-stat-sub">distinct category_path</div>
+  </div>
+  <div className="ab-card ab-stat">
+    <div className="ab-stat-eyebrow"><span>LAST SYNC</span><span className="right">db</span></div>
+    <div className="ab-stat-num">
+      {lastSyncAt ? formatRelativeTime(lastSyncAt) : "—"}
+    </div>
+    <div className="ab-stat-sub">
+      <span className="pulse" />
+      <span>{lastSyncAt ? new Date(lastSyncAt).toISOString().slice(0, 10) : "no sync yet"}</span>
+    </div>
+  </div>
 </div>
 ```
 
-**결정 — 별도 컴포넌트 신규 (AboutSubHero.tsx)**: `PostsListSubHero` 의 `accent` prop 은 'popular' icon 전용으로 About 컨텍스트와 의미 불일치. 두 sub-hero 의 시각 패턴(eyebrow + title + meta + divider)은 유사하나 컨텍스트 분리가 명확. 향후 다른 페이지 (e.g. /tags) 에 sub-hero 가 더 추가될 때 공통화 검토 (별도 plan).
+### 5. `src/components/about/{StackGrid,LinksGrid}.tsx` + `src/app/about/page.tsx` 통합
 
-### 2. `src/components/about/ProfileCard.tsx` 신규
-
-기존 GitHub 프로필 카드 영역 분리. props:
-- `name`, `bio`, `avatarUrl`, `htmlUrl`, `publicRepos`, `followers`
-
-레이아웃:
-- 좌: `next/image` avatar 96~128px, rounded-full, `border border-[var(--color-border-subtle)]`
-- 우: name (h1, fg-primary), bio (fg-secondary), 통계 (`{publicRepos} repos · {followers} followers` — fg-muted), GitHub 링크 (brand-400)
-- 컨테이너: `bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] rounded-[12px] p-6 md:p-8`
-
-### 3. `src/components/about/SiteStats.tsx` 신규
-
-신규 카드 — 블로그 사이트 통계.
-
-데이터:
-- 총 글 수 (`postCount`): `getRepositories().post.countActive()` 또는 기존 helper
-- 카테고리 수 (`categoryCount`): `categoryIcons` 키 개수 또는 distinct query
-- 최근 sync 시점 (`lastSyncAt`): 가장 최근 `posts.updatedAt` MAX
-
-**구현 노트**:
-- About 페이지 자체가 server component 라 `getRepositories()` 직접 호출 가능
-- 통계 fetch 함수 1개 신규 (`getAboutStats()` in `src/services/StatsService.ts`) — 구조 일관성 위해 service 분리 필수
-- **Service factory 등록 필수**: `src/services/index.ts` 에 `createStatsService()` factory 함수 추가하여 기존 DI 패턴 일치 유지 (다른 service 와 동일하게)
-- 빈 DB 상태 fallback: `0 / 0 / 동기화 전`
-
-레이아웃:
-- 3 column grid (`grid grid-cols-3 gap-4`), 각 cell:
-  - eyebrow (font-mono uppercase 11px fg-muted): `POSTS` / `CATEGORIES` / `LAST SYNC`
-  - 큰 숫자 (semibold 32px fg-primary): `218`, `9`, `2시간 전` (`formatRelativeTime` from `@/lib/format-time` — plan022 에서 추가, `Date | string` 양쪽 수용)
-  - 컨테이너: `bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] rounded-[12px] p-5`
-
-### 4. `src/components/about/StackGrid.tsx` 신규
-
-기술 스택 정리 (현재 inline 으로 있는 부분을 카드 grid 로):
-
+**StackGrid**: 위 STACK 상수, mockup chip 패턴:
 ```tsx
-const STACK_ITEMS = [
-  { label: "Next.js", category: "react" },
-  { label: "TypeScript", category: "js" },
-  { label: "MySQL", category: "db" },
-  { label: "Drizzle ORM", category: "db" },
-  { label: "Tailwind CSS", category: "react" },
-  { label: "Docker", category: "devops" },
-  // ... 기존 about/page.tsx 의 스택 목록 그대로
-];
+<span className="ab-chip" style={{ "--cat-color": `oklch(0.74 0.09 ${s.hue})` } as React.CSSProperties}>
+  <span className="dot" />
+  <span className="ab-chip-label">{s.label}</span>
+  <span className="key">{s.key}</span>
+</span>
+```
+`.ab-chip-label` 의 ellipsis truncation 은 about.css 에서 처리.
+
+**LinksGrid**: 위 LINKS, lucide 아이콘:
+```tsx
+<a className="ab-chip link" href={l.href} target="_blank" rel="noopener noreferrer">
+  <span className="ico"><l.ico size={16} /></span>
+  <span className="ab-chip-link-body">
+    <span className="ttl">{l.ttl}</span>
+    <span className="sub">{l.sub}</span>
+  </span>
+  <span className="key">↗</span>
+</a>
 ```
 
-각 카드:
-- chip `bg-[var(--color-bg-subtle)] border border-[var(--color-border-subtle)] rounded-[8px] px-3 py-2`
-- 작은 dot `h-1.5 w-1.5 rounded-full` 카테고리별 색 (plan022 Avatar 의 `CAT_HEX_PALETTE` 와 일관)
-- 텍스트 `text-[var(--color-fg-secondary)] text-sm`
+**`page.tsx` 통합** (Server Component):
 
-grid: `grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3`
+```tsx
+import "./about.css";
 
-### 5. `src/app/about/page.tsx` 통합
+export const revalidate = 3600;
 
-기존 page.tsx 를 컨테이너로 단순화 — section 구성:
-1. `<AboutSubHero ... />` (또는 PostsListSubHero 재사용)
-2. `<ProfileCard ... />` — GitHub fetch 결과 전달
-3. `<SiteStats ... />` — 사이트 통계 fetch 결과 전달
-4. `<StackGrid />`
-5. 링크 섹션 (GitHub / 블로그 / 이메일 등): `LinksGrid.tsx` 신규 또는 inline — 4번과 같은 chip 패턴
+export default async function AboutPage() {
+  const profile = await fetchGitHubProfile();
+  const stats = await createStatsService(getRepositories()).getAboutStats();
 
-container: `<div className="container mx-auto max-w-[1180px] px-4 py-12 md:py-16">`
+  return (
+    <div className="ab-shell">
+      <header className="ab-subhero">
+        <div className="ab-container">
+          <span className="ab-eyebrow">ABOUT</span>
+          <h1 className="ab-title">FOS Study</h1>
+          <p className="ab-meta">
+            한 명의 백엔드 엔지니어가 매일 쌓는 학습 노트.
+            공부하면서 기록하고, 기록하면서 다시 배웁니다.
+          </p>
+        </div>
+      </header>
+      <main className="ab-container">
+        <Section idx="01" label="profile">
+          <ProfileCard {...profile} />
+        </Section>
+        <Section idx="02" label="site stats" right="snapshot">
+          <SiteStats {...stats} />
+        </Section>
+        <Section idx="03" label="stack" right={`${STACK.length} packages`}>
+          <StackGrid />
+        </Section>
+        <Section idx="04" label="links" right="external">
+          <LinksGrid />
+        </Section>
+        <div className="ab-end">
+          <span>fos-blog · /about</span>
+          <span>© {new Date().getFullYear()} jon890</span>
+        </div>
+      </main>
+    </div>
+  );
+}
+```
 
-각 section 사이 `mt-12 md:mt-16`.
-
-기존 metadata 객체는 그대로 유지.
+`<Section>` 은 page.tsx 안의 helper (별도 component 분리 X). `fetchGitHubProfile()` 는 기존 about/page.tsx 에 이미 있는 fetch 로직을 함수 추출 (인증 헤더 + revalidate=3600). 메타데이터 객체는 그대로 유지.
 
 ### 6. 자동 verification
 
 ```bash
+# cwd: <worktree root>
 pnpm lint
 pnpm type-check
 pnpm test --run
 pnpm build
 
-# 잔존 하드코딩 색 0줄 (about 영역 전체)
-! grep -nE "bg-white|bg-gray-|bg-blue-|text-gray-|text-blue-|text-white|border-gray-|focus:ring-blue" src/app/about/page.tsx src/components/about/
-
-# 신규 컴포넌트
-test -d src/components/about
+# 신규 파일
+test -f src/app/about/about.css
 test -f src/components/about/ProfileCard.tsx
 test -f src/components/about/SiteStats.tsx
 test -f src/components/about/StackGrid.tsx
+test -f src/components/about/LinksGrid.tsx
+test -f src/services/StatsService.ts
+test -f src/services/StatsService.test.ts
 
-# stats service (있다면)
-test -f src/services/StatsService.ts || grep -n "getAboutStats" src/app/about/page.tsx
+# 하드코딩 색 0줄 (about 영역)
+! grep -nE "bg-white|bg-gray-|bg-blue-|text-gray-|text-blue-|text-white|border-gray-|focus:ring-blue|#[0-9a-fA-F]{3,6}\b" src/app/about/page.tsx src/components/about/*.tsx
+# about.css 는 plan009 var + oklch 만 (raw hex 0건)
+! grep -nE "#[0-9a-fA-F]{3,6}\b" src/app/about/about.css
+
+# Service factory 등록
+grep -n "createStatsService" src/services/index.ts
+
+# lucide 아이콘 사용 (mockup 인라인 SVG 가 아닌)
+grep -n 'from "lucide-react"' src/components/about/LinksGrid.tsx
+
+# RSS / Newsletter / X 링크 부재 (실 데이터만)
+! grep -nE "rss\.xml|newsletter|twitter" src/components/about/LinksGrid.tsx
+
+# Vercel / MDX / Redis 부재 (mockup placeholder 제거)
+! grep -nE "Vercel|\\bMDX\\b|Redis" src/components/about/StackGrid.tsx
 ```
 
 수동 smoke (사용자 안내):
-- `pnpm dev` → `/about` 진입 → 다크/라이트 모드 양쪽 시각 확인
-- GitHub fetch 실패 시 fallback (try/catch 의 catch 분기) 동작
-- 통계 카드의 숫자가 실제 DB 와 일치 (총 글 수)
+- `pnpm dev` → `/about` 진입 → 다크/라이트 모드 양쪽에서 mockup 과 1:1 비교
+- pulse 애니메이션 (LAST SYNC 카드) 동작
+- chip hover transition (`translateY(-1px)` + border-color 변화)
+- LinksGrid hover 시 brand-400 으로 color shift + dot 발광
+- GitHub avatar 정상 로드 확인 (이니셜이 사진 뒤에 가려져 있으면 OK)
 
 ## Critical Files
 
 | 파일 | 상태 |
 |---|---|
+| `src/app/about/about.css` | 신규 |
+| `src/app/about/page.tsx` | 대폭 수정 |
 | `src/components/about/ProfileCard.tsx` | 신규 |
 | `src/components/about/SiteStats.tsx` | 신규 |
 | `src/components/about/StackGrid.tsx` | 신규 |
-| `src/components/about/LinksGrid.tsx` (선택) | 신규 또는 inline |
-| `src/services/StatsService.ts` (선택) | 신규 |
-| `src/app/about/page.tsx` | 대폭 수정 |
+| `src/components/about/LinksGrid.tsx` | 신규 |
+| `src/services/StatsService.ts` | 신규 |
+| `src/services/StatsService.test.ts` | 신규 |
+| `src/services/index.ts` | factory 추가 |
 
 ## Out of Scope
 
-- Claude Design mockup 도착 시 layout 미세조정은 후속 review-fix 또는 별도 plan
-- 다국어 about (i18n)
 - About 의 OG 이미지 별도 생성 (현재 layout.tsx 의 default OG 사용)
+- 다국어 about (i18n)
+- Newsletter / X / RSS 링크 (모두 미구현)
+- mockup 의 "3 are draft-only", "main · #a3f9c1" 같은 가짜 메타
 
 ## Risks & Mitigations
 
 | 리스크 | 완화 |
 |---|---|
-| GitHub API rate limit | **인증 요청 필수** — `Authorization: Bearer ${process.env.GITHUB_TOKEN}` 헤더 사용 (5000/hour, 미인증 60/hour 의 ~83x). `revalidate = 3600` 은 보조 캐시 역할. 다중 컨테이너 재시작 / CDN 무효화 동시 fetch 시에도 한도 여유. ProfileCard fetch 구현: `fetch("https://api.github.com/users/jon890", { headers: { Authorization: \`Bearer ${process.env.GITHUB_TOKEN}\` }, next: { revalidate: 3600 } })` |
-| countActive 가 기존 repository 에 없음 | 있으면 그대로, 없으면 `db.select({ count: sql<number>\`count(*)\` }).from(posts).where(eq(posts.isActive, true))` inline 또는 service 추가 |
-| Stack 목록이 about/page.tsx 에 inline 으로 박혀 있어 중복 위험 | StackGrid 내부에 상수로 두고 about/page.tsx 에서는 import 만 — 단일 소스 |
+| GitHub API 일시 장애 | 인증 헤더 + revalidate=3600. 디자인 자체가 이니셜 컨테이너를 항상 렌더하고 그 위에 사진을 덮는 구조라 사진 누락 시 그래픽 깨짐 없음 |
+| `next/image` 의 fill + relative parent | `.ab-avatar` 가 `position: relative`, `next/image` 가 `position: absolute; inset: 0`. mockup 의 컨테이너 spec 그대로 |
+| `oklch(... ${hue})` 카테고리 색이 양쪽 모드에서 채도 차이 | mockup 채도 0.09 가 양쪽에서 충분히 분간 가능 (plan009 categoryIcons 와 일관) |
+| `formatRelativeTime` null 처리 | `lastSyncAt === null` 분기 명시. plan022 helper 가 `Date | string` 양쪽 수용하므로 null 만 추가 가드 |

--- a/tasks/plan023-about-redesign/phase-02.md
+++ b/tasks/plan023-about-redesign/phase-02.md
@@ -1,34 +1,73 @@
-# Phase 02 — 검증 + docs 생성 + 마킹
+# Phase 02 — 자동 검증 + docs 생성 + 마킹
 
 **Model**: haiku
-**Goal**: phase 1 결과 통합 검증 + `docs/pages/about.md` 신규 + index.json 마킹.
+**Goal**: phase-01 결과의 자동 게이트 검증 + `docs/pages/about.md` 신규 + index.json 마킹.
 
 ## 작업 항목
 
-### 1. 검증
+### 1. 자동 게이트 (필수 — 모두 통과해야 phase 종료)
 
 ```bash
+# cwd: <worktree root>
 pnpm lint
 pnpm type-check
 pnpm test --run
 pnpm build
+
+# 신규 파일 존재
+test -f src/app/about/about.css
+test -f src/components/about/ProfileCard.tsx
+test -f src/components/about/SiteStats.tsx
+test -f src/components/about/StackGrid.tsx
+test -f src/components/about/LinksGrid.tsx
+test -f src/services/StatsService.ts
+test -f src/services/StatsService.test.ts
+
+# 하드코딩 색 0줄 (about 영역)
+! grep -nE "bg-white|bg-gray-|bg-blue-|text-gray-|text-blue-|text-white|border-gray-|focus:ring-blue|#[0-9a-fA-F]{3,6}\b" src/app/about/page.tsx src/components/about/*.tsx
+# about.css 는 plan009 var + oklch 만 (raw hex 0건)
+! grep -nE "#[0-9a-fA-F]{3,6}\b" src/app/about/about.css
+
+# Service factory 등록
+grep -n "createStatsService" src/services/index.ts
+
+# lucide 아이콘 사용 (mockup 인라인 SVG 가 아닌)
+grep -n 'from "lucide-react"' src/components/about/LinksGrid.tsx
+
+# RSS / Newsletter / X 링크 부재 (실 데이터만)
+! grep -nE "rss\.xml|newsletter|twitter" src/components/about/LinksGrid.tsx
+
+# Vercel / MDX / Redis 부재 (mockup placeholder 제거)
+! grep -nE "Vercel|\bMDX\b|Redis" src/components/about/StackGrid.tsx
+
+# GitHub fetch 인증 헤더 추가 확인
+grep -n "Authorization.*GITHUB_TOKEN" src/app/about/page.tsx
 ```
 
 ### 2. `docs/pages/about.md` 신규
 
 3~5줄 짧게 — 컴포넌트 분리 + 데이터 소스만:
-- 컴포넌트: `ProfileCard` (GitHub API), `SiteStats` (DB), `StackGrid` (정적)
-- container: 1180px max-width
-- plan009 토큰 + plan016 sub-hero 패턴
-- revalidate=3600 (시간당 GitHub fetch)
+- 컴포넌트: `ProfileCard` (GitHub API, 인증 헤더 + revalidate=3600), `SiteStats` (StatsService), `StackGrid` / `LinksGrid` (정적)
+- container 1180px max-width, plan009 토큰 + numbered 섹션 헤더
+- CSS: co-located `src/app/about/about.css` (Tailwind arbitrary 만으로 어색한 ::after hairline / @keyframes / oklch dynamic chip color 처리)
+- 데이터: `categoryCount = COUNT(DISTINCT posts.category WHERE isActive)`, `lastSyncAt = MAX(posts.updatedAt)`
 
 ### 3. index.json status 마킹
 
 `tasks/plan023-about-redesign/index.json` 의 phase 1/2 + 최상위 `status` = `"completed"`.
 
-### 4. verification
+### 4. 마킹 검증
 
 ```bash
 test -f docs/pages/about.md
-grep -n "\"completed\"" tasks/plan023-about-redesign/index.json | wc -l  # 3 (top + 2 phases)
+[ "$(jq -r '.status' tasks/plan023-about-redesign/index.json)" = "completed" ]
+[ "$(jq -r '[.phases[] | select(.status=="completed")] | length' tasks/plan023-about-redesign/index.json)" = "2" ]
 ```
+
+## 수동 smoke (참고 — 자동 게이트 통과 후 사용자가 별도 확인)
+
+- `pnpm dev` → `/about` 진입 → 다크/라이트 모드 양쪽에서 mockup 과 1:1 비교
+- pulse 애니메이션 (LAST SYNC 카드) 동작
+- chip hover transition (`translateY(-1px)` + border-color 변화)
+- LinksGrid hover 시 brand-400 으로 color shift + dot 발광
+- GitHub avatar 정상 로드 (이니셜이 사진 뒤에 가려져 있으면 OK)


### PR DESCRIPTION
## Summary

- `/about` 페이지를 Claude Design mockup 시각 사양으로 전면 리디자인
- ProfileCard (2-stage avatar) + SiteStats (DB stats + pulse) + StackGrid + LinksGrid 4개 컴포넌트로 분리
- 신규 `StatsService` + `PostRepository` 의 distinct category / lastUpdatedAt 메서드 (isActive 필터)
- `fetchGitHubProfile` 에 인증 헤더 (Authorization: Bearer GITHUB_TOKEN) 추가 — anon 60/h → 5000/h
- co-located `src/app/about/about.css` (ADR-022)
- ADR-022 신규 — co-located CSS + 2-stage avatar 결정 근거

## Design Reference

- mockup: `tasks/plan023-about-redesign/design-about.{css,jsx}` (Claude Design 핸드오프 번들)
- plan009 토큰 (`--color-*`) 일관 사용, 하드코딩 색 0줄
- numbered 섹션 헤더 (01~04), oklch dynamic chip dot, `@keyframes ab-pulse`

## Pipeline

build-with-teams 통과:
- critic v2 APPROVE (REVISE 6건 반영 후)
- code-reviewer PASS (LOW 2건 cleanup 적용)
- docs-verifier PASS (ADR-022 + about.md 보완 후)

## Test plan

- [x] `pnpm lint` (worktree)
- [x] `pnpm type-check` (worktree)
- [x] `pnpm exec vitest run` — 24 files, 232 tests pass
- [x] `pnpm build` (DB 온라인 상태에서 통과 — 다른 ISR 페이지와 동일)
- [ ] 수동: `/about` 다크/라이트 양쪽에서 mockup 1:1 비교
- [ ] 수동: pulse 애니메이션 (LAST SYNC) 동작
- [ ] 수동: chip hover (translateY + brand-400 transition)
- [ ] 수동: GitHub avatar 정상 로드 + 실패 시 이니셜 표시

## Build

- 통합 검증 모두 plan 범위 내에서 통과. main 잔존 깨짐 의존 없음.
- `eslint.config.mjs` 의 `tasks/**` / `.claude/**` ignores 추가 — design reference asset (`design-about.jsx` 의 `window` 사용) 이 lint 대상에 포함되어 발생한 본래 잘못된 설정 정정. scope 외 변경이지만 빌드 게이트 통과 위해 본 PR 에 동봉.

## Files

신규: `src/components/about/{ProfileCard,SiteStats,StackGrid,LinksGrid}.tsx`, `src/services/StatsService.ts(.test.ts)`, `src/app/about/about.css`, `docs/pages/about.md`

수정: `src/app/about/page.tsx`, `src/services/index.ts`, `src/infra/db/repositories/PostRepository.ts`, `eslint.config.mjs`, `docs/adr.md`, `tasks/plan023-about-redesign/index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)