### PR TITLE
chore(task): plan028 rate limit policy (#113 #82)

### DIFF
--- a/tasks/plan028-rate-limit-policy/index.json
+++ b/tasks/plan028-rate-limit-policy/index.json
@@ -1,0 +1,27 @@
+{
+  "name": "plan028-rate-limit-policy",
+  "description": "Rate limit 정책 정리 (issues #113 + #82) — proxy.ts matcher 가 /api/ 전체를 제외하던 버그 수정. /api/sync 만 인증 Bearer 로 보호되므로 제외, 나머지 (/api/comments, /api/visit, /api/search, /api/og) 는 기존 1000/min/IP 한도 적용. /api/comments POST 의 댓글 스팸 차단 + DDoS 일반 보호.",
+  "status": "pending",
+  "created_at": "2026-05-07",
+  "total_phases": 2,
+  "related_docs": [
+    "docs/adr.md"
+  ],
+  "depends_on": [],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "proxy.ts matcher 변경 + 회귀 테스트 (rate limit 정책 적용)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "검증 + ADR-016 갱신 + index.json 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan028-rate-limit-policy/phase-01.md
+++ b/tasks/plan028-rate-limit-policy/phase-01.md
@@ -1,0 +1,151 @@
+# Phase 01 — proxy.ts matcher 변경 + 회귀 테스트
+
+**Model**: sonnet
+**Goal**: `/api/` 전체가 rate limit 에서 제외되던 버그 수정. `/api/sync` 만 제외, 나머지는 기존 1000/min/IP 한도 적용.
+
+## Context (자기완결)
+
+`src/proxy.ts` 의 `config.matcher` 패턴:
+
+```ts
+matcher: [
+  "/",
+  "/posts/:path*",
+  "/((?!_next/static|_next/image|_next/data|api/|favicon|logo|og-default|fonts/|sitemap\\.xml|robots\\.txt|ads\\.txt|manifest\\.json|.*\\.(?:png|jpg|jpeg|svg|ico|webp|gif|css|js|map)$).*)",
+],
+```
+
+세 번째 패턴이 negative lookahead 로 `api/` 를 제외 → proxy.ts 의 `rateLimit(request)` 호출이 모든 `/api/*` 에 도달하지 못함. 결과:
+- `POST /api/comments` 댓글 스팸 차단 안 됨 (issue #113)
+- `/api/search` FULLTEXT 쿼리 보호 안 됨
+- `/api/visit` insert 스팸 보호 안 됨
+- `/api/og` satori CPU 사용 보호 안 됨
+
+`/api/sync` 는 `SYNC_API_KEY` Bearer token 으로 이미 인증됨 → 제외 유지.
+
+## 결정 (사용자 2026-05-07)
+
+**Option B 채택** — matcher 에서 `api/` 전체 제외 → `api/sync` 만 제외. rateLimit() 시그니처는 변경 없음 (path 별 분기 없이 단일 1000/min/IP 한도 유지).
+
+## 작업 항목
+
+### 1. `src/proxy.ts` matcher 패턴 수정
+
+기존 negative lookahead 의 `api/` 토큰을 `api/sync` 로 정확히 교체:
+
+```ts
+matcher: [
+  "/",
+  "/posts/:path*",
+  "/((?!_next/static|_next/image|_next/data|api/sync|favicon|logo|og-default|fonts/|sitemap\\.xml|robots\\.txt|ads\\.txt|manifest\\.json|.*\\.(?:png|jpg|jpeg|svg|ico|webp|gif|css|js|map)$).*)",
+],
+```
+
+**핵심 변경**: `api/` → `api/sync`.
+
+다른 negative lookahead 항목은 그대로. 첫 두 라인 (`"/"`, `"/posts/:path*"`) 도 그대로.
+
+### 2. `src/middleware/rateLimit.ts` 변경 없음
+
+기존 동작 유지:
+- 1000/min/IP fixed window
+- localhost / RFC1918 IP 우회 (관리자 / 내부망)
+- 봇 UA (Googlebot/Bingbot/NaverBot/Yeti) 우회
+- IP 기반 bucket Map (최대 10000 bucket)
+
+이번 phase 의 본질은 matcher 1줄 변경 — rateLimit.ts 는 손대지 않는다.
+
+### 3. 회귀 테스트 신규 — `src/proxy.test.ts`
+
+이미 있으면 케이스 추가, 없으면 신규 생성:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { proxy } from "./proxy";
+import { NextRequest } from "next/server";
+
+// rateLimit 의 부수효과 (Map state) 격리 위해 매 케이스마다 모듈 재import 또는 mock
+vi.mock("@/middleware/rateLimit", () => ({
+  rateLimit: vi.fn(() => null),
+}));
+vi.mock("@/middleware/visit", () => ({
+  trackVisit: vi.fn(),
+}));
+
+import { rateLimit } from "@/middleware/rateLimit";
+
+describe("proxy matcher coverage", () => {
+  beforeEach(() => {
+    vi.mocked(rateLimit).mockClear();
+  });
+
+  it("호출됨 — POST /api/comments (rate limit 적용 대상)", () => {
+    // matcher 는 next.js 가 평가 — 단위 테스트는 proxy() 가 호출됐을 때 rateLimit 가 호출되는지 만 검증
+    const req = new NextRequest("https://blog.fosworld.co.kr/api/comments", { method: "POST" });
+    proxy(req, {} as never);
+    expect(rateLimit).toHaveBeenCalled();
+  });
+
+  it("호출됨 — /api/search", () => { /* 동일 패턴 */ });
+  it("호출됨 — /api/visit", () => { /* 동일 패턴 */ });
+  it("호출됨 — /api/og/posts/foo", () => { /* 동일 패턴 */ });
+
+  // matcher pattern 자체 검증 — config.matcher 에 api/sync 포함, api/ 미포함
+  it("config.matcher 가 api/sync 만 제외, api/ 전체 제외 아님", () => {
+    const { config } = require("./proxy");
+    const pattern = String(config.matcher.find((m: string) => m.includes("(?!")) ?? "");
+    expect(pattern).toContain("api/sync");
+    expect(pattern).not.toMatch(/[|(]api\/[|)]/); // "api/" 단독 토큰 부재
+  });
+});
+```
+
+**중요**: `config.matcher` 는 Next.js routing 레이어 평가 — **단위 테스트로 매칭 자체를 검증할 수 없다**. 위 마지막 테스트는 패턴 문자열 정합성만 확인. matcher 실제 동작은 e2e/manual smoke 로 검증.
+
+수동 smoke (사용자 안내):
+```bash
+# rate limit 동작 확인 — 1001 회 요청 시 429
+for i in $(seq 1 1001); do
+  curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:3000/api/comments \
+    -H "Content-Type: application/json" \
+    -d '{"postSlug":"x","nickname":"y","password":"1234","content":"z"}' &
+done | sort | uniq -c
+# 기대: 1000 × 200 + 1 × 429 (또는 validation 에러 동일 수치)
+# 단 localhost IP 면 우회되므로 외부 IP 시뮬레이션 필요 — X-Forwarded-For 헤더 추가
+```
+
+### 4. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+
+grep -n "api/sync" src/proxy.ts        # 1줄
+! grep -nE 'api/[|)]' src/proxy.ts     # api/ 단독 토큰 부재
+test -f src/proxy.test.ts || grep -n "api/sync" src/proxy.test.ts
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/proxy.ts` | 수정 (matcher 1 토큰) |
+| `src/proxy.test.ts` | 신규 또는 케이스 추가 |
+
+## Out of Scope
+
+- rateLimit.ts 의 path-aware 분기 (option B 결정으로 OOS)
+- `/api/search` 별도 엄격 한도 (OOS — 후속 plan 후보)
+- nginx / Cloudflare 단 글로벌 한도 (Option D — 인프라 영역)
+- Comments API 스팸 패턴 별도 분석 (예: 같은 IP 의 burst 검출)
+
+## Risks & Mitigations
+
+| 리스크 | 완화 |
+|---|---|
+| matcher 변경으로 정상 페이지 navigation 도 rate limit 에 영향 | 기존 동작 — 페이지 (/, /posts/*) 는 이미 rate limit 적용 중. 이번 변경은 `/api/*` 에 추가 적용일 뿐 |
+| `/api/visit` 가 매 페이지 호출 → 1000/min 빠르게 소진 | 일반 사용자가 1분에 1000 페이지 접근은 비현실 — 한도 적정. RFC1918 / 봇 UA 우회 로직 그대로 작동 |
+| 테스트 모킹이 실제 matcher 동작 미검증 | 한계 명시 — 매뉴얼 smoke 로 보완. e2e 테스트는 별도 plan |
+| 사이트 운영자 (jon890) 본인이 댓글 작성 시 한도 차단 | RFC1918 / localhost 우회 가능 — 외부 접근 시는 1000/min 한도 안에 들어감. 일반 사용 영향 없음 |

--- a/tasks/plan028-rate-limit-policy/phase-01.md
+++ b/tasks/plan028-rate-limit-policy/phase-01.md
@@ -149,3 +149,4 @@ test -f src/proxy.test.ts || grep -n "api/sync" src/proxy.test.ts
 | `/api/visit` 가 매 페이지 호출 → 1000/min 빠르게 소진 | 일반 사용자가 1분에 1000 페이지 접근은 비현실 — 한도 적정. RFC1918 / 봇 UA 우회 로직 그대로 작동 |
 | 테스트 모킹이 실제 matcher 동작 미검증 | 한계 명시 — 매뉴얼 smoke 로 보완. e2e 테스트는 별도 plan |
 | 사이트 운영자 (jon890) 본인이 댓글 작성 시 한도 차단 | RFC1918 / localhost 우회 가능 — 외부 접근 시는 1000/min 한도 안에 들어감. 일반 사용 영향 없음 |
+| **X-Forwarded-For 헤더 무조건 신뢰 시 rate limit 우회** (보안 specialist 지적) | 홈서버 환경은 nginx → Next.js 단일 reverse proxy. `rateLimit.ts` 의 IP 추출은 신뢰 가능한 직속 프록시(127.0.0.1) 가 설정한 헤더만 사용. 외부에서 직접 들어오는 요청의 X-Forwarded-For 는 무시하고 `request.headers.get('x-real-ip')` 또는 socket address 우선. 위 수동 smoke 의 X-Forwarded-For 헤더는 **로컬 테스트 시뮬레이션 한정** — 프로덕션에서는 신뢰 프록시 외 헤더는 무시되어야 함. phase 1 실행 시 `rateLimit.ts` 에 해당 검증 로직 또는 주석 보강 |

--- a/tasks/plan028-rate-limit-policy/phase-02.md
+++ b/tasks/plan028-rate-limit-policy/phase-02.md
@@ -1,0 +1,38 @@
+# Phase 02 — 검증 + ADR-016 갱신 + 마킹
+
+**Model**: haiku
+**Goal**: phase 1 결과 통합 검증 + ADR-016 (Rate limit 정책) 갱신 + index.json 마킹.
+
+## 작업 항목
+
+### 1. 검증
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+```
+
+오류 0건. 있으면 phase 1 로 돌려 수정.
+
+### 2. `docs/adr.md` ADR-016 갱신
+
+기존 ADR-016 (Rate limit 정책) 본문 끝에 한 단락 추가 — `/api/sync` 만 제외, 나머지는 일반 한도 적용 결정. 트레이드오프 (option C/D 기각 사유) 1~2줄.
+
+새 ADR 번호 부여 X — 기존 ADR-016 의 후속 결정이라 본문 갱신.
+
+### 3. issue close 코멘트
+
+PR merge 후 자동 close 되도록 PR body 에 `Closes #113` `Closes #82` 작성. 또는 이미 plan028 PR 에 명시되어 있으면 별도 작업 없음.
+
+### 4. index.json status 마킹
+
+`tasks/plan028-rate-limit-policy/index.json` 의 phase 1/2 + 최상위 `status` = `"completed"`.
+
+### 5. verification
+
+```bash
+grep -n "api/sync" docs/adr.md         # ADR-016 갱신 확인
+grep -n "\"completed\"" tasks/plan028-rate-limit-policy/index.json | wc -l  # 3
+```

--- a/tasks/plan028-rate-limit-policy/phase-02.md
+++ b/tasks/plan028-rate-limit-policy/phase-02.md
@@ -20,6 +20,8 @@ pnpm build
 
 기존 ADR-016 (Rate limit 정책) 본문 끝에 한 단락 추가 — `/api/sync` 만 제외, 나머지는 일반 한도 적용 결정. 트레이드오프 (option C/D 기각 사유) 1~2줄.
 
+**처리 순서 명기** (보안 specialist 지적): ADR-016 갱신 시 각 `/api/*` 엔드포인트에서의 처리 레이어 순서를 한 줄 명시 — `proxy(matcher) → rateLimit (proxy.ts 안에서) → 라우트 handler 의 입력 검증(Zod) → 비즈니스 로직`. 이 순서를 명문화하면 후속 작업자가 XSS/injection 입력 차단 책임이 어느 레이어인지 (입력 검증 = 라우트 handler) 혼동 없음.
+
 새 ADR 번호 부여 X — 기존 ADR-016 의 후속 결정이라 본문 갱신.
 
 ### 3. issue close 코멘트


### PR DESCRIPTION
Rate limit 정책 정리 — proxy.ts matcher 가 /api/ 전체 제외하던 버그 수정.

## Summary
- /api/sync 만 제외 + 나머지 (/api/comments, /api/visit, /api/search, /api/og) 모두 1000/min/IP 적용
- POST /api/comments 댓글 스팸 차단
- 2 phases (sonnet + haiku)

## Issues
- Closes #113 (보안 버그)
- Closes #82 (정책 검토)

🤖 Generated with [Claude Code](https://claude.com/claude-code)