### PR TITLE
feat(series): plan047 — 시리즈 발견성 개선 (/series 인덱스 + 메인 섹션 + Header)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -536,6 +536,7 @@
 
 ---
 
+<a id="adr-028"></a>
 ## ADR-028. 시리즈 인덱스 카드는 별도 SeriesCard 컴포넌트 (plan047)
 
 - **결정**: 시리즈 인덱스 (`/series`) 와 메인 페이지 시리즈 섹션에서 사용할 카드는 `PostCard` 의 variant 가 아닌 신규 `SeriesCard` 컴포넌트로 분리한다. 도메인 필드 — 시리즈명, postCount, latestUpdatedAt, 대표 카테고리, 첫 글 description — 만 props 로 받는다.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,16 @@
 import { getRepositories } from "@/infra/db/repositories";
-import type { CategoryData, PostData } from "@/infra/db/types";
+import type { CategoryData, PostData, SeriesInfo } from "@/infra/db/types";
 import { env } from "@/env";
 import logger from "@/lib/logger";
 
 const log = logger.child({ module: "app/page" });
 import { CategoryList } from "@/components/CategoryList";
 import { PostCard } from "@/components/PostCard";
+import { SeriesCard } from "@/components/SeriesCard";
 import { SectionCTAButton } from "@/components/SectionCTAButton";
 import { WebsiteJsonLd } from "@/components/JsonLd";
 import { HomeHero } from "@/components/HomeHero";
-import { ArrowRight, Flame } from "lucide-react";
+import { ArrowRight, Flame, Layers } from "lucide-react";
 import Link from "next/link";
 
 const siteUrl = env.NEXT_PUBLIC_SITE_URL;
@@ -39,15 +40,17 @@ export default async function HomePage() {
   let visitCounts: Record<string, number> = {};
   let postCountTotal = 0;
   let seriesCount = 0;
+  let seriesList: SeriesInfo[] = [];
 
   try {
     const { category, post, visit } = getRepositories();
-    [categories, recentPosts, popularPosts, postCountTotal, seriesCount] = await Promise.all([
+    [categories, recentPosts, popularPosts, postCountTotal, seriesCount, seriesList] = await Promise.all([
       category.getCategories(),
       post.getRecentPosts(6),
       getPopularPosts(6),
       post.getActivePostCount(),
       post.countSeries(),
+      post.getAllSeries(4),
     ]);
 
     const postPaths = recentPosts.map((p) => p.path);
@@ -94,6 +97,24 @@ export default async function HomePage() {
               ))}
             </div>
             <SectionCTAButton href="/posts/popular" label="인기 글 더 보기" />
+          </section>
+        )}
+
+        {/* Series Section */}
+        {seriesList.length > 0 && (
+          <section className="mb-8 md:mb-16">
+            <div className="flex items-center gap-2 mb-4 md:mb-8">
+              <Layers className="w-6 h-6 text-[var(--color-brand-400)]" />
+              <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">
+                시리즈
+              </h2>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {seriesList.map((s) => (
+                <SeriesCard key={s.name} series={s} />
+              ))}
+            </div>
+            <SectionCTAButton href="/series" label="시리즈 더 보기" />
           </section>
         )}
 

--- a/src/app/series/page.tsx
+++ b/src/app/series/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { getRepositories } from "@/infra/db/repositories";
+import { PostsListSubHero } from "@/components/PostsListSubHero";
+import { SeriesCard } from "@/components/SeriesCard";
+import { env } from "@/env";
+
+const siteUrl = env.NEXT_PUBLIC_SITE_URL;
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: "시리즈",
+  description: "FOS Study 블로그의 모든 시리즈 모음",
+  alternates: { canonical: `${siteUrl}/series` },
+  openGraph: {
+    title: "시리즈 | FOS Study",
+    description: "FOS Study 블로그의 모든 시리즈 모음",
+    url: `${siteUrl}/series`,
+    type: "website",
+  },
+};
+
+export default async function SeriesIndexPage() {
+  const { post } = getRepositories();
+  const seriesList = await post.getAllSeries();
+
+  return (
+    <div className="container mx-auto max-w-[1180px] px-4">
+      <PostsListSubHero
+        eyebrow="SERIES"
+        title="시리즈"
+        meta={`${seriesList.length} SERIES`}
+      />
+      {seriesList.length === 0 ? (
+        <div className="py-16 text-center text-[var(--color-fg-muted)]">
+          아직 등록된 시리즈가 없습니다.
+        </div>
+      ) : (
+        <ul className="grid grid-cols-1 gap-6 pb-16 md:grid-cols-2">
+          {seriesList.map((s) => (
+            <li key={s.name}>
+              <SeriesCard series={s} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/series/page.tsx
+++ b/src/app/series/page.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
 import { getRepositories } from "@/infra/db/repositories";
+import logger from "@/lib/logger";
 import { PostsListSubHero } from "@/components/PostsListSubHero";
 import { SeriesCard } from "@/components/SeriesCard";
+import type { SeriesInfo } from "@/infra/db/types";
 import { env } from "@/env";
+
+const log = logger.child({ module: "app/series/page" });
 
 const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
@@ -21,8 +25,17 @@ export const metadata: Metadata = {
 };
 
 export default async function SeriesIndexPage() {
-  const { post } = getRepositories();
-  const seriesList = await post.getAllSeries();
+  let seriesList: SeriesInfo[] = [];
+
+  try {
+    const { post } = getRepositories();
+    seriesList = await post.getAllSeries();
+  } catch (error) {
+    log.warn(
+      { err: error instanceof Error ? error : new Error(String(error)) },
+      "Database not available"
+    );
+  }
 
   return (
     <div className="container mx-auto max-w-[1180px] px-4">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ThemeToggle } from "./ThemeToggle";
 import { SearchDialog } from "./SearchDialog";
-import { Book, Github, Home, Menu, X, Search, PanelLeft } from "lucide-react";
+import { Book, Github, Home, Layers, Menu, X, Search, PanelLeft } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useSidebar } from "./SidebarContext";
 import type { CSSProperties } from "react";
@@ -48,6 +48,7 @@ export function Header() {
   const navLinks = [
     { href: "/", label: "01 / 홈", icon: Home },
     { href: "/categories", label: "02 / 카테고리", icon: Book },
+    { href: "/series", label: "03 / 시리즈", icon: Layers },
   ];
 
   const isActive = (href: string) => {

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import { categoryIcons, DEFAULT_CATEGORY_ICON } from "@/infra/db/constants";
 import type { PostData } from "@/infra/db/types";
 import { getCategoryColor, toCanonicalCategory } from "@/lib/category-meta";
+import { formatDate } from "@/lib/date-utils";
 import { Eye } from "lucide-react";
 
 interface PostCardProps {
@@ -135,7 +136,3 @@ export function PostCard({
   );
 }
 
-function formatDate(date: Date | null | undefined): string {
-  if (!date || Number.isNaN(date.getTime())) return "";
-  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
-}

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import type { CSSProperties } from "react";
+import type { SeriesInfo } from "@/infra/db/types";
+import { getCategoryColor, toCanonicalCategory } from "@/lib/category-meta";
+
+interface SeriesCardProps {
+  series: SeriesInfo;
+}
+
+function seriesHref(name: string): string {
+  return `/series/${encodeURIComponent(name)}`;
+}
+
+function formatDate(date: Date | null | undefined): string {
+  if (!date || Number.isNaN(date.getTime())) return "";
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export function SeriesCard({ series }: SeriesCardProps) {
+  const catColor = getCategoryColor(series.firstPost.category);
+  const canonical = toCanonicalCategory(series.firstPost.category);
+  const inlineStyle = { "--cat-color": catColor } as CSSProperties;
+
+  return (
+    <Link
+      href={seriesHref(series.name)}
+      style={inlineStyle}
+      className="group flex flex-col overflow-hidden rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] transition-[border-color,transform] duration-[var(--duration-default)] ease-[var(--ease-out)] hover:-translate-y-0.5 hover:border-[var(--color-border-strong)] motion-reduce:transform-none motion-reduce:transition-none"
+    >
+      <div className="flex flex-1 flex-col gap-2 p-5">
+        <div className="flex items-center justify-between gap-2 font-mono text-[11px] uppercase tracking-[0.06em]">
+          <span className="flex items-center gap-2" style={{ color: "var(--cat-color)" }}>
+            <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+            <span>{canonical}</span>
+          </span>
+          <span className="text-[var(--color-fg-muted)]">{series.postCount} posts</span>
+        </div>
+        <h3 className="text-[17px] font-medium leading-snug tracking-tight text-[var(--color-fg-primary)] line-clamp-2">
+          {series.name}
+        </h3>
+        {series.firstPost.description && (
+          <p className="line-clamp-2 text-[13px] leading-relaxed text-[var(--color-fg-secondary)]">
+            {series.firstPost.description}
+          </p>
+        )}
+        <div className="mt-auto flex items-center justify-between gap-3 border-t border-[var(--color-border-subtle)] pt-3 font-mono text-[11px] text-[var(--color-fg-muted)]">
+          <span>{formatDate(series.latestUpdatedAt)}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -2,18 +2,11 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 import type { SeriesInfo } from "@/infra/db/types";
 import { getCategoryColor, toCanonicalCategory } from "@/lib/category-meta";
+import { formatDate } from "@/lib/date-utils";
+import { seriesHref } from "@/lib/path-utils";
 
 interface SeriesCardProps {
   series: SeriesInfo;
-}
-
-function seriesHref(name: string): string {
-  return `/series/${encodeURIComponent(name)}`;
-}
-
-function formatDate(date: Date | null | undefined): string {
-  if (!date || Number.isNaN(date.getTime())) return "";
-  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
 }
 
 export function SeriesCard({ series }: SeriesCardProps) {

--- a/src/infra/db/repositories/PostRepository.test.ts
+++ b/src/infra/db/repositories/PostRepository.test.ts
@@ -72,6 +72,128 @@ describe("PostRepository.getRecentPostsCursor", () => {
   });
 });
 
+describe("PostRepository.getAllSeries", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const aggDate = new Date("2024-02-01T00:00:00Z");
+  const aggDateOlder = new Date("2024-01-01T00:00:00Z");
+
+  function buildAggChain(rows: unknown[]) {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn().mockReturnValue(chain);
+    chain.where = vi.fn().mockReturnValue(chain);
+    chain.groupBy = vi.fn().mockReturnValue(chain);
+    chain.orderBy = vi.fn().mockReturnValue(chain);
+    chain.limit = vi.fn().mockResolvedValue(rows);
+    chain.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (e: unknown) => unknown,
+    ) => Promise.resolve(rows).then(onfulfilled, onrejected);
+    return chain;
+  }
+
+  function buildFirstPostChain(rows: unknown[]) {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn().mockReturnValue(chain);
+    chain.where = vi.fn().mockResolvedValue(rows);
+    return chain;
+  }
+
+  function makeRepoForSeries(aggregates: unknown[], firstPosts: unknown[]) {
+    const aggChain = buildAggChain(aggregates);
+    const fpChain = buildFirstPostChain(firstPosts);
+    let callCount = 0;
+    const db = {
+      select: vi.fn().mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? aggChain : fpChain;
+      }),
+    };
+    return { repo: new PostRepository(db as unknown as DbInstance), aggChain };
+  }
+
+  it("집계 결과 없으면 빈 배열 반환", async () => {
+    const { repo } = makeRepoForSeries([], []);
+    const result = await repo.getAllSeries();
+    expect(result).toEqual([]);
+  });
+
+  it("시리즈별 postCount + latestUpdatedAt + firstPost 반환", async () => {
+    const aggregates = [
+      { series: "A", postCount: "3", latestUpdatedAt: aggDate, minSeriesOrder: 1 },
+    ];
+    const firstPosts = [
+      {
+        title: "First A",
+        description: "desc A",
+        category: "cat",
+        slug: "first-a",
+        path: "cat/first-a.md",
+        series: "A",
+        seriesOrder: 1,
+      },
+    ];
+    const { repo } = makeRepoForSeries(aggregates, firstPosts);
+    const result = await repo.getAllSeries();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("A");
+    expect(result[0].postCount).toBe(3);
+    expect(result[0].latestUpdatedAt).toBe(aggDate);
+    expect(result[0].firstPost.path).toBe("cat/first-a.md");
+  });
+
+  it("집계 정렬(latestUpdatedAt DESC) 순서 유지", async () => {
+    const aggregates = [
+      { series: "B", postCount: "2", latestUpdatedAt: aggDate, minSeriesOrder: 1 },
+      { series: "A", postCount: "3", latestUpdatedAt: aggDateOlder, minSeriesOrder: 1 },
+    ];
+    const firstPosts = [
+      {
+        title: "First A",
+        description: null,
+        category: "cat",
+        slug: "first-a",
+        path: "cat/first-a.md",
+        series: "A",
+        seriesOrder: 1,
+      },
+      {
+        title: "First B",
+        description: null,
+        category: "cat",
+        slug: "first-b",
+        path: "cat/first-b.md",
+        series: "B",
+        seriesOrder: 1,
+      },
+    ];
+    const { repo } = makeRepoForSeries(aggregates, firstPosts);
+    const result = await repo.getAllSeries();
+    expect(result[0].name).toBe("B");
+    expect(result[1].name).toBe("A");
+  });
+
+  it("limit 지정 시 aggChain.limit 호출", async () => {
+    const aggregates = [
+      { series: "A", postCount: "1", latestUpdatedAt: aggDate, minSeriesOrder: 1 },
+    ];
+    const firstPosts = [
+      {
+        title: "T",
+        description: null,
+        category: "cat",
+        slug: "s",
+        path: "cat/s.md",
+        series: "A",
+        seriesOrder: 1,
+      },
+    ];
+    const { repo, aggChain } = makeRepoForSeries(aggregates, firstPosts);
+    await repo.getAllSeries(1);
+    expect(aggChain.limit).toHaveBeenCalledWith(1);
+  });
+});
+
 describe("tagIntersectionSize", () => {
   it("양쪽 빈 배열 → 0", () => {
     expect(tagIntersectionSize([], [])).toBe(0);

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -1,7 +1,7 @@
 import { and, asc, desc, eq, inArray, isNotNull, like, ne, or, sql } from "drizzle-orm";
 import { NewPost, posts } from "../schema";
 import { UpdatePost } from "../schema/posts";
-import type { PostData } from "../types";
+import type { PostData, SeriesInfo } from "../types";
 import { BaseRepository } from "./BaseRepository";
 import { env } from "@/env";
 import logger from "@/lib/logger";
@@ -592,6 +592,70 @@ export class PostRepository extends BaseRepository {
       );
       return [];
     }
+  }
+
+  async getAllSeries(limit?: number): Promise<SeriesInfo[]> {
+    const baseQuery = this.db
+      .select({
+        series: posts.series,
+        postCount: sql<string>`count(*)`,
+        latestUpdatedAt: sql<Date>`max(${posts.updatedAt})`,
+        minSeriesOrder: sql<number>`min(${posts.seriesOrder})`,
+      })
+      .from(posts)
+      .where(and(eq(posts.isActive, true), isNotNull(posts.series)))
+      .groupBy(posts.series)
+      .orderBy(sql`max(${posts.updatedAt}) desc`);
+
+    const aggregates =
+      typeof limit === "number" ? await baseQuery.limit(limit) : await baseQuery;
+    if (aggregates.length === 0) return [];
+
+    const tuples = aggregates.map(
+      (a) => sql`(${a.series}, ${a.minSeriesOrder})`,
+    );
+
+    const firstPosts = await this.db
+      .select({
+        title: posts.title,
+        description: posts.description,
+        category: posts.category,
+        slug: posts.slug,
+        path: posts.path,
+        series: posts.series,
+        seriesOrder: posts.seriesOrder,
+      })
+      .from(posts)
+      .where(
+        and(
+          eq(posts.isActive, true),
+          sql`(${posts.series}, ${posts.seriesOrder}) IN (${sql.join(tuples, sql`, `)})`,
+        ),
+      );
+
+    const firstPostByName = new Map(
+      firstPosts.flatMap((p) => (p.series === null ? [] : [[p.series, p] as const])),
+    );
+
+    return aggregates.flatMap((a) => {
+      if (a.series === null) return [];
+      const first = firstPostByName.get(a.series);
+      if (!first) return [];
+      return [
+        {
+          name: a.series,
+          postCount: Number(a.postCount),
+          latestUpdatedAt: a.latestUpdatedAt,
+          firstPost: {
+            title: first.title,
+            description: first.description,
+            category: first.category,
+            slug: first.slug,
+            path: first.path,
+          },
+        },
+      ];
+    });
   }
 
   async countSeries(): Promise<number> {

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -599,7 +599,7 @@ export class PostRepository extends BaseRepository {
       .select({
         series: posts.series,
         postCount: sql<string>`count(*)`,
-        latestUpdatedAt: sql<Date>`max(${posts.updatedAt})`,
+        latestUpdatedAt: sql<Date | null>`max(${posts.updatedAt})`,
         minSeriesOrder: sql<number>`min(${posts.seriesOrder})`,
       })
       .from(posts)

--- a/src/infra/db/types.ts
+++ b/src/infra/db/types.ts
@@ -38,7 +38,7 @@ export interface FolderContentsResult {
 export interface SeriesInfo {
   name: string;
   postCount: number;
-  latestUpdatedAt: Date;
+  latestUpdatedAt: Date | null;
   firstPost: {
     title: string;
     description: string | null;

--- a/src/infra/db/types.ts
+++ b/src/infra/db/types.ts
@@ -34,3 +34,16 @@ export interface FolderContentsResult {
   posts: PostData[];
   readme: string | null;
 }
+
+export interface SeriesInfo {
+  name: string;
+  postCount: number;
+  latestUpdatedAt: Date;
+  firstPost: {
+    title: string;
+    description: string | null;
+    category: string;
+    slug: string;
+    path: string;
+  };
+}

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { formatDate } from "./date-utils";
+
+describe("formatDate", () => {
+  it("returns YYYY.MM.DD with zero padding", () => {
+    expect(formatDate(new Date(2026, 0, 5))).toBe("2026.01.05");
+    expect(formatDate(new Date(2026, 11, 31))).toBe("2026.12.31");
+  });
+
+  it("returns empty string for null / undefined", () => {
+    expect(formatDate(null)).toBe("");
+    expect(formatDate(undefined)).toBe("");
+  });
+
+  it("returns empty string for Invalid Date", () => {
+    expect(formatDate(new Date("not-a-date"))).toBe("");
+  });
+});

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,4 @@
+export function formatDate(date: Date | null | undefined): string {
+  if (!date || Number.isNaN(date.getTime())) return "";
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+}

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -1,3 +1,7 @@
+export function seriesHref(name: string): string {
+  return `/series/${encodeURIComponent(name)}`;
+}
+
 /**
  * post 경로 목록에서 중간 폴더 경로 집합을 계산한다.
  * 예: ["AI/RAG/intro.md", "AI/basics.md"] → [["AI"], ["AI", "RAG"]]

--- a/tasks/plan047-series-discovery/index.json
+++ b/tasks/plan047-series-discovery/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan047-series-discovery",
   "description": "시리즈 발견성 개선 — plan033 의 OOS 였던 /series 인덱스 페이지 + 메인 페이지 시리즈 섹션 + Header navigation '03 / 시리즈' 진입점 추가. PostRepository.getAllSeries() 신설 (2 쿼리 N+1 회피). 시리즈 카드는 ADR-028 결정에 따라 PostCard variant 가 아닌 별도 SeriesCard 컴포넌트로 분리.",
-  "status": "in_progress",
+  "status": "completed",
   "created_at": "2026-05-21",
   "total_phases": 4,
   "related_docs": [
@@ -20,28 +20,28 @@
       "file": "phase-01.md",
       "title": "PostRepository.getAllSeries + SeriesInfo 타입 + 단위 테스트",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "SeriesCard 컴포넌트 + /series 인덱스 페이지",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "Header navLink + 메인 페이지 시리즈 섹션",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 4,
       "file": "phase-04.md",
       "title": "검증 + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan047-series-discovery/phase-01.md
+++ b/tasks/plan047-series-discovery/phase-01.md
@@ -48,7 +48,9 @@ export interface SeriesInfo {
 ```ts
 async getAllSeries(limit?: number): Promise<SeriesInfo[]> {
   // 1. 시리즈별 aggregate — postCount, latestUpdatedAt, minSeriesOrder 수집
-  let aggregateQuery = this.db
+  // Drizzle query builder 의 type narrowing 이슈 회피를 위해 inline chain 사용
+  // (기존 repo 의 getPostsByTag 등 동일 패턴)
+  const baseQuery = this.db
     .select({
       series: posts.series,
       postCount: sql<string>`count(*)`,
@@ -60,11 +62,8 @@ async getAllSeries(limit?: number): Promise<SeriesInfo[]> {
     .groupBy(posts.series)
     .orderBy(sql`max(${posts.updatedAt}) desc`);
 
-  if (typeof limit === "number") {
-    aggregateQuery = aggregateQuery.limit(limit);
-  }
-
-  const aggregates = await aggregateQuery;
+  const aggregates =
+    typeof limit === "number" ? await baseQuery.limit(limit) : await baseQuery;
   if (aggregates.length === 0) return [];
 
   // 2. 각 시리즈의 첫 글 (seriesOrder = minSeriesOrder) fetch
@@ -212,3 +211,4 @@ grep -n "interface SeriesInfo" src/infra/db/types.ts
 | MySQL row constructor IN 문법 호환성 | MySQL 5.7+ 지원. 본 프로젝트 8.4 → 문제 없음. 단 drizzle sql tag 로 직접 작성 — drizzle 의 자동 placeholder 가 row constructor 를 올바로 직렬화하는지 type-check 단계에서 검증 |
 | seriesOrder NULL 인 row 가 minSeriesOrder 에 섞임 | aggregate 단계의 `isNotNull(posts.series)` 가 series 자체를 필터. seriesOrder NULL 인 시리즈 글은 sync 시점에 series 도 null 로 떨어짐 (SyncService 정책, plan033). 따라서 안전 |
 | 시리즈명 NULL 으로 들어와 Map key 가 깨짐 | aggregate WHERE 절에 `isNotNull(posts.series)` 명시 — a.series 는 항상 non-null |
+| `SeriesInfo.latestUpdatedAt: Date` non-null 타입이 SQL MAX 의 nullable 결과와 충돌 | `aggregates.length === 0` 시 early return → 이후 MAX 는 그룹이 비어있지 않음이 보장되므로 항상 non-null. drizzle `sql<Date>` 단언은 이 invariant 에 의존 |

--- a/tasks/plan047-series-discovery/phase-03.md
+++ b/tasks/plan047-series-discovery/phase-03.md
@@ -66,6 +66,12 @@ import { SeriesCard } from "@/components/SeriesCard";
 import type { SeriesInfo, CategoryData, PostData } from "@/infra/db/types";
 ```
 
+`src/app/page.tsx` 의 기존 lucide-react import 확장 (현재 `ArrowRight, Flame` 만):
+
+```tsx
+import { ArrowRight, Flame, Layers } from "lucide-react";
+```
+
 #### 2b. JSX 섹션 추가
 
 기존 Popular Posts 섹션 닫는 `</section>` 직후, Recent Posts 섹션 열기 전에 삽입:


### PR DESCRIPTION
## Summary

- `/series` 인덱스 페이지 신설 + 메인 페이지 "시리즈" 섹션 (최대 4개) + Header navLink "03 / 시리즈" — plan033 OOS 였던 시리즈 발견성 진입점 3곳 신설.
- `PostRepository.getAllSeries(limit?)` 신설 — aggregate + first-post IN 2 쿼리로 N+1 회피.
- 시리즈 카드는 ADR-028 결정에 따라 `PostCard` variant 가 아닌 별도 `SeriesCard` 컴포넌트로 분리 (PostCard grid variant 시각 토큰은 일치).
- 부수: ADR-028 anchor 누락 보강 (Index 링크 깨짐 복구).

## Test plan

- [x] `pnpm lint` / `pnpm type-check` 통과
- [x] `pnpm test --run` — 281 tests 통과 (29 files)
- [x] `pnpm build` 성공 — `/series` 경로 정적 prerender + 5m revalidate 확인
- [x] critic APPROVE (v2) — phase-01 inline-chain + Risks/import 명시 반영
- [x] code-reviewer PASS (v2) — `series!` non-null assertion 3건 제거
- [x] docs-verifier PASS (v2) — ADR-028 anchor 추가, 5축 정합 확인
- [ ] 머지 후 prod 데이터에서 `/series` + 메인 시리즈 섹션 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)