### PR TITLE
fix(sync): deactive EXCLUDED files on incremental remove/rename + backfill

### DIFF
--- a/drizzle/0007_deactivate_excluded_filenames.sql
+++ b/drizzle/0007_deactivate_excluded_filenames.sql
@@ -1,0 +1,15 @@
+-- Deactivate posts that were synced before EXCLUDED_FILENAMES policy was added.
+-- Idempotent — only touches is_active=1 rows whose path basename is an EXCLUDED filename.
+UPDATE posts
+SET is_active = 0
+WHERE is_active = 1
+  AND UPPER(SUBSTRING_INDEX(path, '/', -1)) IN (
+    'README.MD',
+    'AGENTS.MD',
+    'CLAUDE.MD',
+    'GEMINI.MD',
+    'COPILOT.MD',
+    'CURSOR.MD',
+    'CODERABBIT.MD',
+    'CODY.MD'
+  );

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,660 @@
+{
+  "id": "e43c996c-3843-4b07-9bb9-a416be934d6b",
+  "prevId": "f0ddf875-5e64-4317-99e4-63c727165fad",
+  "version": "5",
+  "dialect": "mysql",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_id": {
+          "name": "categories_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_slug": {
+          "name": "post_slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "post_slug_idx": {
+          "name": "post_slug_idx",
+          "columns": [
+            "post_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comments_id": {
+          "name": "comments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "path_idx": {
+          "name": "path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "folders_path_unique": {
+          "name": "folders_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folders": {
+          "name": "folders",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "series": {
+          "name": "series",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_order": {
+          "name": "series_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "category_idx": {
+          "name": "category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "posts_updated_at_id_idx": {
+          "name": "posts_updated_at_id_idx",
+          "columns": [
+            "`updated_at` DESC",
+            "`id` DESC"
+          ],
+          "isUnique": false
+        },
+        "series_idx": {
+          "name": "series_idx",
+          "columns": [
+            "series"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "posts_id": {
+          "name": "posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "posts_path_unique": {
+          "name": "posts_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posts_added": {
+          "name": "posts_added",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_updated": {
+          "name": "posts_updated",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_deleted": {
+          "name": "posts_deleted",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_logs_id": {
+          "name": "sync_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_logs": {
+      "name": "visit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visited_date": {
+          "name": "visited_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "visit_page_ip_date_idx": {
+          "name": "visit_page_ip_date_idx",
+          "columns": [
+            "page_path",
+            "ip_hash",
+            "visited_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_logs_id": {
+          "name": "visit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "visit_stats": {
+      "name": "visit_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "visit_stats_page_path_idx": {
+          "name": "visit_stats_page_path_idx",
+          "columns": [
+            "page_path"
+          ],
+          "isUnique": true
+        },
+        "visit_stats_count_path_idx": {
+          "name": "visit_stats_count_path_idx",
+          "columns": [
+            "`visit_count` DESC",
+            "`page_path` ASC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "visit_stats_id": {
+          "name": "visit_stats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "posts_updated_at_id_idx": {
+        "columns": {
+          "`updated_at` DESC": {
+            "isExpression": true
+          },
+          "`id` DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "visit_stats_count_path_idx": {
+        "columns": {
+          "`visit_count` DESC": {
+            "isExpression": true
+          },
+          "`page_path` ASC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778219204772,
       "tag": "0006_amused_professor_monster",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "5",
+      "when": 1778420075632,
+      "tag": "0007_deactivate_excluded_filenames",
+      "breakpoints": true
     }
   ]
 }

--- a/src/services/SyncService.test.ts
+++ b/src/services/SyncService.test.ts
@@ -7,6 +7,7 @@ import type { PostService } from "./PostService";
 import type { PostRepository } from "@/infra/db/repositories/PostRepository";
 import type { SyncLogRepository } from "@/infra/db/repositories/SyncLogRepository";
 import type {
+  ChangedFile,
   getChangedFilesSince,
   getCurrentHeadSha,
   getDirectoryContents,
@@ -39,6 +40,7 @@ function makeMocks() {
   const postRepo = {
     getAllForSync: vi.fn().mockResolvedValue([]),
     deactivateByIds: vi.fn().mockResolvedValue(0),
+    deactive: vi.fn().mockResolvedValue(true),
   } as unknown as PostRepository;
 
   const syncLogRepo = {
@@ -114,6 +116,23 @@ describe("SyncService.sync", () => {
     expect(syncLogRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({ status: "success" }),
     );
+  });
+
+  it("incremental sync — README.md (EXCLUDED) 가 removed 이벤트로 들어와도 deactive 호출", async () => {
+    const { postSyncService, metadataSyncService, postService, postRepo, syncLogRepo, githubApi } = makeMocks();
+    const headSha = "newsha";
+    const lastSha = "oldsha";
+
+    vi.mocked(githubApi.getCurrentHeadSha).mockResolvedValue(headSha);
+    vi.mocked(syncLogRepo.getLatest).mockResolvedValue({ commitSha: lastSha } as SyncLog);
+    vi.mocked(githubApi.getChangedFilesSince).mockResolvedValue([
+      { status: "removed", filename: "css/FlexBox/README.md" },
+    ] as ChangedFile[]);
+
+    const service = new SyncService(postSyncService, metadataSyncService, postService, postRepo, syncLogRepo, githubApi);
+    await service.sync();
+
+    expect(postRepo.deactive).toHaveBeenCalledWith("css/FlexBox/README.md");
   });
 
   it("에러 발생 시 syncLogRepo.create({ status: 'failed' })를 호출하고 에러를 다시 던진다", async () => {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -256,13 +256,11 @@ export class SyncService {
 
     for (const file of changedFiles) {
       if (file.status === "removed") {
-        if (shouldSyncFile(file.filename)) {
-          const ok = await this.postRepo.deactive(file.filename);
-          if (ok) deleted++;
-          log.info({ filename: file.filename }, `삭제: ${file.filename}`);
-        }
+        const ok = await this.postRepo.deactive(file.filename);
+        if (ok) deleted++;
+        log.info({ filename: file.filename }, `삭제: ${file.filename}`);
       } else if (file.status === "renamed") {
-        if (file.previous_filename && shouldSyncFile(file.previous_filename)) {
+        if (file.previous_filename) {
           const ok = await this.postRepo.deactive(file.previous_filename);
           if (ok) deleted++;
           log.info({ filename: file.previous_filename }, `이름 변경(삭제): ${file.previous_filename}`);

--- a/tasks/plan038-sync-excluded-deactivate/index.json
+++ b/tasks/plan038-sync-excluded-deactivate/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan038-sync-excluded-deactivate",
   "description": "incremental sync 의 removed/renamed 분기에서 EXCLUDED 파일 (README.MD 등) 이 deactivate 안 되는 버그 fix + 과거 sync 됐던 EXCLUDED 잔존 row (예: id=17 css/FlexBox/README.md) 를 Drizzle migration SQL 로 일괄 is_active=0 백필. 재발 차단 + 잔존 정리.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-10",
   "total_phases": 1,
   "related_docs": [
@@ -14,7 +14,7 @@
       "file": "phase-01.md",
       "title": "performIncrementalSync removed/renamed shouldSyncFile 가드 제거 + EXCLUDED 잔존 row 백필 migration + 회귀 테스트 + 검증 + 마킹",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `performIncrementalSync` 의 `removed`/`renamed` 분기에서 `shouldSyncFile` 가드 제거 — EXCLUDED 파일 (README.md / AGENTS.md 등) 이 GitHub 에서 삭제되거나 이름 변경돼도 DB row 가 deactivate 되도록 수정
- Drizzle custom migration `0007_deactivate_excluded_filenames.sql` — 과거 EXCLUDED 정책 추가 전 sync 됐던 잔존 row (예: `id=17 css/FlexBox/README.md`) 일괄 `is_active=0` 백필. 멱등 SQL (`is_active=1` 조건)
- `SyncService.test.ts` 회귀 테스트 — README.md 가 `removed` 이벤트로 들어와도 `deactive` 호출되는지 검증
- 신규 INSERT (renamed 의 새 이름 + 일반 upsert) 정책은 그대로 유지

## Why

plan037 self-heal 은 categories drift 만 정리했고, EXCLUDED 잔존 posts 는 `performFullSync` 에서만 처리됨. 평상 운영에서 incremental 만 도는 한 영구 잔존 — 사용자 보고 사례 (`css/FlexBox/README.md` 가 fos-study 폴더 통째 삭제 후에도 살아있음) 가드.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test --run` (247 tests passed, 신규 케이스 +1)
- [x] `pnpm build`
- [x] guard 제거 grep 검증
- [x] migration SQL + journal entry 존재 + snapshot 동기

## Notes

- mode B/C 혼합 진행 (옵션 B 별도 -impl 브랜치 + 모드 C team-lead 직접 처리)
- Drizzle `--custom` 명령 결과 SQL + `_journal.json` + `0007_snapshot.json` 3 파일 모두 commit 포함

Closes plan038

🤖 Generated with [Claude Code](https://claude.com/claude-code)