### PR TITLE
feat(home): reorder sections + expand categories to 9

### DIFF
--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -2,7 +2,7 @@
 
 **Route:** `/`  
 **File:** `src/app/page.tsx`  
-**Updated:** 2026-04-27
+**Updated:** 2026-05-07
 
 ---
 
@@ -18,6 +18,7 @@
 |--------|--------|---------|
 | CategoryRepository | `getCategories()` | 전체 카테고리 목록 + 글 수 |
 | PostRepository | `getRecentPosts(6)` | 최근 글 6개 |
+| CategoryRepository | `getCategories()` | postCount desc 정렬 — 홈에서 상위 9개 표시 (plan030) |
 | PostRepository | `getActivePostCount()` | HomeHero 통계용 활성 글 총 개수 (plan013) |
 | VisitRepository | `getPopularPostPaths(limit*3)` | 인기 글 경로 + 조회수 |
 | PostRepository | `getPostsByPaths(paths)` | 인기 글 상세 데이터 |
@@ -36,7 +37,7 @@
 |-----------|------|
 | `HomeHero` (plan013) | eyebrow + h1 + lead + `<dl>` 4 stats 한 컴포넌트 — 기존 별도 Hero/Stats 섹션 통합 |
 | `HeroMesh` (plan013) | SVG `<radialGradient>` + CSS slow rotate 배경 mesh (server, prefers-reduced-motion 자동 처리) |
-| `CategoryList` | 카테고리 그리드 (최대 6개 표시) |
+| `CategoryList` | 카테고리 그리드 (최대 9개 표시, lg 3×3) |
 | `PostCard` | 인기 글 / 최근 글 카드 |
 | `WebsiteJsonLd` | JSON-LD 구조화 데이터 |
 
@@ -65,12 +66,14 @@
 
 ```
 HomeHero (eyebrow + h1<em> + caret + lead + <dl> 4 stats)  ← plan013, HeroMesh 배경 포함
-Categories Section (최대 6개 → 헤더 우측 "모두 보기" 링크)
 Popular Posts Section (인기 글, 조회수 있을 때만 표시)
   └ 섹션 하단 CTA 버튼 "인기 글 더 보기 →"
 Recent Posts Section (최근 6개)
   └ 섹션 하단 CTA 버튼 "최신 글 더 보기 →"
+Categories Section (최대 9개, 3×3 grid → 헤더 우측 "모두 보기" 링크)  ← plan030
 ```
+
+> plan030: 인기/최신을 카테고리보다 위로 올려 신규 방문자가 콘텐츠를 먼저 만나도록 재배치. 카테고리는 6→9로 확장하여 3×3 grid 로 표시.
 
 > plan013 이전: 별도 Hero Section + Stats Section 으로 분리되어 있었음. 현재는 `<HomeHero>` 한 컴포넌트로 통합 — eyebrow, h1, lead, 4 stats `<dl>` (posts/categories/series·subscribers placeholder).
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,21 +124,23 @@ export default async function HomePage() {
         </section>
 
         {/* Categories Section */}
-        <section>
-          <div className="flex items-center justify-between mb-4 md:mb-8">
-            <h2 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">
-              카테고리
-            </h2>
-            <Link
-              href="/categories"
-              className="flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium"
-            >
-              모두 보기
-              <ArrowRight className="w-4 h-4" />
-            </Link>
-          </div>
-          <CategoryList categories={categories.slice(0, 9)} />
-        </section>
+        {categories.length > 0 && (
+          <section>
+            <div className="flex items-center justify-between mb-4 md:mb-8">
+              <h2 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">
+                카테고리
+              </h2>
+              <Link
+                href="/categories"
+                className="flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium"
+              >
+                모두 보기
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+            <CategoryList categories={categories.slice(0, 9)} />
+          </section>
+        )}
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,27 +74,10 @@ export default async function HomePage() {
         subscriberCount={subscriberCount}
       />
       <main className="container mx-auto px-4 py-12 md:py-16">
-        {/* Categories Section */}
-        <section className="mb-8 md:mb-16">
-          <div className="flex items-center justify-between mb-4 md:mb-8">
-            <h2 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">
-              카테고리
-            </h2>
-            <Link
-              href="/categories"
-              className="flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium"
-            >
-              모두 보기
-              <ArrowRight className="w-4 h-4" />
-            </Link>
-          </div>
-          <CategoryList categories={categories.slice(0, 6)} />
-        </section>
-
         {/* Popular Posts Section */}
         {popularPosts.length > 0 && (
-          <section className="mb-16">
-            <div className="flex items-center gap-2 mb-8">
+          <section className="mb-8 md:mb-16">
+            <div className="flex items-center gap-2 mb-4 md:mb-8">
               <Flame className="w-6 h-6 text-orange-500" />
               <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
                 인기 글
@@ -114,7 +97,7 @@ export default async function HomePage() {
         )}
 
         {/* Recent Posts Section */}
-        <section>
+        <section className="mb-8 md:mb-16">
           <div className="flex items-center justify-between mb-4 md:mb-8">
             <h2 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">
               최근 글
@@ -138,6 +121,23 @@ export default async function HomePage() {
               <p>아직 등록된 글이 없습니다.</p>
             </div>
           )}
+        </section>
+
+        {/* Categories Section */}
+        <section>
+          <div className="flex items-center justify-between mb-4 md:mb-8">
+            <h2 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">
+              카테고리
+            </h2>
+            <Link
+              href="/categories"
+              className="flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium"
+            >
+              모두 보기
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
+          <CategoryList categories={categories.slice(0, 9)} />
         </section>
       </main>
     </>

--- a/tasks/plan030-home-reorder/index.json
+++ b/tasks/plan030-home-reorder/index.json
@@ -1,0 +1,20 @@
+{
+  "name": "plan030-home-reorder",
+  "description": "홈 섹션 순서 변경 + 카테고리 노출 9개로 확장. 현재 Hero → 카테고리(6) → 인기(6) → 최신(6) → 변경 후 Hero → 인기(6) → 최신(6) → 카테고리(9). CategoryList 의 grid 도 lg:grid-cols-3 (3×3) 로 조정. getCategories() 는 이미 postCount desc 정렬이라 추가 변경 없음.",
+  "status": "pending",
+  "created_at": "2026-05-07",
+  "total_phases": 1,
+  "related_docs": [
+    "docs/pages/home.md"
+  ],
+  "depends_on": [],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "page.tsx 섹션 순서 변경 + slice(0, 9) + CategoryList grid 3x3",
+      "model": "sonnet",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan030-home-reorder/index.json
+++ b/tasks/plan030-home-reorder/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan030-home-reorder",
   "description": "홈 섹션 순서 변경 + 카테고리 노출 9개로 확장. 현재 Hero → 카테고리(6) → 인기(6) → 최신(6) → 변경 후 Hero → 인기(6) → 최신(6) → 카테고리(9). CategoryList 의 grid 도 lg:grid-cols-3 (3×3) 로 조정. getCategories() 는 이미 postCount desc 정렬이라 추가 변경 없음.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-07",
   "total_phases": 1,
   "related_docs": [
@@ -14,7 +14,7 @@
       "file": "phase-01.md",
       "title": "page.tsx 섹션 순서 변경 + slice(0, 9) + CategoryList grid 3x3",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan030-home-reorder/phase-01.md
+++ b/tasks/plan030-home-reorder/phase-01.md
@@ -28,14 +28,11 @@ JSX 트리에서 Popular → Recent → Categories 순서로 재배치. 각 sect
 <CategoryList categories={categories.slice(0, 9)} />
 ```
 
-### 3. `src/components/CategoryList.tsx` grid 조정
+### 3. `src/components/CategoryList.tsx` grid 점검 (변경 가능성 낮음)
 
-기존 grid (PostCard 와 비슷한 패턴) 를 3×3 으로:
-- 모바일: `grid-cols-2` (2 × 5 → 마지막 1개는 단독)
-- 태블릿: `md:grid-cols-3` (3 × 3)
-- 데스크톱: `lg:grid-cols-3` (3 × 3)
+현재 `CategoryList.tsx` 는 이미 `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` 적용됨 — **3×3 grid 자연스럽게 형성, 변경 불필요**. 수정 항목으로 두는 이유는 `md:grid-cols-3` 추가 여부 (현재 sm→lg 점프) 정도의 미세 조정 가능성. 실제 시각 점검 후 어색하지 않으면 변경 0.
 
-CategoryList 를 먼저 grep 으로 확인 후 결정. 만약 현재 `lg:grid-cols-2` 라면 `lg:grid-cols-3` 로 교체. 기존 카드 비율이 너무 wide 해 보이면 cell aspect 도 조정 검토 (OOS — 기존 톤 유지가 기본).
+기존 카드 비율이 너무 wide 해 보이면 cell aspect 조정 검토 (OOS — 기존 톤 유지가 기본).
 
 ### 4. 마지막 섹션 (카테고리) margin/spacing 조정
 
@@ -43,7 +40,7 @@ CategoryList 를 먼저 grep 으로 확인 후 결정. 만약 현재 `lg:grid-co
 
 ### 5. Empty state 처리
 
-기존 popular/recent 의 conditional 렌더 로직 (`length > 0`) 그대로 유지. 카테고리 빈 배열 (`categories.length === 0`) 일 때 섹션 자체 hide 또는 placeholder — 기존 동작 유지.
+기존 popular/recent 의 conditional 렌더 로직 (`length > 0`) 그대로 유지. **카테고리 섹션도 동일한 가드 추가** — `categories.length > 0 && (<section>...)` 로 빈 배열일 때 헤더만 노출되는 어색함 차단. (PR #122 review-fix 반영)
 
 ### 6. 자동 verification
 
@@ -53,8 +50,9 @@ pnpm type-check
 pnpm test --run
 pnpm build
 
-# 섹션 순서 — popularPosts JSX 가 categories JSX 보다 위에 위치
-node -e "const s = require('fs').readFileSync('src/app/page.tsx','utf8'); const a = s.indexOf('popularPosts.length'); const b = s.indexOf('CategoryList'); process.exit(a < b ? 0 : 1)"
+# 섹션 순서 — popularPosts JSX 가 CategoryList JSX 보다 위에 위치
+# 주의: 단순 indexOf("CategoryList") 는 import 라인을 잡아 false positive 발생 — JSX 태그 패턴으로 비교
+node -e "const s = require('fs').readFileSync('src/app/page.tsx','utf8'); const a = s.indexOf('popularPosts.length > 0 &&'); const b = s.indexOf('<CategoryList categories'); process.exit(a > 0 && b > 0 && a < b ? 0 : 1)"
 
 # 9 cap
 grep -n "categories\.slice(0, 9)" src/app/page.tsx

--- a/tasks/plan030-home-reorder/phase-01.md
+++ b/tasks/plan030-home-reorder/phase-01.md
@@ -1,0 +1,96 @@
+# Phase 01 — 홈 섹션 순서 변경 + 카테고리 9개
+
+**Model**: sonnet
+**Goal**: `/` 홈 페이지의 섹션 순서를 인기 → 최신 → 카테고리 로 재배열 + 카테고리 노출 6 → 9개 + grid 3×3 조정.
+
+## Context (자기완결)
+
+`src/app/page.tsx` 의 현재 구조:
+1. `<HomeHero />`
+2. Categories section (`<CategoryList categories={categories.slice(0, 6)} />`)
+3. Popular section (`popularPosts.length > 0 && ...`)
+4. Recent section (`recentPosts.length > 0 ? ... : empty`)
+
+`src/infra/db/repositories/CategoryRepository.ts:31` 의 `getCategories()` 는 이미 `postCount desc` 정렬.
+
+## 작업 항목
+
+### 1. `src/app/page.tsx` 섹션 재배열
+
+JSX 트리에서 Popular → Recent → Categories 순서로 재배치. 각 section 의 `<h2>` / spacing / wrapper className 은 그대로.
+
+### 2. 카테고리 노출 6 → 9
+
+```tsx
+<CategoryList categories={categories.slice(0, 6)} />
+//                                          ^^^^
+// → 9
+<CategoryList categories={categories.slice(0, 9)} />
+```
+
+### 3. `src/components/CategoryList.tsx` grid 조정
+
+기존 grid (PostCard 와 비슷한 패턴) 를 3×3 으로:
+- 모바일: `grid-cols-2` (2 × 5 → 마지막 1개는 단독)
+- 태블릿: `md:grid-cols-3` (3 × 3)
+- 데스크톱: `lg:grid-cols-3` (3 × 3)
+
+CategoryList 를 먼저 grep 으로 확인 후 결정. 만약 현재 `lg:grid-cols-2` 라면 `lg:grid-cols-3` 로 교체. 기존 카드 비율이 너무 wide 해 보이면 cell aspect 도 조정 검토 (OOS — 기존 톤 유지가 기본).
+
+### 4. 마지막 섹션 (카테고리) margin/spacing 조정
+
+기존 마지막 섹션 (Recent posts) 는 `<section>` 그대로 끝 — bottom margin 없음. 카테고리가 새 마지막이 되면 bottom margin 점검 — 페이지 푸터와 자연스러운 간격.
+
+### 5. Empty state 처리
+
+기존 popular/recent 의 conditional 렌더 로직 (`length > 0`) 그대로 유지. 카테고리 빈 배열 (`categories.length === 0`) 일 때 섹션 자체 hide 또는 placeholder — 기존 동작 유지.
+
+### 6. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+
+# 섹션 순서 — popularPosts JSX 가 categories JSX 보다 위에 위치
+node -e "const s = require('fs').readFileSync('src/app/page.tsx','utf8'); const a = s.indexOf('popularPosts.length'); const b = s.indexOf('CategoryList'); process.exit(a < b ? 0 : 1)"
+
+# 9 cap
+grep -n "categories\.slice(0, 9)" src/app/page.tsx
+! grep -n "categories\.slice(0, 6)" src/app/page.tsx
+
+# CategoryList grid 3 columns
+grep -nE "lg:grid-cols-3|md:grid-cols-3" src/components/CategoryList.tsx
+```
+
+수동 smoke:
+- `pnpm dev` → 홈 진입 → 시각 순서 확인 (Hero → Popular → Recent → Categories)
+- 모바일 (375px) / 태블릿 (768px) / 데스크톱 (1180px) breakpoint 확인
+- 카테고리 9개 표시 (DB 가 9개 미만이면 그만큼만)
+
+### 7. `docs/pages/home.md` 갱신
+
+기존 home.md 의 섹션 순서 / 카테고리 개수 기록 1~2줄 갱신.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/page.tsx` | 수정 (JSX 순서 + slice 인자) |
+| `src/components/CategoryList.tsx` | 수정 (grid columns) |
+| `docs/pages/home.md` | 수정 (섹션 순서 / 카테고리 개수) |
+
+## Out of Scope
+
+- /categories 인덱스 페이지 변경
+- 카테고리 카드 디자인 (plan015 결과 유지)
+- 인기/최신 글 표시 개수 (현재 6개 유지)
+- 섹션 간 motion / scroll reveal — plan025 motion polish 와 별개
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| DB 카테고리 수가 9개 미만일 때 grid 빈 cell | `slice(0, 9)` 가 자동 truncate — 빈 cell 안 생김. css grid 가 자연스럽게 가용 cell 만 채움 |
+| md/lg breakpoint 에서 3 cols 가 어색해 보일 수 있음 | 시각 smoke 후 필요시 lg:grid-cols-3 → lg:grid-cols-4 fallback 결정 (이번 phase OOS, 후속 review-fix) |


### PR DESCRIPTION
## Summary

- 홈 섹션 순서를 Hero → 카테고리 → 인기 → 최신 에서 **Hero → 인기 → 최신 → 카테고리** 로 재배치 — 신규 방문자가 콘텐츠를 먼저 만나도록
- CategoryList 노출 **6 → 9개**, 기존 `lg:grid-cols-3` 가 자연스럽게 3×3 grid 로 표시 (CategoryList grid 변경 불필요)
- `docs/pages/home.md` Layout / Components / Data 표 갱신

## Plan & Task

- Plan: `tasks/plan030-home-reorder/`
- Phase 01: page.tsx 섹션 순서 변경 + slice(0, 9) + docs 갱신

## Test plan

- [x] `pnpm lint` 통과
- [x] `pnpm type-check` 통과
- [x] `pnpm test -- --run` 통과 (24 files / 232 tests)
- [x] `pnpm build` 통과
- [x] grep: `categories.slice(0, 9)` 존재 + `categories.slice(0, 6)` 부재
- [x] JSX 순서: `popularPosts.length > 0 &&` 가 `<CategoryList categories` 보다 위
- [ ] 수동 smoke (dev): 모바일 / 태블릿 / 데스크톱 breakpoint 에서 섹션 순서 + 카테고리 9개 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)