### PR TITLE
fix(markdown): strip HTML tags from extractDescription

### DIFF
--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -141,6 +141,24 @@ description: 메타 설명
     expect(result.endsWith("...")).toBe(false);
     expect(result).toBe("짧은 내용");
   });
+
+  it("본문의 HTML 태그를 제거한다 (<br> / <details> 등)", () => {
+    const content = "첫 줄<br>두 번째 줄 그리고<details>숨김</details> 끝";
+    const result = extractDescription(content);
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
+    expect(result).toContain("첫 줄");
+    expect(result).toContain("끝");
+  });
+
+  it("frontmatter description 의 HTML 태그도 제거한다", () => {
+    const content = `---
+description: 한 줄<br>다음 줄
+---
+
+본문`;
+    expect(extractDescription(content)).toBe("한 줄 다음 줄");
+  });
 });
 
 // ===== getReadingTime =====

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -82,15 +82,17 @@ export function extractDescription(
   const { frontMatter, content: mainContent } = parseFrontMatter(content);
 
   if (frontMatter.description) {
-    return frontMatter.description as string;
+    return (frontMatter.description as string).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
   }
 
   // Remove markdown syntax and get first paragraph
   const plainText = mainContent
+    .replace(/<[^>]+>/g, " ") // Remove HTML tags (<br>, <details> 등)
     .replace(/^#+\s+.+$/gm, "") // Remove headers
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Replace links with text
     .replace(/[*_`~]/g, "") // Remove formatting
     .replace(/\n+/g, " ") // Replace newlines with spaces
+    .replace(/\s+/g, " ") // Collapse repeated whitespace from tag removal
     .trim();
 
   if (plainText.length > maxLength) {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -2,6 +2,8 @@
 import GithubSlugger from "github-slugger";
 import type { Element as HastElement, ElementContent, Text } from "hast";
 
+const HTML_TAG_RE = /<[^>]+>/g;
+
 export interface FrontMatter {
   title?: string;
   date?: string;
@@ -82,12 +84,12 @@ export function extractDescription(
   const { frontMatter, content: mainContent } = parseFrontMatter(content);
 
   if (frontMatter.description) {
-    return (frontMatter.description as string).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    return frontMatter.description.replace(HTML_TAG_RE, " ").replace(/\s+/g, " ").trim();
   }
 
   // Remove markdown syntax and get first paragraph
   const plainText = mainContent
-    .replace(/<[^>]+>/g, " ") // Remove HTML tags (<br>, <details> 등)
+    .replace(HTML_TAG_RE, " ") // Remove HTML tags (<br>, <details> 등)
     .replace(/^#+\s+.+$/gm, "") // Remove headers
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Replace links with text
     .replace(/[*_`~]/g, "") // Remove formatting


### PR DESCRIPTION
## Summary

글 본문/frontmatter description 에 `<br>`, `<details>` 등 raw HTML 이 있을 때 ArticleHero / OG / SEO meta 에 태그가 이스케이프된 문자열로 노출되던 버그 수정.

## 사례

[ai-semiconductor-infrastructure-cycle-2026-05-07](https://blog.fosworld.co.kr/posts/finance/investing/ai-semiconductor-infrastructure-cycle-2026-05-07.md) 의 hero description 에 `<br>` 가 그대로 보임.

## 변경

`src/lib/markdown.ts` 의 `extractDescription()`:
- frontmatter description 분기에 HTML strip + whitespace 정리 추가
- 본문 추출 분기에 `<[^>]+>` 제거 + 반복 공백 collapse 추가

## Test plan

- [x] markdown.test.ts 신규 테스트 2개 (HTML 태그 제거 / frontmatter HTML 제거)
- [x] pnpm test / lint / type-check 통과
- [ ] 머지 후 해당 글 페이지 hero 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)