### PR TITLE
fix(ci): add 15-min timeout to claude-code-review job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,6 +17,10 @@ jobs:
          contains(github.event.comment.body, '/review'))
       )
     runs-on: ubuntu-latest
+    # 정상 리뷰는 5~10분 내 완료. claude-code-action 이 hang 하는 경우
+    # (issue anthropics/claude-code-action#1290 등) GitHub Actions 기본 360분까지 대기되어
+    # 이전 stuck run 이 1.5시간 동안 방치된 사고 발생 — job-level timeout 으로 자동 fail.
+    timeout-minutes: 15
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
     # 같은 PR에 대해 동시에 실행 중인 이전 리뷰 run을 취소하여 중복 코멘트 방지


### PR DESCRIPTION
## Summary

`claude-code-review.yml` 워크플로우의 job-level `timeout-minutes: 15` 추가.

## 배경

PR #134 의 Claude 코드 리뷰 run (`25536859969`) 이 04:31 시작 후 1.5시간째 멈춰 있어 수동 cancel. 원인:

- `claude-code-action` 이 가끔 hang (이미 코드 주석에 `claude-code-action#1290 (2026-05-06 회귀)` 이슈로 v1.0.111 pin 처리 흔적)
- 워크플로우에 `timeout-minutes` 미설정 → GitHub Actions 기본값 **360분 (6시간)** 까지 대기
- `concurrency.cancel-in-progress: true` 는 같은 PR 에 새 run 이 진입해야 이전 취소 → 단독 hang 미보호

## 수정

job-level `timeout-minutes: 15` 추가. 정상 리뷰는 5~10분 내 완료되므로 15분이면 정상 케이스 영향 없고 hang 시 자동 fail.

## Test plan

- [x] yaml syntax 정합 (변경 4 라인 추가, 기존 구조 보존)
- [ ] 머지 후 다음 PR 의 review run 이 정상 시간 내 완료되는지 확인
- [ ] (스트레스 테스트) hang 시뮬레이션 — `/review` 명령 후 15분 시점에 자동 fail 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)