### PR TITLE
fix(footer): enable RSS link (plan027 구현 완료)

### DIFF
--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -178,7 +178,6 @@ export function SiteFooter() {
                 ttl="RSS feed"
                 sub="/rss.xml"
                 arrow="↗"
-                disabled // 미구현 — 별도 issue. graceful fallback.
               />
               <SocialItem
                 href="#newsletter"


### PR DESCRIPTION
## Summary

`SiteFooter` 의 RSS link 가 plan027 구현 완료 후에도 `disabled` 로 남아 있어 사용자가 클릭 못하던 문제 수정.

## 변경
- `<SocialItem href="/rss.xml" ... disabled />` → `disabled` prop 제거
- "미구현" 주석 제거

## 보존
- Newsletter (`#89`) 는 close 결정에 따라 `disabled` 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)