### PR TITLE
fix(prose): blockquote 우측 padding 추가 (모바일 가독성)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,7 +113,7 @@
   --prose-meta-size: 12px;          /* h2::before / code-card-head / line-number */
   --prose-label-size: 10px;         /* blockquote QUOTE / .lang */
   --prose-block-margin: 24px 0;     /* blockquote / code-card 외곽 vertical margin */
-  --prose-blockquote-padding: 4px 0 4px 20px;
+  --prose-blockquote-padding: 8px 16px 8px 20px;
   --prose-code-padding: 1px 6px;    /* inline code */
   --prose-codeblock-header-padding: 10px 14px;
   --prose-codeblock-padding: 16px 20px;


### PR DESCRIPTION
## Summary

`--prose-blockquote-padding` 이 `4px 0 4px 20px` 로 우측이 0 이라 모바일에서 인용 텍스트가 prose container 우측 끝까지 닿아 부자연스러웠음. 우측 16px / 상하 8px 로 균형 보정.

## 변경

```diff
- --prose-blockquote-padding: 4px 0 4px 20px;
+ --prose-blockquote-padding: 8px 16px 8px 20px;
```

좌측 20px (brand teal 보더 + padding) 강조는 유지, 우측에 16px 여유 추가.

## 검증

- agent-browser iPhone 14 emulation 으로 발견
- pnpm lint / type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
