### PR TITLE
fix(prose): mobile readability — inline code wrap + table overflow + code block scroll (#136 #137 #138)

### DIFF
--- a/docs/pages/post-detail.md
+++ b/docs/pages/post-detail.md
@@ -146,7 +146,7 @@
 - `src/infra/db/repositories/VisitRepository.ts` — `getVisitCount(pagePath)`
 - `src/lib/markdown.ts` — 본문 처리 + plan012 hast 헬퍼 (`extractRawText` / `findChildText` / `findCodeProp`)
 - `src/lib/category-meta.ts` — `getCategoryColor` / `getCategoryHue` / `toCanonicalCategory` (plan010)
-- `src/app/globals.css` — plan009 토큰 + plan011 prose 확장 (H2 counter / blockquote QUOTE / inline code / mermaid 격리) + plan012 코드 블록 frame (`.code-card` / shiki dual theme)
+- `src/app/globals.css` — plan009 토큰 + plan011 prose 확장 (H2 counter / blockquote QUOTE / inline code / mermaid 격리) + plan012 코드 블록 frame (`.code-card` / shiki dual theme) + plan035 모바일 가독성 (inline code keep-all / code-card-body pre overflow-x)
 
 ---
 
@@ -158,3 +158,4 @@
 - `ReadingProgressBar` 는 신규 토큰 추가 없이 plan009 토큰 (`--color-brand-400`) 만 사용. `<dialog>` element 가 아닌 `role="dialog"` div 채택 이유는 SSR hydration mismatch 회피 + bottom sheet 애니메이션/배경 처리 자유도 확보 (plan019 risks 표 참조)
 - **조회수 증가**는 `src/proxy.ts` Node Runtime middleware (실 동작은 `src/middleware/visit.ts`) 에서 upsert. **표시**는 page.tsx 가 server-side `getVisitCount(post.path)` 로 fetch 하여 `<ArticleHero viewCount={…}/>` 에 전달 (plan011 이전의 client `<PostViewCount>` 패턴은 폐기)
 - prose 의 H2 CSS counter 는 `.prose` 단일 셀렉터에서 reset 되므로, 페이지 내 prose 컨테이너는 1개로 유지해야 번호가 어긋나지 않음
+- **모바일 (390px) 본문 가독성 정책 (plan035)** — (a) inline code 는 `word-break: keep-all` + `overflow-wrap: anywhere` 로 token 단위 wrap 보존 (식별자가 글자 단위로 깨지지 않게, 단일 token 이 viewport 보다 길면만 끊김). (b) GFM 테이블은 `components.table` override 가 `-mx-4 overflow-x-auto md:mx-0` wrapper + `min-w-[32rem]` 로 모바일 가로 스크롤 제공, 데스크톱은 `md:min-w-full` 로 기존 동작 유지. (c) 코드 블록은 `.prose .code-card-body pre` 가 자체 `overflow-x: auto` 를 가져 부모 `.code-card` 의 `overflow: hidden` 안에서도 가로 스크롤 동작 (issue #136 #137 #138)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,7 +231,9 @@ code, kbd, samp, pre {
   color: var(--color-brand-400);
   margin-bottom: 8px;
 }
-/* inline code 는 더 공격적으로 — 식별자 한가운데서도 wrap.
+/* inline code — token 단위 wrap 보존 (plan035 #136).
+ * `word-break: keep-all` 로 식별자 (`EXPLAIN`, `created_at`) 가 글자 단위로 깨지지 않게.
+ * `overflow-wrap: anywhere` 는 viewport 보다 긴 단일 token (200+ chars hash 등) fallback.
  * `pre code` (CodeCard / shiki 토큰) 와의 selector 충돌 회피. */
 .prose :not(pre) > code {
   font-family: var(--font-mono);
@@ -241,8 +243,8 @@ code, kbd, samp, pre {
   border-radius: 4px;
   background: var(--color-bg-subtle);
   color: var(--color-brand-400);
+  word-break: keep-all;
   overflow-wrap: anywhere;
-  word-break: break-all;
 }
 .prose ul li::marker {
   content: "— ";
@@ -320,6 +322,11 @@ code, kbd, samp, pre {
   padding: var(--prose-codeblock-padding);
   background: transparent !important; /* keepBackground:false 와 결합 */
   border: none !important;
+  /* plan035 #138 — pre 자체에 가로 스크롤 활성. 부모 .code-card 의 overflow:hidden 이
+   * .code-card-body 의 wrapping 만으로는 scrollWidth>clientWidth 케이스 (모바일 긴 SQL) 를
+   * 수용하지 못해 라인이 잘려 보이던 회귀를 회복. */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   /* fallback color — shiki 가 처리하지 못한 영역 (data-line 외부, plain text 등).
    * 토큰 span 은 아래 .code-card-body pre span 규칙이 var(--shiki-{light|dark}) 로 override. */
   color: var(--color-fg-secondary);

--- a/src/components/MarkdownRenderer.regression-3.test.ts
+++ b/src/components/MarkdownRenderer.regression-3.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("plan035 모바일 가독성 룰 회귀 가드", () => {
+  const css = readFileSync(join(__dirname, "../app/globals.css"), "utf-8");
+  const components = readFileSync(
+    join(__dirname, "markdown/components.tsx"),
+    "utf-8"
+  );
+
+  it("inline code 에 word-break: keep-all 룰 존재 (#136)", () => {
+    expect(css).toMatch(/word-break:\s*keep-all/);
+  });
+
+  it("inline code 에 overflow-wrap: anywhere 룰 존재 (#136 fallback)", () => {
+    expect(css).toMatch(/overflow-wrap:\s*anywhere/);
+  });
+
+  it("코드 블록 pre 에 overflow-x: auto 룰 존재 (#138)", () => {
+    expect(css).toMatch(/\.code-card-body pre[\s\S]*?overflow-x:\s*auto/);
+  });
+
+  it("테이블 override 가 overflow-x-auto wrapper 사용 (#137)", () => {
+    expect(components).toMatch(/overflow-x-auto/);
+  });
+
+  it("테이블 override 가 min-w-[32rem] 명시 (#137)", () => {
+    expect(components).toMatch(/min-w-\[32rem\]/);
+  });
+});

--- a/src/components/markdown/components.tsx
+++ b/src/components/markdown/components.tsx
@@ -204,9 +204,9 @@ export function createMarkdownComponents(basePath: string): Partial<Components> 
       </blockquote>
     ),
     table: ({ children, ...props }) => (
-      <div className="my-4 overflow-x-auto">
+      <div className="prose-table-wrapper my-4 -mx-4 overflow-x-auto md:mx-0">
         <table
-          className="min-w-full border border-gray-200 dark:border-gray-800 rounded-lg"
+          className="min-w-[32rem] mx-4 border border-gray-200 dark:border-gray-800 rounded-lg md:mx-0 md:min-w-full"
           {...props}
         >
           {children}

--- a/tasks/plan035-mobile-readability-fix/index.json
+++ b/tasks/plan035-mobile-readability-fix/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan035-mobile-readability-fix",
   "description": "모바일 (390px) 본문 가독성 일괄 수정 — issues #136 #137 #138. (1) inline code 가 token 중간에 글자 단위로 wrap 되던 문제 (#136), (2) 테이블이 좁은 cell 폭에 강제 압축되고 가로 스크롤 불가 (#137), (3) 코드 블록 overflow-x:visible 회귀로 긴 라인 잘려보임 (#138). agent-browser iPhone 14 emulation 으로 실측 검증된 문제들. 사용자 핵심 사용 시나리오 (아침 모바일 글 읽기).",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-08",
   "total_phases": 2,
   "related_docs": [
@@ -18,14 +18,14 @@
       "file": "phase-01.md",
       "title": "inline code wrap 정책 + 테이블 wrapper + 코드 블록 overflow-x 일괄 수정 + 회귀 테스트",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + 모바일 smoke 가이드 + 3개 이슈 close + 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan035-mobile-readability-fix/index.json
+++ b/tasks/plan035-mobile-readability-fix/index.json
@@ -1,0 +1,31 @@
+{
+  "name": "plan035-mobile-readability-fix",
+  "description": "모바일 (390px) 본문 가독성 일괄 수정 — issues #136 #137 #138. (1) inline code 가 token 중간에 글자 단위로 wrap 되던 문제 (#136), (2) 테이블이 좁은 cell 폭에 강제 압축되고 가로 스크롤 불가 (#137), (3) 코드 블록 overflow-x:visible 회귀로 긴 라인 잘려보임 (#138). agent-browser iPhone 14 emulation 으로 실측 검증된 문제들. 사용자 핵심 사용 시나리오 (아침 모바일 글 읽기).",
+  "status": "pending",
+  "created_at": "2026-05-08",
+  "total_phases": 2,
+  "related_docs": [
+    "docs/pages/post-detail.md"
+  ],
+  "depends_on": [
+    "plan011-article-page-redesign",
+    "plan012-code-block-redesign",
+    "plan018-mobile-horizontal-scroll"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "inline code wrap 정책 + 테이블 wrapper + 코드 블록 overflow-x 일괄 수정 + 회귀 테스트",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "검증 + 모바일 smoke 가이드 + 3개 이슈 close + 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan035-mobile-readability-fix/phase-01.md
+++ b/tasks/plan035-mobile-readability-fix/phase-01.md
@@ -1,0 +1,206 @@
+# Phase 01 — 모바일 가독성 3개 fix 일괄 + 회귀 테스트
+
+**Model**: sonnet
+**Goal**: 모바일 (390px) 글 상세 페이지의 본문 inline code / 테이블 / 코드 블록 가독성 회복.
+
+## Context (자기완결)
+
+agent-browser (Chrome for Testing) iPhone 14 (390×844, dpr=3) emulation 으로 https://blog.fosworld.co.kr/posts/database/mysql/mysql-index-explain-commerce-api.md 확인 시 **3개 가독성 회귀** 발견:
+
+### 문제 1 — inline code token 단위 wrap 안 됨 (issue #136)
+
+prose 내 `:not(pre) > code` 의 computed style:
+- `word-break: break-all`
+- `overflow-wrap: anywhere`
+
+두 속성이 동시 적용되면 모든 글자 사이에서 wrap 가능 → token 보존이 깨짐.
+
+실측 사례:
+- `EXPLAIN` → `EXPL` `AIN` 두 줄
+- `created_at` → `c` `reated_at`
+- `database/mysql/mysql-innodb-index.md` 도 글자 단위 깨짐
+
+원인: plan018 (mobile horizontal scroll guard) 에서 페이지 가로 overflow 만 막으려고 prose 전체에 너무 공격적인 `word-break: break-all` 적용.
+
+### 문제 2 — 테이블 가로 스크롤 wrapper 부재 (issue #137)
+
+GFM 테이블이 `width: 100%` 로 viewport 강제 fit 됨. 좁은 cell 폭에 안의 inline code 가 더 심하게 깨짐.
+
+실측 사례 — EXPLAIN 핵심 필드 표:
+- 첫 컬럼 `필드` width 67px → `type`, `key`, `key_len` 등이 한 글자씩 세로로 깨짐
+- 둘째 컬럼 `무엇을 보는가` 274px → `const, eq_ref, ref, range...` 부자연스럽게 끊김
+
+가로 스크롤 wrapper (`overflow-x: auto`) 도 없어 손가락 가로 스크롤 불가.
+
+### 문제 3 — 코드 블록 overflow-x visible 회귀 (issue #138)
+
+`pre` 의 computed style:
+- `overflow: visible`, `overflow-x: visible`
+- `scrollWidth: 501px`, `clientWidth: 340px`
+
+긴 SQL/명령 라인이 viewport 밖으로 잘려 보이고 가로 스크롤도 불가.
+
+원인 추정: plan012 (code block redesign) 의 `.code-card-body pre` selector 가 어디선가 회귀됐거나 prose `pre` selector specificity 충돌.
+
+## 작업 항목
+
+### 1. `src/app/globals.css` — inline code wrap 정책 분리 (#136)
+
+현재 prose 전반에 적용된 word-break 룰을 inline code 한정으로 완화. 새 룰을 prose 영역 끝에 추가 (specificity 우선):
+
+```css
+.prose :not(pre) > code,
+.prose :not(pre) code {
+  /* token 단위 wrap 보존 (한국어 어절 + 영문 식별자) */
+  word-break: keep-all;
+  /* 너무 긴 token (200+ chars hash 등) 만 끊김 허용 — 안전망 */
+  overflow-wrap: anywhere;
+}
+```
+
+**중요**:
+- `word-break: keep-all` 만 두면 viewport 보다 긴 단일 token 이 horizontal overflow 유발 가능 → `overflow-wrap: anywhere` 가 fallback (정상 token 길이 10~30 chars 는 wrap 안 됨, 200 chars 같은 극단만 발동)
+- pre 안 코드 (`pre code`) 는 영향 받지 않게 selector 명확히 — 위 selector 의 `:not(pre)` parent 검사
+
+선택자 점검:
+```bash
+# 어떤 selector 가 inline code 에 word-break: break-all 을 적용 중인지 grep
+grep -nE "word-break|overflow-wrap" src/app/globals.css
+```
+
+기존 `word-break: break-all` 룰을 prose 전반에서 제거하고 inline code / table cell 등 좁은 영역만 명시적으로 적용. 또는 위 새 룰이 specificity 로 우선 적용되면 기존 룰 유지 가능 (적용 후 verify).
+
+### 2. `src/components/markdown/components.tsx` — 테이블 wrapper override (#137)
+
+`createMarkdownComponents` 의 `table` 키에 div wrapper override 추가:
+
+```tsx
+table: ({ children, ...props }: ComponentProps<'table'>) => (
+  <div className="prose-table-wrapper my-6 -mx-4 overflow-x-auto md:mx-0">
+    <table className="min-w-[32rem] mx-4 md:mx-0" {...props}>
+      {children}
+    </table>
+  </div>
+),
+```
+
+설명:
+- `-mx-4` 로 모바일에서 prose padding 을 넘어 wrapper 가 viewport 끝까지 확장 → 가로 스크롤 영역 넓힘
+- `min-width: 32rem (512px)` 로 cell 폭 강제 압축 방지 → 가로 스크롤 가능
+- `md:mx-0` / `md:` 로 데스크톱은 기존 동작 유지 (overflow 안 발생)
+- `prose-table-wrapper` className 으로 globals.css 추가 polish 가능 (지금은 OOS)
+
+`createMarkdownComponents` 위치 확인:
+```bash
+grep -n "table:" src/components/markdown/components.tsx
+```
+
+기존 table override 가 이미 있으면 그 자리에 추가, 없으면 신규 키 추가.
+
+### 3. `src/app/globals.css` — 코드 블록 overflow-x 명시 (#138)
+
+prose 코드 블록 + plan012 `.code-card` wrapper 양쪽 selector 모두 가로 스크롤 활성:
+
+```css
+.prose pre,
+.code-card-body pre {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+```
+
+`.code-card` 자체에 `overflow: hidden` 이 있다면 inner `pre` 의 가로 스크롤이 안 됨 — 그 경우 `.code-card { overflow: visible; }` 후 `.code-card-body { overflow-x: auto; }` 로 정정 필요. 실제 selector 구조 확인:
+
+```bash
+grep -n "\.code-card" src/app/globals.css
+```
+
+발견된 룰의 구조에 따라:
+- `.code-card-body pre` 가 명시되어 있으면 거기 `overflow-x: auto` 추가
+- 없으면 위 selector 그대로 추가
+
+### 4. 회귀 테스트 — `MarkdownRenderer.regression-3.test.ts` 신규
+
+source 파일 grep 으로 selector 존재 검증:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("plan035 모바일 가독성 룰 회귀 가드", () => {
+  const css = readFileSync(join(__dirname, "../app/globals.css"), "utf-8");
+  const components = readFileSync(
+    join(__dirname, "markdown/components.tsx"),
+    "utf-8"
+  );
+
+  it("inline code 에 word-break: keep-all 룰 존재", () => {
+    expect(css).toMatch(/word-break:\s*keep-all/);
+  });
+
+  it("inline code 에 overflow-wrap: anywhere 룰 존재 (fallback)", () => {
+    expect(css).toMatch(/overflow-wrap:\s*anywhere/);
+  });
+
+  it("코드 블록 overflow-x: auto 룰 존재", () => {
+    expect(css).toMatch(/overflow-x:\s*auto/);
+  });
+
+  it("테이블 override 가 overflow-x-auto wrapper 사용", () => {
+    expect(components).toMatch(/overflow-x-auto/);
+  });
+
+  it("테이블 override 가 min-width 명시", () => {
+    expect(components).toMatch(/min-w-\[32rem\]/);
+  });
+});
+```
+
+### 5. 자동 verification
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+
+grep -nE "word-break:\s*keep-all" src/app/globals.css
+grep -nE "overflow-x:\s*auto" src/app/globals.css
+grep -n "overflow-x-auto" src/components/markdown/components.tsx
+grep -n "min-w-\[32rem\]" src/components/markdown/components.tsx
+```
+
+### 6. 모바일 smoke (사용자 안내)
+
+`pnpm dev` 후 다음 페이지 모바일 viewport (Chrome DevTools mobile / agent-browser iPhone 14) 확인:
+
+| URL | 검증 |
+|---|---|
+| `/posts/database/mysql/mysql-index-explain-commerce-api.md` | EXPLAIN 표 가로 스크롤 + 컬럼 폭 회복 + inline code (`type`, `key_len`) token 보존 |
+| `/posts/database/mysql/mysql-index-explain-commerce-api.md` (스크롤) | SQL 코드 블록 가로 스크롤 동작 + `SELECT id, store_id, status, total_price` 끝까지 |
+| 본문 일반 prose | `EXPLAIN`, `created_at` 등 inline code token 단위 wrap 유지 |
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/globals.css` | 수정 (inline code wrap + code block overflow-x) |
+| `src/components/markdown/components.tsx` | 수정 (table wrapper override) |
+| `src/components/MarkdownRenderer.regression-3.test.ts` | 신규 (회귀 가드) |
+
+## Out of Scope
+
+- 데스크톱 시각 변경 — 모든 룰은 모바일 영향 위주, 데스크톱 동일 보존
+- 코드 블록 디자인 변경 (plan012 결과 보존)
+- 테이블 디자인 변경 (단순 wrapper 만)
+- prose 다른 영역 (이미지 / 인용 / 리스트) — 별도 plan 필요 시 후속
+
+## Risks & Mitigations
+
+| 리스크 | 완화 |
+|---|---|
+| `word-break: keep-all` 으로 한국어 긴 어절이 잘 안 끊겨 horizontal overflow 발생 | `overflow-wrap: anywhere` fallback 으로 viewport 보다 긴 token 자동 wrap. 일반 한국어 어절 (3~5 chars) 은 영향 없음 |
+| 테이블 wrapper 의 `-mx-4` 가 다른 prose 요소와 충돌 | wrapper 는 div 단일 자식 — Z-index / position 영향 없음. wrapping 은 명시적 (`<table>` 만 affected) |
+| `.code-card { overflow: hidden }` 충돌로 inner pre 스크롤 막힘 | phase 시작 시 globals.css 의 `.code-card` 룰 grep → overflow 충돌 발견 시 wrapper / inner 분리 정정 |
+| 회귀 테스트가 source grep 만 — 실제 렌더 결과 미검증 | 모바일 smoke 가이드 (작업 6) 필수 — 사용자 또는 executor 가 시각 확인 |

--- a/tasks/plan035-mobile-readability-fix/phase-02.md
+++ b/tasks/plan035-mobile-readability-fix/phase-02.md
@@ -1,0 +1,35 @@
+# Phase 02 — 검증 + smoke 가이드 + issue close + 마킹
+
+**Model**: haiku
+
+## 작업 항목
+
+### 1. 검증
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test --run
+pnpm build
+```
+
+### 2. `docs/pages/post-detail.md` 갱신
+
+본문 영역 모바일 정책 1단락 추가:
+- inline code: token 보존 wrap (keep-all + overflow-wrap)
+- 테이블: 모바일 가로 스크롤 wrapper
+- 코드 블록: 가로 스크롤 명시
+
+### 3. issue close
+
+PR body 에 `Closes #136 #137 #138` 명시.
+
+### 4. index.json status 마킹
+
+phase 1/2 + 최상위 `status` = `"completed"`.
+
+### 5. verification
+
+```bash
+grep -n "\"completed\"" tasks/plan035-mobile-readability-fix/index.json | wc -l  # 3
+```


### PR DESCRIPTION
## Summary

모바일 (390px) 글 상세 본문 가독성 회귀 3건 일괄 수정 (plan035).

- **inline code (#136)**: `word-break: break-all` 로 인해 식별자 (`EXPLAIN`, `created_at`) 가 글자 단위로 깨지던 문제. `keep-all` + `overflow-wrap: anywhere` 조합으로 token 보존, 단일 token 이 viewport 보다 긴 극단 케이스만 끊김 허용.
- **GFM 테이블 (#137)**: `components.table` override 가 `-mx-4 overflow-x-auto md:mx-0` wrapper + `min-w-[32rem]` 로 모바일 가로 스크롤 제공. 데스크톱은 `md:min-w-full` 로 기존 동작 유지.
- **코드 블록 (#138)**: `.prose .code-card-body pre` 에 자체 `overflow-x: auto` 추가. 부모 `.code-card { overflow: hidden }` 안에서도 긴 SQL/명령 라인 가로 스크롤 동작.

## Test plan

- [x] `pnpm lint` PASS
- [x] `pnpm type-check` PASS
- [x] `pnpm test --run` PASS (246 tests, +5 신규 회귀 테스트 `MarkdownRenderer.regression-3.test.ts`)
- [x] `pnpm build` PASS
- [ ] 모바일 smoke (사용자 검증):
  - `/posts/database/mysql/mysql-index-explain-commerce-api.md` — EXPLAIN 표 가로 스크롤 + inline code token 보존 + SQL 코드 블록 가로 스크롤

## docs

`docs/pages/post-detail.md` Constraints 섹션에 모바일 가독성 정책 1단락 추가.

Closes #136 #137 #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)