### PR TITLE
feat(sync): self-heal metadata drift via short-circuit recompute + UPSERT

### DIFF
--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -302,3 +302,10 @@ src/components/
 - **`HomeHero`** — `seriesCount` 실값 연결 (`countSeries()`).
 
 설계 의도 (RSS 2.0 vs Atom / pubDate=createdAt / 50 limit) 는 ADR-024 참조.
+
+---
+
+## sync 자가 치유 metadata (plan037)
+
+- **`CategoryRepository.syncAll(stats)`** — UPSERT (`onDuplicateKeyUpdate` on `name`) + orphan DELETE (`notInArray(categories.name, currentNames)`). 기존 `replaceAll` (DELETE all + INSERT all) 대체. id 안정성 + 변경 없는 row 의 `updatedAt` 미터치. `stats.length === 0` 분기로 빈 입력 시 전체 row 삭제 명시.
+- **`SyncService.sync` short-circuit path** — `lastSyncedSha === headSha` 분기에서도 `metadataSyncService.updateCategories()` + `syncFolderReadmes()` 호출. posts 변경 없어도 categories drift (예: GitHub 측 디렉터리 통째 삭제 후 sync) 자가 치유. 응답 shape (`upToDate: true, deleted: 0`) 는 그대로 — metadata 재계산은 caller-invisible 부수효과.

--- a/src/infra/db/repositories/CategoryRepository.ts
+++ b/src/infra/db/repositories/CategoryRepository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, notInArray, sql } from "drizzle-orm";
 import { categoryIcons, DEFAULT_CATEGORY_ICON } from "../constants";
 import { categories, posts } from "../schema";
 import type { CategoryData } from "../types";
@@ -46,13 +46,30 @@ export class CategoryRepository extends BaseRepository {
     return categoryIcons[category] || DEFAULT_CATEGORY_ICON;
   }
 
-  async replaceAll(
-    stats: Array<{ name: string; slug: string; icon: string; postCount: number }>,
+  async syncAll(
+    stats: Array<{ name: string; slug: string; icon: string | null; postCount: number }>,
   ): Promise<void> {
     await this.db.transaction(async (tx) => {
-      await tx.delete(categories);
-      for (const stat of stats) {
-        await tx.insert(categories).values(stat);
+      if (stats.length > 0) {
+        await tx
+          .insert(categories)
+          .values(stats)
+          .onDuplicateKeyUpdate({
+            set: {
+              slug: sql`VALUES(${categories.slug})`,
+              icon: sql`VALUES(${categories.icon})`,
+              postCount: sql`VALUES(${categories.postCount})`,
+            },
+          });
+      }
+
+      const currentNames = stats.map((s) => s.name);
+      if (currentNames.length === 0) {
+        await tx.delete(categories);
+      } else {
+        await tx
+          .delete(categories)
+          .where(notInArray(categories.name, currentNames));
       }
     });
   }

--- a/src/services/MetadataSyncService.test.ts
+++ b/src/services/MetadataSyncService.test.ts
@@ -12,7 +12,7 @@ function makeMocks() {
   } as unknown as PostRepository;
 
   const categoryRepo = {
-    replaceAll: vi.fn().mockResolvedValue(undefined),
+    syncAll: vi.fn().mockResolvedValue(undefined),
   } as unknown as CategoryRepository;
 
   const folderRepo = {
@@ -33,7 +33,7 @@ describe("MetadataSyncService.updateCategories", () => {
     vi.clearAllMocks();
   });
 
-  it("getCategoryStats 결과를 replaceAll에 올바르게 매핑한다", async () => {
+  it("getCategoryStats 결과를 syncAll에 올바르게 매핑한다", async () => {
     const { postRepo, categoryRepo, folderRepo, githubApi } = makeMocks();
 
     vi.mocked(postRepo.getCategoryStats).mockResolvedValue([
@@ -45,7 +45,7 @@ describe("MetadataSyncService.updateCategories", () => {
     await service.updateCategories();
 
     expect(postRepo.getCategoryStats).toHaveBeenCalledOnce();
-    expect(categoryRepo.replaceAll).toHaveBeenCalledWith([
+    expect(categoryRepo.syncAll).toHaveBeenCalledWith([
       { name: "AI", slug: "AI", icon: "🤖", postCount: 5 },
       { name: "database", slug: "database", icon: "🗄️", postCount: 3 },
     ]);
@@ -61,12 +61,12 @@ describe("MetadataSyncService.updateCategories", () => {
     const service = new MetadataSyncService(categoryRepo, folderRepo, postRepo, githubApi);
     await service.updateCategories();
 
-    expect(categoryRepo.replaceAll).toHaveBeenCalledWith([
+    expect(categoryRepo.syncAll).toHaveBeenCalledWith([
       { name: "unknown-topic", slug: "unknown-topic", icon: "📁", postCount: 2 },
     ]);
   });
 
-  it("카테고리가 없으면 빈 배열로 replaceAll을 호출한다", async () => {
+  it("post 가 0 건이면 syncAll([]) 호출되어 모든 카테고리 row 삭제", async () => {
     const { postRepo, categoryRepo, folderRepo, githubApi } = makeMocks();
 
     vi.mocked(postRepo.getCategoryStats).mockResolvedValue([]);
@@ -74,6 +74,6 @@ describe("MetadataSyncService.updateCategories", () => {
     const service = new MetadataSyncService(categoryRepo, folderRepo, postRepo, githubApi);
     await service.updateCategories();
 
-    expect(categoryRepo.replaceAll).toHaveBeenCalledWith([]);
+    expect(categoryRepo.syncAll).toHaveBeenCalledWith([]);
   });
 });

--- a/src/services/MetadataSyncService.ts
+++ b/src/services/MetadataSyncService.ts
@@ -21,7 +21,7 @@ export class MetadataSyncService {
 
   async updateCategories(): Promise<void> {
     const stats = await this.postRepo.getCategoryStats();
-    await this.categoryRepo.replaceAll(
+    await this.categoryRepo.syncAll(
       stats.map((s) => ({
         name: s.category,
         slug: s.category,

--- a/src/services/SyncService.test.ts
+++ b/src/services/SyncService.test.ts
@@ -75,6 +75,8 @@ describe("SyncService.sync", () => {
     expect(result.upToDate).toBe(true);
     expect(result.commitSha).toBe(sha);
     expect(syncLogRepo.create).not.toHaveBeenCalled();
+    expect(metadataSyncService.updateCategories).toHaveBeenCalledTimes(1);
+    expect(metadataSyncService.syncFolderReadmes).toHaveBeenCalledTimes(1);
   });
 
   it("lastSyncedSha가 없으면 performFullSync를 호출한다", async () => {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -70,7 +70,9 @@ export class SyncService {
       );
 
       if (lastSyncedSha === headSha) {
-        log.info("이미 최신 상태입니다.");
+        log.info("이미 최신 상태 — posts 변경 없음, metadata 만 재계산");
+        await this.metadataSyncService.updateCategories();
+        await this.metadataSyncService.syncFolderReadmes();
         const titles = await this.postService.retitleAll();
         return {
           added: 0,

--- a/tasks/plan037-sync-self-healing-metadata/index.json
+++ b/tasks/plan037-sync-self-healing-metadata/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan037-sync-self-healing-metadata",
   "description": "Sync 의 metadata drift 자가 치유 (issue #145) — short-circuit path 에서도 updateCategories + syncFolderReadmes 호출. 동시에 CategoryRepository.replaceAll (DELETE+INSERT) 을 syncAll (UPSERT + orphan DELETE) 로 교체해 id 안정성 + 변경 없는 row 미터치. 다음 sync 1회로 잔존 카테고리 (go/css/react) 자동 정리.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-09",
   "total_phases": 2,
   "related_docs": [
@@ -14,14 +14,14 @@
       "file": "phase-01.md",
       "title": "CategoryRepository.syncAll (UPSERT + orphan DELETE) + SyncService short-circuit metadata recompute + 회귀 테스트",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + code-architecture.md 갱신 + #145 close + index.json 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- short-circuit path (`lastSyncedSha === headSha`) 에서도 `updateCategories` + `syncFolderReadmes` 호출 — posts 변경 없어도 categories drift 자가 복구 (issue #145 의 잔존 `go/css/react` 카테고리)
- `CategoryRepository.replaceAll` (DELETE+INSERT) → `syncAll` (UPSERT `onDuplicateKeyUpdate` + orphan DELETE `notInArray`) — id 안정성 + 변경 없는 row 의 `updatedAt` 미터치
- 응답 shape (`upToDate: true, deleted: 0`) 그대로 — metadata 재계산은 caller-invisible 부수효과

Closes #145

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test --run` (246 tests passed)
- [x] `pnpm build`
- [x] `SyncService.test.ts` short-circuit case 에 `updateCategories`/`syncFolderReadmes` 호출 횟수 assertion
- [x] `MetadataSyncService.test.ts` 빈 stats 케이스 (`syncAll([])` 호출 검증)
- [ ] 수동 smoke (production sync 재호출 → /categories 페이지에서 잔존 카테고리 사라짐 확인) — 머지 후

## Notes

- mode B (사후 검수) 진행. code-reviewer + docs-verifier 모두 PASS
- code-reviewer LOW (non-blocking): `sql\`VALUES(\${categories.col})\`` 는 MySQL 8.0.20+ deprecated warning 대상. 비-deprecated 대체는 row alias (`INSERT ... AS new ON DUPLICATE KEY UPDATE col = new.col`) — 후속 plan 후보
- docs-verifier: plan037 자체 PASS. 별도로 plan033 머지 시 발생한 ADR-025 Index drift 발견 (이번 PR scope 외, 별도 docs PR 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)