### PR TITLE
feat(migrate): add DB connection retry loop on container startup (#68)

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -2,6 +2,36 @@ import { drizzle } from "drizzle-orm/mysql2";
 import { migrate } from "drizzle-orm/mysql2/migrator";
 import mysql from "mysql2/promise";
 
+const MAX_RETRIES = 10;
+const INITIAL_DELAY_MS = 500;
+const MAX_DELAY_MS = 5_000;
+
+async function connectWithRetry(databaseUrl: string) {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const conn = await mysql.createConnection(databaseUrl);
+      await conn.query("SELECT 1");
+      if (attempt > 1) {
+        console.log(`[migrate] DB ready after ${attempt} attempts`);
+      }
+      return conn;
+    } catch (error) {
+      lastError = error;
+      const msg = error instanceof Error ? error.message : String(error);
+      const delay = Math.min(
+        INITIAL_DELAY_MS * Math.pow(2, attempt - 1),
+        MAX_DELAY_MS
+      );
+      console.log(
+        `[migrate] DB not ready (attempt ${attempt}/${MAX_RETRIES}): ${msg} — retry in ${delay}ms`
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 async function main() {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -11,10 +41,10 @@ async function main() {
 
   let conn;
   try {
-    conn = await mysql.createConnection(databaseUrl);
+    conn = await connectWithRetry(databaseUrl);
   } catch (error) {
     console.error(
-      "[migrate] DB connection failed:",
+      "[migrate] DB connection failed after retries:",
       error instanceof Error ? error.message : String(error)
     );
     process.exit(1);

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -6,8 +6,16 @@ const MAX_RETRIES = 10;
 const INITIAL_DELAY_MS = 500;
 const MAX_DELAY_MS = 5_000;
 
-async function connectWithRetry(databaseUrl: string) {
-  let lastError: unknown;
+function maskDatabaseUrl(message: string): string {
+  return message.replace(/:([^@/]*)@/, ":***@");
+}
+
+async function connectWithRetry(
+  databaseUrl: string
+): Promise<mysql.Connection> {
+  let lastError: Error = new Error(
+    "DB 연결 최대 재시도 횟수 초과"
+  );
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       const conn = await mysql.createConnection(databaseUrl);
@@ -17,8 +25,8 @@ async function connectWithRetry(databaseUrl: string) {
       }
       return conn;
     } catch (error) {
-      lastError = error;
-      const msg = error instanceof Error ? error.message : String(error);
+      lastError = error instanceof Error ? error : new Error(String(error));
+      const msg = maskDatabaseUrl(lastError.message);
       const delay = Math.min(
         INITIAL_DELAY_MS * Math.pow(2, attempt - 1),
         MAX_DELAY_MS
@@ -29,7 +37,7 @@ async function connectWithRetry(databaseUrl: string) {
       await new Promise((r) => setTimeout(r, delay));
     }
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  throw lastError;
 }
 
 async function main() {
@@ -43,9 +51,11 @@ async function main() {
   try {
     conn = await connectWithRetry(databaseUrl);
   } catch (error) {
+    const rawMsg =
+      error instanceof Error ? error.message : String(error);
     console.error(
       "[migrate] DB connection failed after retries:",
-      error instanceof Error ? error.message : String(error)
+      maskDatabaseUrl(rawMsg)
     );
     process.exit(1);
   }

--- a/tasks/plan032-migration-healthcheck/index.json
+++ b/tasks/plan032-migration-healthcheck/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan032-migration-healthcheck",
   "description": "마이그레이션 컨테이너 기동 시 DB ready race 보호 (issue #68) — scripts/migrate.ts 에 connection retry loop 도입 (exponential backoff, max ~30초). Production docker-compose 는 repo 외부라 application-level 보호만 추가 (Option B).",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-07",
   "total_phases": 1,
   "related_docs": [],
@@ -12,7 +12,7 @@
       "file": "phase-01.md",
       "title": "scripts/migrate.ts retry loop + connection 안정화",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan032-migration-healthcheck/index.json
+++ b/tasks/plan032-migration-healthcheck/index.json
@@ -1,0 +1,18 @@
+{
+  "name": "plan032-migration-healthcheck",
+  "description": "마이그레이션 컨테이너 기동 시 DB ready race 보호 (issue #68) — scripts/migrate.ts 에 connection retry loop 도입 (exponential backoff, max ~30초). Production docker-compose 는 repo 외부라 application-level 보호만 추가 (Option B).",
+  "status": "pending",
+  "created_at": "2026-05-07",
+  "total_phases": 1,
+  "related_docs": [],
+  "depends_on": [],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "scripts/migrate.ts retry loop + connection 안정화",
+      "model": "sonnet",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan032-migration-healthcheck/phase-01.md
+++ b/tasks/plan032-migration-healthcheck/phase-01.md
@@ -1,0 +1,133 @@
+# Phase 01 — migrate.ts retry loop
+
+**Model**: sonnet
+**Goal**: 컨테이너 기동 시 DB 가 아직 ready 가 아닐 때 즉시 실패하지 않도록 connection retry loop 추가.
+
+## Context (자기완결)
+
+`scripts/migrate.ts` 가 컨테이너 기동 시 첫 라인에서 `mysql.createConnection(databaseUrl)` 호출. MySQL 컨테이너가 아직 ready 가 아니면 `ECONNREFUSED` 또는 `ENOTFOUND` 로 즉시 process.exit(1).
+
+**현재 상태**: 홈서버 docker-compose 가 MySQL 먼저 기동 + `restart=unless-stopped` 정책으로 일시 실패 자연 복구. 그러나 일시 장애 시 컨테이너 재시작 사이클 길어짐.
+
+**Production docker-compose.yml 은 repo 외부** (홈서버 인프라 privacy 메모) — Option A (compose healthcheck condition) 는 repo 에서 작업 불가. **Option B (application-level retry loop) 만 채택**.
+
+**플젝 컨벤션**:
+- `scripts/*.ts` 는 standalone — `console.log/error` 허용 (eslint config 명시)
+- Dockerfile 의 CMD: `node migrate.js && node server.js` 그대로 유지
+
+## 작업 항목
+
+### 1. `scripts/migrate.ts` connection retry 추가
+
+```ts
+const MAX_RETRIES = 10;
+const INITIAL_DELAY_MS = 500;
+
+async function connectWithRetry(databaseUrl: string) {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const conn = await mysql.createConnection(databaseUrl);
+      // 실제 ping 으로 ready 확인
+      await conn.query("SELECT 1");
+      if (attempt > 1) {
+        console.log(`[migrate] DB ready after ${attempt} attempts`);
+      }
+      return conn;
+    } catch (error) {
+      lastError = error;
+      const msg = error instanceof Error ? error.message : String(error);
+      const delay = INITIAL_DELAY_MS * Math.pow(2, attempt - 1);
+      // 지수 백오프 — 0.5s → 1s → 2s → 4s → 8s → ... cap 5s
+      const cappedDelay = Math.min(delay, 5_000);
+      console.log(
+        `[migrate] DB not ready (attempt ${attempt}/${MAX_RETRIES}): ${msg} — retry in ${cappedDelay}ms`
+      );
+      await new Promise((r) => setTimeout(r, cappedDelay));
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(String(lastError));
+}
+```
+
+총 대기 시간: 0.5 + 1 + 2 + 4 + 5 + 5 + 5 + 5 + 5 + 5 = ~37 초. 이 안에 DB 가 ready 안 되면 종료.
+
+### 2. main() 함수 connection 부분 교체
+
+기존:
+```ts
+let conn;
+try {
+  conn = await mysql.createConnection(databaseUrl);
+} catch (error) {
+  console.error("[migrate] DB connection failed:", ...);
+  process.exit(1);
+}
+```
+
+→
+
+```ts
+let conn;
+try {
+  conn = await connectWithRetry(databaseUrl);
+} catch (error) {
+  console.error(
+    "[migrate] DB connection failed after retries:",
+    error instanceof Error ? error.message : String(error)
+  );
+  process.exit(1);
+}
+```
+
+migrate(db, ...) 호출 부분과 catch 블럭은 그대로 유지.
+
+### 3. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build  # tsc 컴파일이 migrate.ts 도 포함되는지 확인 — 안 되면 `pnpm build:migrate` 또는 Dockerfile 의 별도 컴파일 스텝
+
+# scripts/migrate.ts 가 retry loop 포함
+grep -n "connectWithRetry\|MAX_RETRIES" scripts/migrate.ts
+```
+
+수동 smoke (사용자 안내):
+```bash
+# DB 끄고 migrate 실행 → retry 로그 확인 → DB 켜면 성공
+pnpm db:down
+pnpm db:migrate:runtime &
+# 5초 대기 후 DB 기동
+sleep 5
+pnpm db:up
+# migrate 가 retry 로 connection 성공 + 마이그레이션 적용 확인
+wait
+```
+
+### 4. `tasks/plan032-migration-healthcheck/index.json` status="completed" 마킹
+
+phase 완료 시.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `scripts/migrate.ts` | 수정 (connectWithRetry 추가) |
+
+## Out of Scope
+
+- production docker-compose.yml healthcheck condition (repo 외부)
+- migrate 외 다른 startup 스크립트 (없음)
+- mysqladmin ping shell wrapper (Node 단 retry 가 더 portable)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 영구 장애 시 ~37초 대기 후 컨테이너 종료 | restart=unless-stopped 정책으로 자동 재시작 → 다음 사이클에서 다시 시도. 영향 미미 |
+| MAX_RETRIES + delay 가 K8s liveness probe timeout 보다 김 | 홈서버 단일 호스트라 K8s 미사용. 향후 확장 시 reconfig |
+| ping 으로 SELECT 1 추가 호출이 정상 케이스에서 50ms 지연 | 무시 가능 |


### PR DESCRIPTION
## Summary

\`scripts/migrate.ts\` 가 컨테이너 기동 시 MySQL 이 아직 ready 가 아니면 즉시 \`process.exit(1)\` 하던 문제를 보호. application-level connection retry loop 추가 (Option B).

## 변경 내용

- \`connectWithRetry(databaseUrl)\` 신규 함수 — 지수 백오프 retry + \`SELECT 1\` ping
- 상수: \`MAX_RETRIES=10\`, \`INITIAL_DELAY_MS=500\`, \`MAX_DELAY_MS=5_000\`
- 백오프: 0.5s → 1s → 2s → 4s → 5s × 6 (총 ~37초)
- \`main()\` 의 \`createConnection\` 호출을 \`connectWithRetry\` 로 교체

## 왜 Option B 만?

production docker-compose 는 홈서버 인프라 영역 (repo 외부) 이라 \`depends_on.condition: service_healthy\` (Option A) 적용 불가. application-level retry 가 portable 하고 \`restart=unless-stopped\` 정책과 결합해 일시 장애 자연 복구.

## Plan & Task

- Plan: \`tasks/plan032-migration-healthcheck/\`
- Phase 01: scripts/migrate.ts retry loop + connection 안정화

## Test plan

- [x] \`pnpm lint\` 통과
- [x] \`pnpm type-check\` 통과
- [x] \`pnpm test -- --run\` 통과 (24 files / 232 tests)
- [x] \`pnpm build\` 통과
- [x] grep: \`connectWithRetry\` + \`MAX_RETRIES\` 존재
- [ ] 수동 smoke: \`pnpm db:down\` → \`pnpm db:migrate:runtime &\` → 5초 후 \`pnpm db:up\` → retry 로그 + 마이그레이션 적용 확인

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)