### PR TITLE
fix(post-card): row variant 을 container query 로 좁은 부모 폭 대응

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -80,23 +80,23 @@ export function PostCard({
     <Link
       href={postHref(post.slug)}
       style={inlineStyle}
-      className="group relative grid grid-cols-[64px_1fr_auto] items-baseline gap-4 border-t border-[var(--color-border-subtle)] py-5 last:border-b md:grid-cols-[80px_1fr_180px_100px] md:gap-6 md:py-6"
+      className="group @container relative grid grid-cols-[64px_1fr_auto] items-baseline gap-4 border-t border-[var(--color-border-subtle)] py-5 last:border-b @md:grid-cols-[80px_1fr_180px_100px] @md:gap-6 @md:py-6"
     >
       <span className="self-center font-mono text-[11px] uppercase tracking-[0.06em] text-[var(--color-fg-faint)]">
         {num ? `— ${num}` : "—"}
       </span>
 
       <div className="min-w-0">
-        <div className="text-[16px] font-medium leading-snug tracking-tight text-[var(--color-fg-primary)] transition-colors duration-150 group-hover:text-[var(--color-brand-400)] md:text-[17px]">
+        <div className="text-[16px] font-medium leading-snug tracking-tight text-[var(--color-fg-primary)] transition-colors duration-150 group-hover:text-[var(--color-brand-400)] @md:text-[17px]">
           {post.title}
         </div>
         {post.description && (
-          <div className="mt-1.5 line-clamp-2 text-[13px] leading-relaxed text-[var(--color-fg-secondary)] md:text-[14px]">
+          <div className="mt-1.5 line-clamp-2 text-[13px] leading-relaxed text-[var(--color-fg-secondary)] @md:text-[14px]">
             {post.description}
           </div>
         )}
         {/* 모바일에선 cat/meta 를 본문 아래로 내림 */}
-        <div className="mt-2 flex items-center gap-3 font-mono text-[11px] text-[var(--color-fg-muted)] md:hidden">
+        <div className="mt-2 flex items-center gap-3 font-mono text-[11px] text-[var(--color-fg-muted)] @md:hidden">
           {showCategory && (
             <span
               className="inline-flex items-center gap-1.5 uppercase tracking-[0.04em]"
@@ -117,7 +117,7 @@ export function PostCard({
 
       {showCategory && (
         <div
-          className="hidden self-center items-center gap-2 font-mono text-[11px] uppercase tracking-[0.04em] md:flex"
+          className="hidden self-center items-center gap-2 font-mono text-[11px] uppercase tracking-[0.04em] @md:flex"
           style={{ color: "var(--cat-color)" }}
         >
           <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
@@ -125,7 +125,7 @@ export function PostCard({
         </div>
       )}
 
-      <div className="hidden self-center text-right font-mono text-[11px] leading-relaxed text-[var(--color-fg-muted)] md:block">
+      <div className="hidden self-center text-right font-mono text-[11px] leading-relaxed text-[var(--color-fg-muted)] @md:block">
         {formatDate(post.createdAt)}
         {viewCount !== undefined && (
           <>


### PR DESCRIPTION
## Summary
- `PostCard` row variant 가 viewport `md:` breakpoint 를 쓰고 있어, `RelatedPosts` 처럼 2열 grid 에 배치되어 카드 폭이 ~493px 로 줄어들면 고정 컬럼 (80px+180px+100px+gap 72px = 432px) 이 그대로 적용되어 1fr 제목 컬럼이 **61px** 로 압축되는 문제를 수정
- `@container` + `@md:` (Tailwind v4 내장 container query) 로 바꿔 부모 폭에 따라 자동 폴드 — 넓을 땐 4-col Editorial row, 좁을 땐 모바일 3-col row

## Before / After
| | 제목 컬럼 폭 | 카드 높이 |
|---|---|---|
| Before | 61px | 289~359px (5~6자씩 줄바꿈) |
| After | 307px | 160px |

## Test plan
- [x] `/posts/database/redis/pub-sub.md` "이런 글도" 섹션 제목이 한두 줄에 들어오는지 cmux browser 로 확인
- [x] 메인 페이지 row 리스트 (PostsInfiniteList) 회귀 없음 — 풀폭이라 동일 분기
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과

## Follow-up (별도 PR 후보)
- row variant 의 "—" 순번 컬럼은 모든 사용처에서 `index` prop 미전달 상태라 80px 공간이 dash 하나로 비어 있음. 순번 주입 vs 컬럼 제거를 별도로 논의 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)