### PR TITLE
feat(motion): plan025 motion tokens + motion-reduce variants

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -629,6 +629,22 @@ html:not(.dark) .prose .code-card-body pre span {
   color: var(--cat-color);
 }
 
+/* === Link underline draw (plan025) ===
+   적용은 별도 plan — 본 정의만 노출. prose 외 nav/card link 후보. */
+.link-draw {
+  text-decoration-line: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color var(--duration-fast) var(--ease-out);
+}
+.link-draw:hover {
+  text-decoration-color: currentColor;
+}
+@media (prefers-reduced-motion: reduce) {
+  .link-draw { transition: none; }
+}
+
 /* === Footer accent line === */
 .fbf-accent {
   background: linear-gradient(

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -21,7 +21,7 @@ export function CategoryCard({ category }: CategoryCardProps) {
           borderLeftColor: catColor,
         } as CSSProperties
       }
-      className="cat-card group relative flex flex-col gap-2 overflow-hidden rounded-lg border border-[var(--color-border-subtle)] border-l-2 bg-[var(--color-bg-elevated)] p-[22px] pb-5 transition-[transform,border-color] duration-200 ease-out hover:-translate-y-0.5 hover:border-[var(--cat-color)]"
+      className="cat-card group relative flex flex-col gap-2 overflow-hidden rounded-lg border border-[var(--color-border-subtle)] border-l-2 bg-[var(--color-bg-elevated)] p-[22px] pb-5 transition-[transform,border-color] duration-[var(--duration-default)] ease-[var(--ease-out)] hover:-translate-y-0.5 hover:border-[var(--cat-color)] motion-reduce:transform-none motion-reduce:transition-none"
     >
       <div className="flex items-center justify-between gap-3">
         <span

--- a/src/components/CategoryFeatured.tsx
+++ b/src/components/CategoryFeatured.tsx
@@ -25,7 +25,7 @@ export function CategoryFeatured({ category, rank, latestUpdatedAt }: CategoryFe
     <Link
       href={`/category/${encodeURIComponent(category.slug)}`}
       style={inlineStyle}
-      className="group relative flex flex-col min-h-[220px] rounded-lg border border-[var(--color-border-subtle)] border-l-2 p-7 pb-6 transition-[transform,border-color] duration-200 ease-out hover:-translate-y-0.5 hover:border-[var(--cat-color)]"
+      className="group relative flex flex-col min-h-[220px] rounded-lg border border-[var(--color-border-subtle)] border-l-2 p-7 pb-6 transition-[transform,border-color] duration-[var(--duration-default)] ease-[var(--ease-out)] hover:-translate-y-0.5 hover:border-[var(--cat-color)] motion-reduce:transform-none motion-reduce:transition-none"
     >
       <span
         className="absolute top-3.5 right-4 font-mono text-[10px] tracking-[0.1em] text-[var(--color-fg-faint)]"

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -39,7 +39,7 @@ export function PostCard({
       <Link
         href={postHref(post.slug)}
         style={inlineStyle}
-        className="group flex flex-col overflow-hidden rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] transition-[border-color,transform] duration-200 ease-out hover:-translate-y-0.5 hover:border-[var(--color-border-strong)]"
+        className="group flex flex-col overflow-hidden rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] transition-[border-color,transform] duration-[var(--duration-default)] ease-[var(--ease-out)] hover:-translate-y-0.5 hover:border-[var(--color-border-strong)] motion-reduce:transform-none motion-reduce:transition-none"
       >
         <div className="flex flex-1 flex-col gap-2 p-5">
           {showCategory && (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px motion-reduce:transition-none motion-reduce:active:translate-y-0 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/tasks/plan025-motion-microinteractions/index.json
+++ b/tasks/plan025-motion-microinteractions/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan025-motion-microinteractions",
   "description": "CSS only 마이크로 인터랙션 — PostCard/CategoryCard hover lift + link underline draw + button focus 폴리시. plan009 의 --duration-* / --ease-* 토큰 활용. prefers-reduced-motion 존중. 라이브러리 추가 없음.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-06",
   "total_phases": 1,
   "related_docs": [],
@@ -14,7 +14,7 @@
       "file": "phase-01.md",
       "title": "Card hover lift + link underline draw + button focus + reduced-motion 가드",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan025-motion-microinteractions/phase-01.md
+++ b/tasks/plan025-motion-microinteractions/phase-01.md
@@ -3,6 +3,13 @@
 **Model**: sonnet
 **Goal**: 카드/링크/버튼의 미세한 motion polish. 라이브러리 추가 없이 Tailwind arbitrary values + plan009 motion 토큰만 사용.
 
+> **실행 결과 (보수 노선 — 사용자 결정)**:
+> - ✅ 카드 3종 (PostCard / CategoryCard / CategoryFeatured) 의 `duration-200 ease-out` → 토큰 (`var(--duration-default)` / `var(--ease-out)`) + `motion-reduce:transform-none motion-reduce:transition-none` variant 추가
+> - ✅ button.tsx 에 `motion-reduce:transition-none motion-reduce:active:translate-y-0` 추가 (기존 `active:translate-y-px` 유지)
+> - ✅ globals.css 에 `.link-draw` utility 정의 + `prefers-reduced-motion` 가드
+> - ⏸ **보류 (회귀 위험)**: card `hover:shadow-[var(--shadow-popover)]` (border-color hover 일관성 유지), button `active:scale-[0.98]` (기존 translate-y 와 충돌), `.link-draw` 실제 적용 위치 (Header/ProfileCard 등 — 별도 plan 으로)
+> - ⏸ **보류**: universal `prefers-reduced-motion` reset (`*,*::before,*::after { animation-duration: 0.01ms ... }`) — 기존 hero-mesh/hero-caret 개별 가드로 충분, universal reset 은 의도된 motion(스피너 등)도 차단할 위험
+
 ## Context (자기완결)
 
 `src/app/globals.css` 에 plan009 motion 토큰 정의됨:


### PR DESCRIPTION
## Summary

plan025 (motion micro-interactions) 결과물 반영. PR #111 에서 task 파일만 단독 머지되어 status='pending' 잔존 + 결과물 부분만 적용된 상태였음. 본 PR로 마무리.

## Changes

- **PostCard / CategoryCard / CategoryFeatured**: 카드 hover lift transition 의 하드코딩 `duration-200 ease-out` 을 plan009 토큰 (`var(--duration-default)` / `var(--ease-out)`) 로 변경 + `motion-reduce:transform-none motion-reduce:transition-none` variant 추가
- **Button (`ui/button.tsx`)**: 기존 `active:translate-y-px` 유지 + `motion-reduce:transition-none motion-reduce:active:translate-y-0` 가드 추가
- **globals.css**: `.link-draw` utility 정의 (적용 위치는 별도 plan, 정의만 노출). `prefers-reduced-motion` 가드 포함
- **task**: `index.json` status `pending` → `completed` + `phase-01.md` 상단에 실행 결과(보류 항목) 메모

## 보류 항목 (사용자 결정 — 보수 노선)

- card `hover:shadow-[var(--shadow-popover)]`: 기존 border-color hover 일관성 유지
- button `active:scale-[0.98]`: 기존 `translate-y-px` 와 충돌
- `.link-draw` 의 실제 적용 위치 (Header / ProfileCard 등): 별도 plan
- universal `prefers-reduced-motion` reset: 의도된 motion(스피너 등) 차단 위험

## Test plan

- [x] \`pnpm lint\` 통과
- [x] \`pnpm type-check\` 통과
- [x] \`pnpm test --run\` 통과 (24 files / 232 tests)
- [x] \`pnpm build\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)