### PR TITLE
feat(tags): plan026 tags system (#72)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -436,3 +436,23 @@
 - **2-stage avatar**: GitHub API 일시 장애 / rate limit 시 페이지 그래픽 깨짐 방지. fallback 분기를 ProfileCard 안에 if/else 로 두는 대신 디자인 자체가 두 표시 상태를 항상 처리하도록 설계 — default (이니셜) → enhanced (사진 덮음). mockup 의 gradient + initial 컨테이너는 fallback 이 아니라 base layer 라는 의도.
 
 **Scope 명시**: 이 ADR 의 결정은 about 페이지 한정. 다른 페이지가 동일 패턴 도입 시 본 ADR 의 근거 (`::after` hairline / `@keyframes` / 동적 oklch / API 폴백) 가 모두 해당하는지 재검토.
+
+## ADR-023. 태그 시스템 — `posts.tags JSON` + `JSON_CONTAINS` (plan026)
+
+**Context**: issue #72 — 글 frontmatter 의 `tags` 를 DB 에 저장하고 tag 별 글 목록 페이지를 제공. 모델링 선택지가 둘이라 결정 의도 보존이 필요.
+
+**Decision**:
+
+1. **`posts.tags JSON NOT NULL DEFAULT ('[]')`** — 별도 `tags` / `post_tags` 정규화 테이블 대신 `posts` 의 JSON 컬럼. `folders` 와 같은 패턴 (이미 존재).
+2. **조회**: `JSON_CONTAINS(tags, JSON_QUOTE(?))` — `?` 바인딩으로 SQL injection 안전. 인덱스 미사용 (full table scan).
+3. **`/tag/[name]`** — 5분 ISR, `limit=50`, 존재하지 않는 tag 는 `notFound()`. `/tags` 인덱스 (전체 tag cloud) 는 OOS.
+4. **정규화**: `trim().toLowerCase()` + 빈 문자열 제거 + `Set` dedup. 한글-영문 동의어 매핑 / 대소문자 별 분리는 OOS.
+
+**Why (대안 기각)**:
+
+- **정규화 테이블 (`tags` + `post_tags` join)** 기각: 218 글 × 평균 3-6 tag 규모에서 join 비용 vs JSON_CONTAINS full-scan 비용 차이 무시 가능. 별도 테이블 도입 시 schema 복잡도 + 마이그레이션 비용 큼. 향후 글 수가 1000+ 로 늘고 tag 검색이 성능 병목이 되면 별도 plan 으로 정규화 검토.
+- **`limit=50`**: 한 tag 가 50 글 넘는 경우는 사실상 카테고리 수준 — pagination 보다 카테고리 분리가 자연스러움. pagination 미구현은 의도된 OOS.
+- **`/tags` 인덱스 OOS**: 인덱스 페이지는 navigation 가치가 낮고 SEO 도 카테고리로 충분. 필요 시 별도 plan.
+- **한글-영문 동의어 매핑 OOS**: 글 작성자 (jon890) 가 frontmatter 작성 시 일관성 유지하는 게 더 단순. 매핑 테이블 도입은 복잡도 대비 이익 작음.
+
+**Scope**: 본 ADR 결정은 plan026 한정. 글 수 1000+ / tag 100+ 도달 시 정규화 테이블 + 인덱스 재검토.

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -263,3 +263,16 @@ src/components/
   - BLG1 db:push 금지 — `pnpm db:generate` → 커밋 → `pnpm db:migrate`
   - BLG2 구조화 로그 — §6 준수
   - BLG3 사일런트 실패 금지 — 500 + 에러 body
+
+---
+
+## 태그 시스템 (plan026)
+
+신규 라우트 + Repository 메서드:
+
+- **`GET /tag/[name]`** (`src/app/tag/[name]/page.tsx`) — tag 별 글 목록. ISR 300s. tag URL decode → `getPostsByTag(tag, { limit: 50 })` + `countPostsByTag`. count 0 이면 `notFound()`.
+- **`PostRepository.getPostsByTag(tag, { limit, offset })`** / **`countPostsByTag(tag)`** — `JSON_CONTAINS(posts.tags, JSON_QUOTE(?))` 쿼리. count 는 `sql<string>\`count(*)\`` + `Number()` (BLG6).
+- **`SyncService.normalizeTags(raw)`** — frontmatter 의 `tags` 를 `trim().toLowerCase()` + 빈 문자열 제거 + Set dedup 후 DB 저장.
+- **`ArticleFooter`** — tag chip 을 `<Link href="/tag/{encoded}">` 로 활성화.
+
+설계 의도 (정규화 테이블 회피, 50 limit, lowercase 만 등) 는 ADR-023 참조.

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -15,6 +15,7 @@
 - Unique: `path`
 - 기존 인덱스: `category_idx(category)`, `slug_idx(slug)`
 - `updatedAt timestamp` (defaultNow, onUpdateNow)
+- `tags JSON NOT NULL DEFAULT ('[]')` — frontmatter `tags` 추출 + sync 시 `trim().toLowerCase()` 정규화 (plan026)
 
 ### visit_stats (`src/infra/db/schema/visitStats.ts`)
 

--- a/drizzle/0005_nervous_human_torch.sql
+++ b/drizzle/0005_nervous_human_torch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `posts` ADD `tags` json DEFAULT ('[]') NOT NULL;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,639 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "c8a07af9-212e-4e51-acdc-ac3751010494",
+  "prevId": "a03c3cdc-48e6-4b1b-8870-6d23dc4899b3",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_slug": {
+          "name": "post_slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "post_slug_idx": {
+          "name": "post_slug_idx",
+          "columns": [
+            "post_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comments_id": {
+          "name": "comments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "path_idx": {
+          "name": "path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "folders_path_unique": {
+          "name": "folders_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folders": {
+          "name": "folders",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "category_idx": {
+          "name": "category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "posts_updated_at_id_idx": {
+          "name": "posts_updated_at_id_idx",
+          "columns": [
+            "`updated_at` DESC",
+            "`id` DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_path_unique": {
+          "name": "posts_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posts_added": {
+          "name": "posts_added",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_updated": {
+          "name": "posts_updated",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_deleted": {
+          "name": "posts_deleted",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_logs_id": {
+          "name": "sync_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_logs": {
+      "name": "visit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visited_date": {
+          "name": "visited_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_page_ip_date_idx": {
+          "name": "visit_page_ip_date_idx",
+          "columns": [
+            "page_path",
+            "ip_hash",
+            "visited_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_logs_id": {
+          "name": "visit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_stats": {
+      "name": "visit_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_stats_page_path_idx": {
+          "name": "visit_stats_page_path_idx",
+          "columns": [
+            "page_path"
+          ],
+          "isUnique": true
+        },
+        "visit_stats_count_path_idx": {
+          "name": "visit_stats_count_path_idx",
+          "columns": [
+            "`visit_count` DESC",
+            "`page_path` ASC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_stats_id": {
+          "name": "visit_stats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "posts_updated_at_id_idx": {
+        "columns": {
+          "`updated_at` DESC": {
+            "isExpression": true
+          },
+          "`id` DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "visit_stats_count_path_idx": {
+        "columns": {
+          "`visit_count` DESC": {
+            "isExpression": true
+          },
+          "`page_path` ASC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777094090262,
       "tag": "0004_cleanup_stale_visits",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1778133904665,
+      "tag": "0005_nervous_human_torch",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/tag/[name]/page.tsx
+++ b/src/app/tag/[name]/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { env } from "@/env";
+import { getRepositories } from "@/infra/db/repositories";
+import { PostsListSubHero } from "@/components/PostsListSubHero";
+import { PostCard } from "@/components/PostCard";
+
+const siteUrl = env.NEXT_PUBLIC_SITE_URL;
+
+export const revalidate = 300;
+
+interface Props {
+  params: Promise<{ name: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { name } = await params;
+  const tag = decodeURIComponent(name);
+  return {
+    title: `#${tag}`,
+    description: `${tag} 태그가 달린 글 모음`,
+    alternates: { canonical: `${siteUrl}/tag/${encodeURIComponent(tag)}` },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function TagPage({ params }: Props) {
+  const { name } = await params;
+  const tag = decodeURIComponent(name);
+  const { post } = getRepositories();
+  const [posts, total] = await Promise.all([
+    post.getPostsByTag(tag, { limit: 50 }),
+    post.countPostsByTag(tag),
+  ]);
+
+  if (total === 0) notFound();
+
+  return (
+    <div className="container mx-auto max-w-[1180px] px-4">
+      <PostsListSubHero
+        eyebrow="TAG"
+        title={`#${tag}`}
+        meta={`${total} POSTS`}
+      />
+      <ul className="grid grid-cols-1 gap-6 pb-16 md:grid-cols-2">
+        {posts.map((p) => (
+          <li key={p.path}>
+            <PostCard post={p} variant="grid" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ArticleFooter.tsx
+++ b/src/components/ArticleFooter.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 interface ArticleFooterProps {
   tags?: string[];
 }
@@ -12,12 +14,13 @@ export function ArticleFooter({ tags }: ArticleFooterProps) {
       </div>
       <div className="flex flex-wrap gap-2">
         {tags.map((tag) => (
-          <span
+          <Link
             key={tag}
-            className="rounded border border-[var(--color-border-subtle)] px-2.5 py-1 font-mono text-[11px] tracking-tight text-[var(--color-fg-secondary)]"
+            href={`/tag/${encodeURIComponent(tag)}`}
+            className="rounded border border-[var(--color-border-subtle)] px-2.5 py-1 font-mono text-[11px] tracking-tight text-[var(--color-fg-secondary)] transition-colors hover:border-[var(--color-brand-400)] hover:text-[var(--color-brand-400)]"
           >
             #{tag}
-          </span>
+          </Link>
         ))}
       </div>
     </footer>

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -279,6 +279,50 @@ export class PostRepository extends BaseRepository {
     return result[0].affectedRows;
   }
 
+  async getPostsByTag(
+    tag: string,
+    { limit = 50, offset = 0 }: { limit?: number; offset?: number } = {},
+  ): Promise<PostData[]> {
+    const normalized = tag.trim().toLowerCase();
+    const result = await this.db
+      .select({
+        title: posts.title,
+        path: posts.path,
+        slug: posts.slug,
+        category: posts.category,
+        subcategory: posts.subcategory,
+        folders: posts.folders,
+        description: posts.description,
+        createdAt: posts.createdAt,
+        updatedAt: posts.updatedAt,
+      })
+      .from(posts)
+      .where(
+        and(
+          eq(posts.isActive, true),
+          sql`JSON_CONTAINS(${posts.tags}, JSON_QUOTE(${normalized}))`,
+        ),
+      )
+      .orderBy(desc(posts.createdAt))
+      .limit(limit)
+      .offset(offset);
+    return result.map((p) => ({ ...p, folders: p.folders || [] }));
+  }
+
+  async countPostsByTag(tag: string): Promise<number> {
+    const normalized = tag.trim().toLowerCase();
+    const [{ count }] = await this.db
+      .select({ count: sql<string>`count(*)` })
+      .from(posts)
+      .where(
+        and(
+          eq(posts.isActive, true),
+          sql`JSON_CONTAINS(${posts.tags}, JSON_QUOTE(${normalized}))`,
+        ),
+      );
+    return Number(count);
+  }
+
   async create(newPost: NewPost) {
     await this.db.insert(posts).values(newPost);
   }

--- a/src/infra/db/schema/posts.ts
+++ b/src/infra/db/schema/posts.ts
@@ -21,6 +21,7 @@ export const posts = mysqlTable(
     category: varchar("category", { length: 255 }).notNull(),
     subcategory: varchar("subcategory", { length: 255 }),
     folders: json("folders").$type<string[]>().default([]), // n-depth 폴더 경로 배열
+    tags: json("tags").$type<string[]>().notNull().default([]),
     content: text("content"),
     description: text("description"),
     sha: varchar("sha", { length: 64 }), // GitHub file SHA for change detection

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -1,6 +1,15 @@
 import { PostRepository } from "@/infra/db/repositories/PostRepository";
 import { SyncLogRepository } from "@/infra/db/repositories/SyncLogRepository";
-import { extractDescription, extractTitle } from "@/lib/markdown";
+import { extractDescription, extractTitle, parseFrontMatter } from "@/lib/markdown";
+
+function normalizeTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const cleaned = raw
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => t.trim().toLowerCase())
+    .filter((t) => t.length > 0);
+  return Array.from(new Set(cleaned));
+}
 import {
   type ChangedFile,
   type getChangedFilesSince,
@@ -155,6 +164,8 @@ export class SyncService {
       const content = rewriteImagePaths(fileData.content, file.path);
       const title = extractTitle(content) || filenameTitle;
       const description = extractDescription(content, 200);
+      const { frontMatter } = parseFrontMatter(content);
+      const tags = normalizeTags(frontMatter.tags);
 
       if (existing) {
         await this.postRepo.update(existing.id, {
@@ -165,6 +176,7 @@ export class SyncService {
           category: file.category,
           subcategory: file.subcategory,
           folders: file.folders,
+          tags,
           isActive: true,
           updatedAt: commitDates?.updatedAt ?? new Date(),
         });
@@ -178,6 +190,7 @@ export class SyncService {
           category: file.category,
           subcategory: file.subcategory,
           folders: file.folders,
+          tags,
           content,
           description,
           sha: fileData.sha,

--- a/tasks/plan026-tags-system/index.json
+++ b/tasks/plan026-tags-system/index.json
@@ -1,0 +1,35 @@
+{
+  "name": "plan026-tags-system",
+  "description": "태그 시스템 (issue #72) — posts.tags JSON 컬럼 추가 + sync 시 frontmatter tags DB 저장 + PostRepository.getPostsByTag + /tag/[name] 상세 페이지 + ArticleFooter tag link 활성화. /tags 인덱스는 OOS.",
+  "status": "pending",
+  "created_at": "2026-05-07",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/data-schema.md",
+    "docs/code-architecture.md"
+  ],
+  "depends_on": [],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "posts.tags JSON 컬럼 + drizzle migration + SyncService 확장",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "PostRepository.getPostsByTag + /tag/[name] 페이지 + ArticleFooter tag link",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "검증 + data-schema.md 갱신 + index.json 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan026-tags-system/index.json
+++ b/tasks/plan026-tags-system/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan026-tags-system",
   "description": "태그 시스템 (issue #72) — posts.tags JSON 컬럼 추가 + sync 시 frontmatter tags DB 저장 + PostRepository.getPostsByTag + /tag/[name] 상세 페이지 + ArticleFooter tag link 활성화. /tags 인덱스는 OOS.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-07",
   "total_phases": 3,
   "related_docs": [
@@ -15,21 +15,21 @@
       "file": "phase-01.md",
       "title": "posts.tags JSON 컬럼 + drizzle migration + SyncService 확장",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "PostRepository.getPostsByTag + /tag/[name] 페이지 + ArticleFooter tag link",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "검증 + data-schema.md 갱신 + index.json 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan026-tags-system/phase-01.md
+++ b/tasks/plan026-tags-system/phase-01.md
@@ -1,0 +1,116 @@
+# Phase 01 — posts.tags JSON 컬럼 + sync 확장
+
+**Model**: sonnet
+**Goal**: posts 테이블에 tags JSON[] 컬럼 추가 + sync 시 frontmatter `tags` 추출해 DB 저장.
+
+## Context (자기완결)
+
+`src/infra/db/schema/posts.ts` 의 `posts` 테이블에 현재 `tags` 컬럼 없음. ArticleFooter 는 frontmatter 에서 runtime 추출 — DB 미저장 상태라 tag 별 글 목록 조회 불가.
+
+기존 `folders` 컬럼이 같은 패턴 (`json("folders").$type<string[]>().default([])`) 으로 이미 사용 중 — JSON column 도입은 새 패턴 아님.
+
+**플젝 컨벤션 (CLAUDE.md)**:
+- DB schema 변경: `pnpm db:generate` 로 SQL 생성 → git 커밋 → `pnpm db:migrate` (apply)
+- `pnpm db:push` 는 production 금지 — 마이그레이션 이력 누락 위험
+- drizzle/ 디렉터리는 git 추적 (이미 `0001_*.sql ~ 0004_*.sql` 커밋됨)
+
+## 작업 항목
+
+### 1. `src/infra/db/schema/posts.ts` 컬럼 추가
+
+기존 `folders` 정의 옆에 `tags`:
+
+```ts
+folders: json("folders").$type<string[]>().default([]),
+tags: json("tags").$type<string[]>().notNull().default([]),
+```
+
+`notNull` 권장 — 빈 배열 default 로 모든 row 가 명시적 값 보유. JSON_CONTAINS 쿼리도 더 안전.
+
+### 2. drizzle migration 생성 + 커밋
+
+```bash
+# cwd: <repo root>
+pnpm db:generate
+# drizzle/0005_*.sql 자동 생성 — ALTER TABLE posts ADD COLUMN tags JSON DEFAULT (...) NOT NULL;
+```
+
+생성된 SQL 파일 검토 (파괴적 변경 없음 — 단순 ADD COLUMN). 기존 row 는 default `[]` 자동 채움.
+
+### 3. `src/services/SyncService.ts` 확장 — tags 추출 + 저장
+
+**현재 동작 추정** (sync 시 frontmatter 파싱):
+- markdown 파일 fetch
+- `parseFrontMatter()` 로 frontmatter 추출
+- title / description / category / subcategory 등 추출 후 DB upsert
+
+**변경**:
+- frontmatter 의 `tags` 도 추출. 타입은 `string[]` (이미 `parseFrontMatter` 가 `[a, b, c]` array literal 파싱 지원 — `src/lib/markdown.ts:45`)
+- normalize: 모든 tag 를 `.trim().toLowerCase()` 처리 → 동일 글에서 중복 제거 (`Array.from(new Set(...))`)
+- DB upsert payload 에 `tags` 추가
+- frontmatter 에 tags 없으면 빈 배열 `[]`
+
+executor 는 SyncService 코드를 먼저 읽고 (`grep -n "frontMatter\|description\|category" src/services/SyncService.ts`) tags 추출 위치를 정확히 파악 후 추가.
+
+### 4. PostRepository upsert 메서드 시그니처 갱신
+
+`src/infra/db/repositories/PostRepository.ts` 의 upsert / insert 메서드가 `NewPost` 타입을 받는다면 schema 변경으로 자동 호환. `Partial<UpdatePost>` 도 동일.
+
+`tags` 가 explicit field 로 들어가야 하는 메서드가 있다면 (예: `createPost(payload)` 안에서 일부 필드만 명시적으로 destructure) tags 추가. grep 으로 영향 위치 확인.
+
+### 5. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+
+# schema
+grep -n "tags:.*json" src/infra/db/schema/posts.ts
+
+# migration
+ls drizzle/ | grep -E "0005_.*\.sql"
+
+# sync 확장
+grep -n "tags" src/services/SyncService.ts
+```
+
+수동 smoke (사용자 안내 — production 영향 작업이라 dev DB 에서만 실행):
+```bash
+# dev DB 에 마이그레이션 적용
+pnpm db:up
+pnpm db:migrate
+
+# 한 글 sync 테스트 → tags JSON 이 제대로 저장됐는지 확인
+pnpm dev  # 별 터미널
+curl -X POST http://localhost:3000/api/sync -H "Authorization: Bearer $SYNC_API_KEY"
+
+# DB 직접 확인
+mysql ... -e "SELECT path, tags FROM posts WHERE JSON_LENGTH(tags) > 0 LIMIT 5;"
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/infra/db/schema/posts.ts` | 수정 (tags 컬럼) |
+| `drizzle/0005_*.sql` | 자동 생성 (커밋 필수) |
+| `src/services/SyncService.ts` | 수정 (tags 추출) |
+| `src/infra/db/repositories/PostRepository.ts` | 수정 (필요 시) |
+
+## Out of Scope
+
+- /tag/[name] 페이지 → phase 2
+- ArticleFooter tag link → phase 2
+- /tags 인덱스 페이지 (전체 tag 클라우드) — 결정으로 OOS
+- tag 정규화 정책 (대소문자 / 한글-영문 동의어 매핑) — 단순 lowercase + trim 만
+
+## Risks & Mitigations
+
+| 리스크 | 완화 |
+|---|---|
+| drizzle generate 결과의 SQL 이 NOT NULL DEFAULT JSON literal 미지원 (MySQL) | MySQL 8.4 는 JSON DEFAULT 지원하지만 expression 형태여야 함. 생성된 SQL 검토 — 깨지면 `default([])` 대신 nullable 후 inline 빈 배열 처리 |
+| 기존 row 218개의 tags 가 default 로만 채워져 빈 배열 | sync 1회 실행으로 frontmatter tags 모두 백필. 사용자가 phase 1 완료 후 sync 호출 |
+| frontmatter 의 tags 가 따옴표 없이 `[a, b]` 로 되어 array 파싱 실패 | `parseFrontMatter` 가 이미 array literal 처리 — 따옴표 제거 + split. 기존 동작 유지 |
+| tags 가 한 글에서 수십 개일 때 storage 부담 | JSON 컬럼이라 길이 가변. 보통 글당 3~6개 — 무시 가능 |

--- a/tasks/plan026-tags-system/phase-02.md
+++ b/tasks/plan026-tags-system/phase-02.md
@@ -1,0 +1,183 @@
+# Phase 02 — getPostsByTag + /tag/[name] 페이지 + ArticleFooter tag link
+
+**Model**: sonnet
+**Goal**: tag 별 글 조회 메서드 + tag 상세 페이지 라우트 + ArticleFooter 의 tag chip 클릭 시 이동.
+
+## Context (자기완결)
+
+phase 1 에서 `posts.tags` JSON 컬럼 + sync 확장 완료. 이번 phase 는 사용자 흐름:
+- 글 상세 페이지 `<ArticleFooter>` 의 `#javascript` 클릭 → `/tag/javascript` 이동
+- `/tag/javascript` 페이지: 해당 tag 가진 모든 글 리스트 (sub-hero + PostCard grid)
+
+## 작업 항목
+
+### 1. `PostRepository.getPostsByTag(tag: string, opts?: { limit, offset })` 신규
+
+`src/infra/db/repositories/PostRepository.ts` 에 추가:
+
+```ts
+async getPostsByTag(
+  tag: string,
+  { limit = 20, offset = 0 }: { limit?: number; offset?: number } = {},
+): Promise<Post[]> {
+  const normalized = tag.trim().toLowerCase();
+  return this.db
+    .select()
+    .from(posts)
+    .where(
+      and(
+        eq(posts.isActive, true),
+        sql`JSON_CONTAINS(${posts.tags}, JSON_QUOTE(${normalized}))`,
+      ),
+    )
+    .orderBy(desc(posts.createdAt))
+    .limit(limit)
+    .offset(offset);
+}
+```
+
+**MySQL JSON_CONTAINS**: 두 번째 인자가 JSON 값이라 `JSON_QUOTE(?)` 로 string → `"value"` 변환. `?` 바인딩으로 SQL injection 안전.
+
+count 메서드도 같은 패턴:
+```ts
+async countPostsByTag(tag: string): Promise<number> {
+  const normalized = tag.trim().toLowerCase();
+  const [{ count }] = await this.db
+    .select({ count: sql<string>`count(*)` })
+    .from(posts)
+    .where(
+      and(
+        eq(posts.isActive, true),
+        sql`JSON_CONTAINS(${posts.tags}, JSON_QUOTE(${normalized}))`,
+      ),
+    );
+  return Number(count);
+}
+```
+
+(MySQL count 은 `sql<string>` 으로 받고 외부에서 `Number()` — common-pitfalls 패턴)
+
+### 2. `src/app/tag/[name]/page.tsx` 신규
+
+```tsx
+import { notFound } from "next/navigation";
+import { getRepositories } from "@/infra/db/repositories";
+import { PostsListSubHero } from "@/components/PostsListSubHero";
+import { PostCard } from "@/components/PostCard";
+import type { Metadata } from "next";
+import { env } from "@/env";
+
+export const revalidate = 300;  // 5분
+
+interface Props {
+  params: Promise<{ name: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { name } = await params;
+  const tag = decodeURIComponent(name);
+  const siteUrl = env.NEXT_PUBLIC_SITE_URL;
+  return {
+    title: `#${tag}`,
+    description: `${tag} 태그가 달린 글 모음`,
+    alternates: { canonical: `${siteUrl}/tag/${encodeURIComponent(tag)}` },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function TagPage({ params }: Props) {
+  const { name } = await params;
+  const tag = decodeURIComponent(name);
+  const { post } = getRepositories();
+  const [posts, total] = await Promise.all([
+    post.getPostsByTag(tag, { limit: 50 }),
+    post.countPostsByTag(tag),
+  ]);
+
+  if (total === 0) notFound();
+
+  return (
+    <div className="container mx-auto max-w-[1180px] px-4">
+      <PostsListSubHero
+        eyebrow="TAG"
+        title={`#${tag}`}
+        meta={`${total} POSTS`}
+      />
+      <ul className="grid grid-cols-1 md:grid-cols-2 gap-6 pb-16">
+        {posts.map((p) => (
+          <li key={p.path}><PostCard post={p} /></li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+`PostsListSubHero` props 에 `accent` 가 `"popular"` 만 정의됐다면 그대로 사용 (accent 없이). 또는 신규 accent variant 가 필요하면 phase 2 OOS — 단순히 기본 sub-hero 사용.
+
+### 3. `src/components/ArticleFooter.tsx` tag link 활성화
+
+기존 코드:
+```tsx
+{tags.map((tag) => (
+  <span key={tag} ...>#{tag}</span>
+))}
+```
+
+→ `<Link href="/tag/{encoded}">` 로 교체. 색상은 `text-[var(--color-fg-muted)] hover:text-[var(--color-brand-400)]` 패턴 (plan009 토큰).
+
+```tsx
+import Link from "next/link";
+
+{tags.map((tag) => (
+  <Link
+    key={tag}
+    href={`/tag/${encodeURIComponent(tag)}`}
+    className="text-[var(--color-fg-muted)] hover:text-[var(--color-brand-400)] transition-colors"
+  >
+    #{tag}
+  </Link>
+))}
+```
+
+기존 컨테이너 / spacing className 은 그대로.
+
+### 4. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+
+test -f src/app/tag/\[name\]/page.tsx
+grep -n "getPostsByTag\|countPostsByTag" src/infra/db/repositories/PostRepository.ts
+grep -n "/tag/" src/components/ArticleFooter.tsx
+```
+
+수동 smoke:
+- 글 상세 페이지에서 `#javascript` 클릭 → `/tag/javascript` 이동
+- 결과 페이지에 해당 tag 글 N개 표시
+- 존재하지 않는 tag (`/tag/nonexistent`) → 404
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/infra/db/repositories/PostRepository.ts` | 수정 (getPostsByTag + countPostsByTag) |
+| `src/app/tag/[name]/page.tsx` | 신규 |
+| `src/components/ArticleFooter.tsx` | 수정 (tag → Link) |
+
+## Out of Scope
+
+- /tags 인덱스 페이지
+- 무한 스크롤 / pagination (50 limit 으로 충분)
+- 비활성 (isActive=false) 글 별도 처리 — 이미 where 절에 포함
+
+## Risks & Mitigations
+
+| 리스크 | 완화 |
+|---|---|
+| JSON_CONTAINS 가 MySQL 인덱스 미사용 (full table scan) | 218 글 규모에서 무시 가능. 향후 성능 이슈 시 별도 tags 테이블 정규화 (issue #72 backup) |
+| tag URL encoding 의 한글 처리 | Next.js dynamic route 가 URL decode 자동 — `decodeURIComponent(name)` 명시로 안전 |
+| 빈 결과를 404 로 처리 시 SEO 영향 | 정상 동작 — 존재하지 않는 tag 는 색인 차단이 맞음. 정상 tag 는 글 수 = 1+ 라 항상 200 |

--- a/tasks/plan026-tags-system/phase-03.md
+++ b/tasks/plan026-tags-system/phase-03.md
@@ -1,0 +1,38 @@
+# Phase 03 — 검증 + docs 갱신 + 마킹
+
+**Model**: haiku
+
+## 작업 항목
+
+### 1. 검증
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+```
+
+### 2. `docs/data-schema.md` 갱신
+
+`posts` 테이블 정의에 `tags JSON[] NOT NULL DEFAULT []` 추가. 기존 `folders` 와 같은 방식으로 한 줄.
+
+### 3. `docs/code-architecture.md` 갱신 (선택)
+
+새 라우트 `/tag/[name]` 만 한 줄 추가. PostRepository.getPostsByTag 메서드명 언급.
+
+### 4. issue close
+
+PR body 에 `Closes #72` 명시 (PR 생성 시 작성).
+
+### 5. index.json status 마킹
+
+`tasks/plan026-tags-system/index.json` 의 phase 1/2/3 + 최상위 `status` = `"completed"`.
+
+### 6. verification
+
+```bash
+grep -n "tags" docs/data-schema.md
+grep -n "/tag/\[name\]" docs/code-architecture.md
+grep -n "\"completed\"" tasks/plan026-tags-system/index.json | wc -l  # 4
+```


### PR DESCRIPTION
## Summary

- `posts.tags JSON NOT NULL DEFAULT ('[]')` 컬럼 추가 + drizzle migration `0005_nervous_human_torch.sql`
- `SyncService` 가 frontmatter `tags` 추출 + 정규화 (`trim().toLowerCase()`, 중복 제거) 후 DB 저장
- `PostRepository.getPostsByTag` / `countPostsByTag` — JSON_CONTAINS + JSON_QUOTE 안전 쿼리
- `/tag/[name]` 라우트 신규 — tag 별 글 목록, 5분 ISR, 존재하지 않으면 404
- `ArticleFooter` 의 tag chip 활성화 (`<span>` → `<Link>`)
- `docs/data-schema.md` 의 posts 테이블 정의 갱신

`Closes #72`

## Phase 진행

| Phase | 상태 | commit |
|---|---|---|
| 01 schema + sync | ✅ | `5c2b9e9` |
| 02 page + repo + footer | ✅ | `31df7df` |
| 03 docs + 마킹 | ✅ | `3d7135a` |

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test --run` — 24 files / 232 tests pass
- [x] `pnpm build`
- [ ] **로컬 DB migrate 검증 필요** (사용자) — `pnpm db:up && pnpm db:migrate` 후 `/api/sync` 호출 → `SELECT path, tags FROM posts WHERE JSON_LENGTH(tags) > 0 LIMIT 5;`
- [ ] 글 상세 → `#tag` 클릭 → `/tag/{name}` 이동 smoke

## OOS

- `/tags` 인덱스 (전체 tag cloud)
- 무한 스크롤 / pagination (50 limit 충분)
- tag 별 별도 인덱스 (218 글 규모는 full table scan 무시 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)