### PR TITLE
chore(post-card): container query 정상화 + dash 컬럼 제거

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -73,63 +73,63 @@ export function PostCard({
   // variant === "row" (기본, Editorial row list)
   // @container 는 후손에게만 query scope 를 제공하므로 별도 래퍼에 부여한다
   return (
-    <div className="@container">
+    <div className="@container last:border-b last:border-[var(--color-border-subtle)]">
       <Link
         href={postHref(post.slug)}
         style={inlineStyle}
-        className="group relative grid grid-cols-[1fr_auto] items-baseline gap-4 border-t border-[var(--color-border-subtle)] py-5 last:border-b @lg:grid-cols-[1fr_180px_100px] @lg:gap-6 @lg:py-6"
+        className="group relative grid grid-cols-[1fr_auto] items-baseline gap-4 border-t border-[var(--color-border-subtle)] py-5 @lg:grid-cols-[1fr_180px_100px] @lg:gap-6 @lg:py-6"
       >
         <div className="min-w-0">
-        <div className="text-[16px] font-medium leading-snug tracking-tight text-[var(--color-fg-primary)] transition-colors duration-150 group-hover:text-[var(--color-brand-400)] @lg:text-[17px]">
-          {post.title}
+          <div className="text-[16px] font-medium leading-snug tracking-tight text-[var(--color-fg-primary)] transition-colors duration-150 group-hover:text-[var(--color-brand-400)] @lg:text-[17px]">
+            {post.title}
+          </div>
+          {post.description && (
+            <div className="mt-1.5 line-clamp-2 text-[13px] leading-relaxed text-[var(--color-fg-secondary)] @lg:text-[14px]">
+              {post.description}
+            </div>
+          )}
+          {/* 모바일에선 cat/meta 를 본문 아래로 내림 */}
+          <div className="mt-2 flex items-center gap-3 font-mono text-[11px] text-[var(--color-fg-muted)] @lg:hidden">
+            {showCategory && (
+              <span
+                className="inline-flex items-center gap-1.5 uppercase tracking-[0.04em]"
+                style={{ color: "var(--cat-color)" }}
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+                {getCategoryIcon(post.category)} {canonical}
+              </span>
+            )}
+            {viewCount !== undefined && (
+              <span className="inline-flex items-center gap-1">
+                <Eye className="h-3 w-3" />
+                {viewCount.toLocaleString()}
+              </span>
+            )}
+          </div>
         </div>
-        {post.description && (
-          <div className="mt-1.5 line-clamp-2 text-[13px] leading-relaxed text-[var(--color-fg-secondary)] @lg:text-[14px]">
-            {post.description}
+
+        {showCategory && (
+          <div
+            className="hidden self-center items-center gap-2 font-mono text-[11px] uppercase tracking-[0.04em] @lg:flex"
+            style={{ color: "var(--cat-color)" }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+            <span>{canonical}</span>
           </div>
         )}
-        {/* 모바일에선 cat/meta 를 본문 아래로 내림 */}
-        <div className="mt-2 flex items-center gap-3 font-mono text-[11px] text-[var(--color-fg-muted)] @lg:hidden">
-          {showCategory && (
-            <span
-              className="inline-flex items-center gap-1.5 uppercase tracking-[0.04em]"
-              style={{ color: "var(--cat-color)" }}
-            >
-              <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
-              {getCategoryIcon(post.category)} {canonical}
-            </span>
-          )}
+
+        <div className="hidden self-center text-right font-mono text-[11px] leading-relaxed text-[var(--color-fg-muted)] @lg:block">
+          {formatDate(post.createdAt)}
           {viewCount !== undefined && (
-            <span className="inline-flex items-center gap-1">
-              <Eye className="h-3 w-3" />
-              {viewCount.toLocaleString()}
-            </span>
+            <>
+              <br />
+              <span className="inline-flex items-center gap-1">
+                <Eye className="h-3 w-3" />
+                {viewCount.toLocaleString()}
+              </span>
+            </>
           )}
         </div>
-      </div>
-
-      {showCategory && (
-        <div
-          className="hidden self-center items-center gap-2 font-mono text-[11px] uppercase tracking-[0.04em] @lg:flex"
-          style={{ color: "var(--cat-color)" }}
-        >
-          <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
-          <span>{canonical}</span>
-        </div>
-      )}
-
-      <div className="hidden self-center text-right font-mono text-[11px] leading-relaxed text-[var(--color-fg-muted)] @lg:block">
-        {formatDate(post.createdAt)}
-        {viewCount !== undefined && (
-          <>
-            <br />
-            <span className="inline-flex items-center gap-1">
-              <Eye className="h-3 w-3" />
-              {viewCount.toLocaleString()}
-            </span>
-          </>
-        )}
-      </div>
       </Link>
     </div>
   );

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -11,8 +11,6 @@ interface PostCardProps {
   variant?: "row" | "grid";
   showCategory?: boolean;
   viewCount?: number;
-  /** row variant 에서 좌측에 표시되는 정렬 번호 (없으면 미표시) */
-  index?: number;
 }
 
 function getCategoryIcon(category: string): string {
@@ -28,7 +26,6 @@ export function PostCard({
   variant = "row",
   showCategory = true,
   viewCount,
-  index,
 }: PostCardProps) {
   const catColor = getCategoryColor(post.category);
   const canonical = toCanonicalCategory(post.category);
@@ -74,29 +71,25 @@ export function PostCard({
   }
 
   // variant === "row" (기본, Editorial row list)
-  const num = typeof index === "number" ? String(index + 1).padStart(3, "0") : null;
-
+  // @container 는 후손에게만 query scope 를 제공하므로 별도 래퍼에 부여한다
   return (
-    <Link
-      href={postHref(post.slug)}
-      style={inlineStyle}
-      className="group @container relative grid grid-cols-[64px_1fr_auto] items-baseline gap-4 border-t border-[var(--color-border-subtle)] py-5 last:border-b @md:grid-cols-[80px_1fr_180px_100px] @md:gap-6 @md:py-6"
-    >
-      <span className="self-center font-mono text-[11px] uppercase tracking-[0.06em] text-[var(--color-fg-faint)]">
-        {num ? `— ${num}` : "—"}
-      </span>
-
-      <div className="min-w-0">
-        <div className="text-[16px] font-medium leading-snug tracking-tight text-[var(--color-fg-primary)] transition-colors duration-150 group-hover:text-[var(--color-brand-400)] @md:text-[17px]">
+    <div className="@container">
+      <Link
+        href={postHref(post.slug)}
+        style={inlineStyle}
+        className="group relative grid grid-cols-[1fr_auto] items-baseline gap-4 border-t border-[var(--color-border-subtle)] py-5 last:border-b @lg:grid-cols-[1fr_180px_100px] @lg:gap-6 @lg:py-6"
+      >
+        <div className="min-w-0">
+        <div className="text-[16px] font-medium leading-snug tracking-tight text-[var(--color-fg-primary)] transition-colors duration-150 group-hover:text-[var(--color-brand-400)] @lg:text-[17px]">
           {post.title}
         </div>
         {post.description && (
-          <div className="mt-1.5 line-clamp-2 text-[13px] leading-relaxed text-[var(--color-fg-secondary)] @md:text-[14px]">
+          <div className="mt-1.5 line-clamp-2 text-[13px] leading-relaxed text-[var(--color-fg-secondary)] @lg:text-[14px]">
             {post.description}
           </div>
         )}
         {/* 모바일에선 cat/meta 를 본문 아래로 내림 */}
-        <div className="mt-2 flex items-center gap-3 font-mono text-[11px] text-[var(--color-fg-muted)] @md:hidden">
+        <div className="mt-2 flex items-center gap-3 font-mono text-[11px] text-[var(--color-fg-muted)] @lg:hidden">
           {showCategory && (
             <span
               className="inline-flex items-center gap-1.5 uppercase tracking-[0.04em]"
@@ -117,7 +110,7 @@ export function PostCard({
 
       {showCategory && (
         <div
-          className="hidden self-center items-center gap-2 font-mono text-[11px] uppercase tracking-[0.04em] @md:flex"
+          className="hidden self-center items-center gap-2 font-mono text-[11px] uppercase tracking-[0.04em] @lg:flex"
           style={{ color: "var(--cat-color)" }}
         >
           <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
@@ -125,7 +118,7 @@ export function PostCard({
         </div>
       )}
 
-      <div className="hidden self-center text-right font-mono text-[11px] leading-relaxed text-[var(--color-fg-muted)] @md:block">
+      <div className="hidden self-center text-right font-mono text-[11px] leading-relaxed text-[var(--color-fg-muted)] @lg:block">
         {formatDate(post.createdAt)}
         {viewCount !== undefined && (
           <>
@@ -137,7 +130,8 @@ export function PostCard({
           </>
         )}
       </div>
-    </Link>
+      </Link>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- 이전 PR #166 의 container query 적용에 미묘한 버그가 있었음 — `@container` 와 `@md:*` 를 같은 element 에 박았는데 Tailwind v4 의 container query 는 **후손에게만** query scope 를 제공함. desktop 분기가 어디서도 활성화되지 않고 mobile 레이아웃으로 폴드되어 있었음
- `@container` 를 별도 wrapper `<div>` 로 분리하고 임계값을 `@lg` (32rem=512px) 로 상향. RelatedPosts (493px) 는 mobile 풀폭, PostsInfiniteList (~992px) 는 desktop Editorial 3-col 분기
- row variant 의 좌측 80px dash/순번 컬럼 제거 — production 어디서도 `index` prop 을 넘기지 않고 시리즈 페이지는 `grid` variant + 외부 span 으로 자체 구현. dead code
- `PostCardProps.index` 타입도 함께 제거

## 측정값 (DOM `grid-template-columns`)

| 위치 | 카드 폭 | grid template | 제목 컬럼 |
|---|---|---|---|
| RelatedPosts ("이런 글도") | 493px | `1fr_auto` (mobile) | **477px** |
| PostsInfiniteList (메인) | 992px | `1fr_180px_100px` (desktop) | **664px** + 카테고리 + 날짜 우측 |

이전 PR #166 시점에서 측정했던 165px (4-col 강제 활성 시) / mobile 폴드된 상태와 비교해 깔끔한 분기가 잡힘.

## Test plan
- [x] `/posts/database/redis/pub-sub.md` "이런 글도" 4개 카드 제목 한 줄, 카드 높이 균일 확인 (playwright)
- [x] 메인 페이지 row 리스트 desktop 3-col 활성, 카테고리/날짜 우측 정렬 확인
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test` 277 passed

## Follow-up
- 시리즈 발견성 개선 (시리즈 인덱스 페이지 신설, 진입점 추가) — 별 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)