### PR TITLE
chore(tasks): mark plan028/029 as completed

### DIFF
--- a/tasks/plan028-rate-limit-policy/index.json
+++ b/tasks/plan028-rate-limit-policy/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan028-rate-limit-policy",
   "description": "Rate limit 정책 정리 (issues #113 + #82) — proxy.ts matcher 가 /api/ 전체를 제외하던 버그 수정. /api/sync 만 인증 Bearer 로 보호되므로 제외, 나머지 (/api/comments, /api/visit, /api/search, /api/og) 는 기존 1000/min/IP 한도 적용. /api/comments POST 의 댓글 스팸 차단 + DDoS 일반 보호.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-07",
   "total_phases": 2,
   "related_docs": [
@@ -14,14 +14,14 @@
       "file": "phase-01.md",
       "title": "proxy.ts matcher 변경 + 회귀 테스트 (rate limit 정책 적용)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + ADR-016 갱신 + index.json 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan029-markdown-sanitize/index.json
+++ b/tasks/plan029-markdown-sanitize/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan029-markdown-sanitize",
   "description": "Markdown 렌더 XSS 강화 (issues #84 + #79) — unified-pipeline 에 rehype-sanitize 도입. defaultSchema 확장으로 rehype-pretty-code 의 shiki span data-* + figure data-rehype-pretty-code-figure + heading id (rehype-slug) + footnote/GFM 표 등 정상 패턴 모두 보존. <script> / <iframe> / on* 핸들러 차단.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-07",
   "total_phases": 2,
   "related_docs": [
@@ -16,14 +16,14 @@
       "file": "phase-01.md",
       "title": "rehype-sanitize 도입 + pretty-code/slug allowlist + 회귀 테스트",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + ADR-020 갱신 + index.json 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

머지 후 `index.json` status 마킹이 누락된 사고 정리.

- **plan028-rate-limit-policy**: PR #116 머지 완료 → status `pending` → `completed`
- **plan029-markdown-sanitize**: PR #119 머지 완료 → status `pending` → `completed`

build-with-teams SKILL.md 의 "completed 마킹 ↔ 머지 정합" 가드 위반 — 그대로 두면 후속 plan 의 사전 검증 게이트에서 재실행 사고 가능.

## Out of Scope

- 코드 변경 없음 (마킹만)
- plan034 (PR #152 머지 대기) 와 plan039 (미실행) 는 별건

🤖 Generated with [Claude Code](https://claude.com/claude-code)