### PR TITLE
feat(rss): RSS feed lite path — content 컬럼 미로드 (plan045, #125)

### DIFF
--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -285,7 +285,7 @@ src/components/
 신규 라우트:
 
 - **`GET /rss.xml`** (`src/app/rss.xml/route.ts`) — RSS 2.0 XML. `runtime = "nodejs"`, `revalidate = 600` (10분). Cache-Control `s-maxage=600, stale-while-revalidate=86400`. `escapeXml()` 인라인 헬퍼로 모든 사용자 입력 sanitize. `<atom:link rel="self">` 포함.
-- **`PostRepository.getRecentActiveLite({ limit })`** (plan045) — `description` + `createdAt` 만 select, `isActive=true` 필터, `desc(createdAt)` 정렬. content 컬럼 미포함 — 캐시 미스 시 DB 트래픽 ~수MB → ~수KB 로 감소. RSS feed 가 description 만 사용하므로 content fallback 불요. description null 인 글은 빈 description 으로 RSS 출력 (suppress 안 함). 기존 `getRecentActive` 는 deprecated — 다른 호출자 없으면 제거 가능.
+- **`PostRepository.getRecentActiveLite({ limit })`** (plan045) — `content` 컬럼 미포함 (title/path/slug/category/subcategory/folders/description/createdAt select), `isActive=true` 필터, `desc(createdAt)` 정렬. 캐시 미스 시 DB 트래픽 ~수MB → ~수KB 로 감소. RSS feed 가 description 만 사용하므로 content fallback 불요. description null 인 글은 빈 description 으로 RSS 출력 (suppress 안 함). 기존 `getRecentActive` 는 deprecated — 다른 호출자 없으면 제거 가능.
 - **`src/app/layout.tsx`** — `metadata.alternates.types` 에 `application/rss+xml` link 추가 → Next.js 가 `<link rel="alternate" type="application/rss+xml" href="/rss.xml">` 자동 생성.
 - **Rate limit**: `/rss.xml` 은 `proxy.ts` matcher 의 catch-all 영역에 포함 — `rateLimit` middleware (1000/min/IP fixed window, RFC1918/봇 우회) 자연 적용. `sitemap.xml` 만 exclusions 에 명시되어 있음 — RSS 는 동일 정책 적용.
 - **Thundering herd**: 현재는 별도 mutex 없이 Next.js `revalidate=600` 만 의존. RSS reader polling 빈도 (보통 1시간+) 와 캐시 hit rate 가 충분히 높아 동시 다수 미스 사고 미관측. 향후 트래픽 증가 시 Promise singleton mutex 도입 검토 (plan025 unified-pipeline 의 `processorPromise` 패턴 재활용 가능).

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -17,7 +17,7 @@ const SITE_DESCRIPTION = "한 명의 백엔드 엔지니어가 매일 쌓는 학
 export async function GET() {
   try {
     const rss = createDefaultRSSService();
-    const posts = await rss.getRecentForFeed({ limit: 50 });
+    const posts = await rss.getRecentForFeedLite({ limit: 50 });
 
     const items = posts
       .map((p) => {
@@ -25,7 +25,7 @@ export async function GET() {
           .split("/")
           .map(encodeURIComponent)
           .join("/")}`;
-        const desc = extractDescription(p.content ?? p.description ?? "", 300);
+        const desc = extractDescription(p.description ?? "", 300);
         const pubDate = (p.createdAt ?? new Date()).toUTCString();
         return `
     <item>

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -99,6 +99,43 @@ export class PostRepository extends BaseRepository {
     }));
   }
 
+  async getRecentActiveLite({ limit = 50 }: { limit?: number } = {}): Promise<
+    Array<
+      Pick<
+        PostData,
+        | "title"
+        | "path"
+        | "slug"
+        | "category"
+        | "subcategory"
+        | "folders"
+        | "description"
+        | "createdAt"
+      >
+    >
+  > {
+    const result = await this.db
+      .select({
+        title: posts.title,
+        path: posts.path,
+        slug: posts.slug,
+        category: posts.category,
+        subcategory: posts.subcategory,
+        folders: posts.folders,
+        description: posts.description,
+        createdAt: posts.createdAt,
+      })
+      .from(posts)
+      .where(eq(posts.isActive, true))
+      .orderBy(desc(posts.createdAt))
+      .limit(limit);
+
+    return result.map((p) => ({
+      ...p,
+      folders: p.folders || [],
+    }));
+  }
+
   async getRecentPostsCursor(params: {
     limit: number;
     cursor?: { updatedAt: Date; id: number };

--- a/src/services/RSSService.test.ts
+++ b/src/services/RSSService.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRSSService } from "./RSSService";
+
+describe("RSSService.getRecentForFeedLite (plan045)", () => {
+  it("repo.getRecentActiveLite 결과를 그대로 반환", async () => {
+    const mockData = [
+      {
+        title: "A",
+        path: "x/a.md",
+        slug: "a",
+        category: "tech",
+        subcategory: null,
+        folders: [],
+        description: "desc A",
+        createdAt: new Date(),
+      },
+      {
+        title: "B",
+        path: "x/b.md",
+        slug: "b",
+        category: "tech",
+        subcategory: null,
+        folders: [],
+        description: null,
+        createdAt: new Date(),
+      },
+    ];
+    const repos = {
+      post: {
+        getRecentActive: vi.fn(),
+        getRecentActiveLite: vi.fn().mockResolvedValue(mockData),
+      },
+    };
+    const service = createRSSService(repos);
+    const result = await service.getRecentForFeedLite({ limit: 50 });
+    expect(repos.post.getRecentActiveLite).toHaveBeenCalledWith({ limit: 50 });
+    expect(result).toBe(mockData);
+  });
+
+  it("limit 미지정 시 50 기본값", async () => {
+    const repos = {
+      post: {
+        getRecentActive: vi.fn(),
+        getRecentActiveLite: vi.fn().mockResolvedValue([]),
+      },
+    };
+    const service = createRSSService(repos);
+    await service.getRecentForFeedLite();
+    expect(repos.post.getRecentActiveLite).toHaveBeenCalledWith({ limit: 50 });
+  });
+
+  it("기존 getRecentForFeed 는 그대로 동작 (회귀 보호)", async () => {
+    const mockData = [
+      {
+        title: "A",
+        path: "x/a.md",
+        slug: "a",
+        category: "tech",
+        subcategory: null,
+        folders: [],
+        description: "d",
+        content: "full md",
+        createdAt: new Date(),
+      },
+    ];
+    const repos = {
+      post: {
+        getRecentActive: vi.fn().mockResolvedValue(mockData),
+        getRecentActiveLite: vi.fn(),
+      },
+    };
+    const service = createRSSService(repos);
+    const result = await service.getRecentForFeed({ limit: 10 });
+    expect(repos.post.getRecentActive).toHaveBeenCalledWith({ limit: 10 });
+    expect(result).toBe(mockData);
+  });
+});

--- a/src/services/RSSService.ts
+++ b/src/services/RSSService.ts
@@ -14,8 +14,21 @@ export type RSSPostData = Pick<
   | "createdAt"
 >;
 
+export type RSSPostDataLite = Pick<
+  PostData,
+  | "title"
+  | "path"
+  | "slug"
+  | "category"
+  | "subcategory"
+  | "folders"
+  | "description"
+  | "createdAt"
+>;
+
 interface RSSPostRepository {
   getRecentActive(args: { limit?: number }): Promise<RSSPostData[]>;
+  getRecentActiveLite(args: { limit?: number }): Promise<RSSPostDataLite[]>;
 }
 
 interface RSSRepositories {
@@ -28,6 +41,11 @@ export function createRSSService(repos: RSSRepositories) {
       RSSPostData[]
     > {
       return repos.post.getRecentActive({ limit });
+    },
+    async getRecentForFeedLite({
+      limit = 50,
+    }: { limit?: number } = {}): Promise<RSSPostDataLite[]> {
+      return repos.post.getRecentActiveLite({ limit });
     },
   };
 }

--- a/tasks/plan045-rss-content-lite/index.json
+++ b/tasks/plan045-rss-content-lite/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan045-rss-content-lite",
   "description": "RSS feed 의 content 컬럼 매번 로드 회피 (issue #125). PostRepository.getRecentActiveLite 신규 (description + createdAt 만 select, content 미포함) + RSSService.getRecentForFeedLite + route.ts 호출 변경. description null 인 글은 빈 description 으로 RSS 출력. rate limit / thundering herd / docs 명문화는 docs/code-architecture.md 에 이미 갱신",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-19",
   "total_phases": 2,
   "related_docs": [
@@ -13,14 +13,14 @@
       "file": "phase-01.md",
       "title": "PostRepository / RSSService lite 메서드 신규 + route 호출 변경",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "회귀 테스트 + 통합 검증 + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `/rss.xml` 캐시 미스 시 `posts.content` (수십KB × 50개) 컬럼 select 회피. DB 트래픽 ~수MB → ~수KB.
- `PostRepository.getRecentActiveLite` 신규 (content 미포함 8 필드 select + `Pick<PostData, ...>` 반환 타입).
- `RSSService.getRecentForFeedLite` + `RSSPostDataLite` 타입.
- `/rss.xml` route 가 lite 호출 + `p.content ?? p.description` fallback 제거 (description null 인 글은 빈 `<description/>` 출력).
- 기존 `getRecentActive` / `getRecentForFeed` 그대로 보존 (호환성).
- `docs/code-architecture.md` lite path 설명 정합 (8 필드 select 명시).

Closes #125

## Test plan

- [x] `pnpm lint` / `pnpm type-check` / `pnpm test --run` / `pnpm build` 모두 통과
- [x] `RSSService.test.ts` 3 케이스 (lite pass-through / 기본 limit 50 / 기존 메서드 회귀 보호) PASS
- [x] BLG15 정적 검사 (select 키 ↔ Pick 키 1:1 일치)
- [ ] 머지 후 production 에서 `curl /rss.xml | head -50` smoke + DB query log 에서 `posts.content` 미선택 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)