### PR TITLE
feat(prose): tokenize repeated px values in prose rules (#75)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,6 +104,19 @@
   --d-section-y: 96px;
   --d-card-pad: 24px;
   --d-row-gap: 16px;
+
+  /* prose typography / spacing (plan031, issue #75)
+   * 의도: 반복되거나 의미 단위인 값만 토큰화. 1회성 값은 inline 유지. */
+  --prose-h2-size: 28px;
+  --prose-h2-margin-top: 56px;
+  --prose-h2-margin-bottom: 16px;
+  --prose-meta-size: 12px;          /* h2::before / code-card-head / line-number */
+  --prose-label-size: 10px;         /* blockquote QUOTE / .lang */
+  --prose-block-margin: 24px 0;     /* blockquote / code-card 외곽 vertical margin */
+  --prose-blockquote-padding: 4px 0 4px 20px;
+  --prose-code-padding: 1px 6px;    /* inline code */
+  --prose-codeblock-header-padding: 10px 14px;
+  --prose-codeblock-padding: 16px 20px;
 }
 
 :root:not(.dark) {
@@ -185,10 +198,10 @@ code, kbd, samp, pre {
   counter-reset: prose-h2;
 }
 .prose h2 {
-  font-size: 28px;
+  font-size: var(--prose-h2-size);
   font-weight: 600;
   letter-spacing: -0.02em;
-  margin: 56px 0 16px;
+  margin: var(--prose-h2-margin-top) 0 var(--prose-h2-margin-bottom);
   color: var(--color-fg-primary);
   scroll-margin-top: 80px;
   counter-increment: prose-h2;
@@ -196,15 +209,15 @@ code, kbd, samp, pre {
 .prose h2::before {
   content: counter(prose-h2, decimal-leading-zero);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--prose-meta-size);
   color: var(--color-fg-muted);
   margin-right: 12px;
   letter-spacing: 0.04em;
 }
 .prose blockquote {
   border-left: 2px solid var(--color-brand-400);
-  padding: 4px 0 4px 20px;
-  margin: 24px 0;
+  padding: var(--prose-blockquote-padding);
+  margin: var(--prose-block-margin);
   font-size: 16px;
   color: var(--color-fg-primary);
   font-style: normal;
@@ -213,7 +226,7 @@ code, kbd, samp, pre {
   content: "QUOTE";
   display: block;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--prose-label-size);
   letter-spacing: 0.08em;
   color: var(--color-brand-400);
   margin-bottom: 8px;
@@ -223,7 +236,7 @@ code, kbd, samp, pre {
 .prose :not(pre) > code {
   font-family: var(--font-mono);
   font-size: 0.88em;
-  padding: 1px 6px;
+  padding: var(--prose-code-padding);
   border: 1px solid var(--color-border-subtle);
   border-radius: 4px;
   background: var(--color-bg-subtle);
@@ -253,17 +266,17 @@ code, kbd, samp, pre {
   border-radius: 8px;
   background: var(--color-bg-subtle);
   overflow: hidden;
-  margin: 24px 0;
+  margin: var(--prose-block-margin);
 }
 .prose .code-card-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 14px;
+  padding: var(--prose-codeblock-header-padding);
   background: var(--color-bg-base);
   border-bottom: 1px solid var(--color-border-subtle);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--prose-meta-size);
 }
 .prose .code-card-head .left {
   display: flex;
@@ -272,7 +285,7 @@ code, kbd, samp, pre {
   color: var(--color-fg-secondary);
 }
 .prose .code-card-head .lang {
-  font-size: 10px;
+  font-size: var(--prose-label-size);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   padding: 2px 6px;
@@ -304,7 +317,7 @@ code, kbd, samp, pre {
 }
 .prose .code-card-body pre {
   margin: 0;
-  padding: 16px 20px;
+  padding: var(--prose-codeblock-padding);
   background: transparent !important; /* keepBackground:false 와 결합 */
   border: none !important;
   /* fallback color — shiki 가 처리하지 못한 영역 (data-line 외부, plain text 등).
@@ -332,7 +345,7 @@ code, kbd, samp, pre {
   margin-right: 1.5ch;
   text-align: right;
   color: var(--color-fg-faint);
-  font-size: 12px;
+  font-size: var(--prose-meta-size);
 }
 @media (max-width: 767px) {
   .prose .code-card-body code[data-line-numbers] [data-line]::before {

--- a/tasks/plan031-prose-px-tokens/index.json
+++ b/tasks/plan031-prose-px-tokens/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan031-prose-px-tokens",
-  "description": "prose 확장 룰의 하드코딩 px 값 → 토큰화 (issue #75). plan011 의 H2 counter / blockquote / inline code / mermaid 격리 등에 28/56/16/24/20px 등이 직접 박혀 있음. plan009 의 spacing/typography 토큰 확장 + globals.css 의 prose 룰 토큰 참조로 교체. 시각 결과 동일 보존.",
-  "status": "pending",
+  "description": "prose 확장 룰의 하드코딩 px 값 → 토큰화 (issue #75). plan011 의 H2 counter / blockquote / inline code / mermaid 격리 등에 28/56/16/24/20px 등이 직접 박혀 있음. plan009 의 spacing/typography 토큰 확장 + globals.css 의 prose 룰 토큰 참조로 교체. 시각 결과 동일 보존. 1회성 / 의미 단위 단일 사용 px 는 inline 유지 (토큰 인플레 회피).",
+  "status": "completed",
   "created_at": "2026-05-07",
   "total_phases": 2,
   "related_docs": [
@@ -17,14 +17,14 @@
       "file": "phase-01.md",
       "title": "prose typography/spacing 토큰 추가 + 하드코딩 px 교체",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + 시각 회귀 smoke + index.json 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan031-prose-px-tokens/index.json
+++ b/tasks/plan031-prose-px-tokens/index.json
@@ -1,0 +1,30 @@
+{
+  "name": "plan031-prose-px-tokens",
+  "description": "prose 확장 룰의 하드코딩 px 값 → 토큰화 (issue #75). plan011 의 H2 counter / blockquote / inline code / mermaid 격리 등에 28/56/16/24/20px 등이 직접 박혀 있음. plan009 의 spacing/typography 토큰 확장 + globals.css 의 prose 룰 토큰 참조로 교체. 시각 결과 동일 보존.",
+  "status": "pending",
+  "created_at": "2026-05-07",
+  "total_phases": 2,
+  "related_docs": [
+    "docs/adr.md"
+  ],
+  "depends_on": [
+    "plan009-design-tokens-foundation",
+    "plan011-article-page-redesign"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "prose typography/spacing 토큰 추가 + 하드코딩 px 교체",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "검증 + 시각 회귀 smoke + index.json 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan031-prose-px-tokens/phase-01.md
+++ b/tasks/plan031-prose-px-tokens/phase-01.md
@@ -1,0 +1,90 @@
+# Phase 01 — prose px → 토큰
+
+**Model**: sonnet
+**Goal**: `src/app/globals.css` 의 prose 확장 룰 (plan011) 의 하드코딩 px 값을 plan009 토큰 시스템으로 흡수. 시각 결과는 변경 없음.
+
+## Context (자기완결)
+
+`globals.css` 의 prose 영역 (line ~145 부터) 에 `28px`, `56px`, `16px`, `24px`, `20px`, `10px`, `12px` 등이 직접 박혀 있음. plan009 는 색/border 만 토큰화하고 spacing/typography scale 은 미정의.
+
+## 작업 항목
+
+### 1. `globals.css` `:root` 에 typography/spacing 토큰 추가
+
+prose 전용 토큰 (semantic 별 grouping):
+
+```css
+:root {
+  /* prose typography */
+  --prose-h2-size: 28px;
+  --prose-h2-margin-top: 56px;
+  --prose-h2-margin-bottom: 16px;
+  --prose-blockquote-padding: 4px 0 4px 20px;
+  --prose-blockquote-margin: 24px 0;
+  --prose-code-padding: 1px 6px;
+  --prose-codeblock-padding: 16px 20px;
+  --prose-codeblock-header-padding: 10px 14px;
+  /* ... 실제 prose 영역 grep 결과의 모든 반복 px 값 */
+}
+```
+
+**주의**: 1회 사용 + 일회성 값은 토큰화 X (issue #75 비-목표). 반복되거나 의미 단위인 값만.
+
+executor 는 phase 시작 시 `grep -nE "[0-9]+px" src/app/globals.css | grep -v -E "//|\\*"` 로 prose 영역 전체 px 추출 → 의미 grouping 후 토큰화 결정.
+
+### 2. prose 룰 px → var() 교체
+
+```css
+.prose h2 {
+  font-size: var(--prose-h2-size);
+  margin: var(--prose-h2-margin-top) 0 var(--prose-h2-margin-bottom);
+  /* ... */
+}
+```
+
+기존 line 188, 191, 206-208, 256, 262, 266, 290, 307, 323 등이 영향.
+
+### 3. ArticleHero inline 시각 값 검토 (선택)
+
+`ArticleHero.tsx` 의 `52px / 34px / 22ch / 880px` 등은 Tailwind arbitrary value 로 들어감. 이 phase 에서는 OOS — issue #75 의 "ArticleHero 도 가능한 범위" 는 대범위 영역이라 별도 plan 후보.
+
+### 4. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+
+# prose 영역의 직접 px 사용이 줄었는지
+grep -cE "^\s*(font-size|margin|padding):.*[0-9]+px" src/app/globals.css
+# → 신규 토큰 추가 후 prose 영역의 inline px 는 0 또는 거의 0 으로 축소
+
+# 신규 토큰 추가됨
+grep -nE "--prose-(h2|blockquote|code)" src/app/globals.css | wc -l  # 5+ 줄
+```
+
+수동 smoke (사용자 안내):
+- `pnpm dev` → 글 상세 페이지 진입 → H2 / blockquote / inline code / 코드 블록 시각 비교 (변경 전후 동일)
+- 다크/라이트 양쪽 확인
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/globals.css` | 수정 (토큰 추가 + 룰 var() 참조) |
+
+## Out of Scope
+
+- ArticleHero inline 값 토큰화
+- 모든 globals.css px 토큰화 — 일회성 사용처는 inline 유지 (issue #75 비-목표)
+- 새 spacing scale 도입 (Tailwind v4 default 그대로)
+- mockup 톤 변경
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 토큰화 후 시각 회귀 | phase 2 의 수동 smoke 로 글 상세 / 다크 / 라이트 / 모바일 모두 확인. 회귀 발견 시 immediate revert |
+| 토큰 이름이 향후 의미 변화에 발목 (예: `--prose-h2-size` 가 다른 곳 영향) | semantic naming + scope 제한 (`--prose-*` prefix) — 다른 영역 영향 없음 |
+| 1회성 px 까지 토큰화하면 토큰 인플레 | 명시적 비-목표. 반복/의미 단위만 토큰화 |

--- a/tasks/plan031-prose-px-tokens/phase-02.md
+++ b/tasks/plan031-prose-px-tokens/phase-02.md
@@ -1,0 +1,22 @@
+# Phase 02 — 검증 + 마킹
+
+**Model**: haiku
+
+## 작업 항목
+
+### 1. 검증
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+```
+
+### 2. issue close
+
+PR body 에 `Closes #75` 명시.
+
+### 3. index.json status 마킹
+
+`tasks/plan031-prose-px-tokens/index.json` 의 phase 1/2 + 최상위 `status` = `"completed"`.


### PR DESCRIPTION
## Summary

`globals.css` 의 prose 확장 룰 (plan011 — H2 counter / blockquote / inline code / CodeCard) 에 하드코딩된 반복/의미 단위 px 를 `:root` 의 `--prose-*` CSS 변수로 추출. 시각 결과 동일 보존.

## 추가 토큰 (10건)

| 토큰 | 값 | 용도 |
|---|---|---|
| `--prose-h2-size` | 28px | h2 font-size |
| `--prose-h2-margin-top` | 56px | h2 margin-top |
| `--prose-h2-margin-bottom` | 16px | h2 margin-bottom |
| `--prose-meta-size` | 12px | h2::before / code-card-head / line-number (반복 3) |
| `--prose-label-size` | 10px | blockquote QUOTE / .lang (반복 2) |
| `--prose-block-margin` | 24px 0 | blockquote / code-card 외곽 vertical margin (반복 2) |
| `--prose-blockquote-padding` | 4px 0 4px 20px | blockquote padding |
| `--prose-code-padding` | 1px 6px | inline code padding |
| `--prose-codeblock-header-padding` | 10px 14px | code-card-head |
| `--prose-codeblock-padding` | 16px 20px | code-card-body pre |

13 개 var() 참조로 교체. 1회성 / 의미 단위 단일 사용 px (border-width / scroll-margin / 다른 font-size 컨텍스트 / gap 등) 는 토큰 인플레 회피 위해 inline 유지.

## Plan & Task

- Plan: `tasks/plan031-prose-px-tokens/`
- Phase 01: 토큰 추가 + var() 교체 / Phase 02: 검증 + 마킹

## Test plan

- [x] \`pnpm lint\` 통과
- [x] \`pnpm type-check\` 통과
- [x] \`pnpm test -- --run\` 통과 (24 files / 232 tests)
- [x] \`pnpm build\` 통과
- [x] grep 검증: `--prose-*` 토큰 10건 + `var(--prose-*)` 13건
- [ ] 수동 smoke: 글 상세 페이지 H2 / blockquote / inline code / CodeCard 시각 비교 (다크 + 라이트)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)