### PR TITLE
fix(seo): plan049 — robots.txt /api/og/ allow 예외 추가

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: "/",
+        allow: ["/", "/api/og/"],
         disallow: ["/api/", "/_next/"],
       },
     ],

--- a/tasks/plan049-robots-og-allow/index.json
+++ b/tasks/plan049-robots-og-allow/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan049-robots-og-allow",
   "description": "Google Search Console 'robots.txt에 의해 차단됨' 알람 9건 해소. /api/ 통째 차단 정책이 /api/og/* OG 이미지 endpoint 까지 막아 글 페이지의 og:image URL 을 Google 이 크롤 시도 → 차단 알람. robots.ts 에 allow:['/api/og/'] 예외 추가. 다른 /api/ 엔드포인트는 차단 유지.",
-  "status": "in_progress",
+  "status": "completed",
   "created_at": "2026-05-21",
   "total_phases": 2,
   "related_docs": [
@@ -14,14 +14,14 @@
       "file": "phase-01.md",
       "title": "robots.ts /api/og/ allow 예외 추가",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + index.json 마킹 + Search Console 안내",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Google Search Console "robots.txt에 의해 차단됨" 알람 9건 해소
- `/api/` 통째 차단이 OG 이미지 endpoint (`/api/og/*`) 까지 막아 글 페이지 og:image URL 의 Google 크롤이 차단되던 문제 수정
- `src/app/robots.ts` 의 `allow: "/"` → `allow: ["/", "/api/og/"]` (1줄 변경). 다른 `/api/*` 는 차단 유지 — longest-match 규칙으로 의도 보장
- task 정의: plan049 (PR #이미 머지). 본 PR 은 결과물 PR

## Test plan
- [x] `pnpm lint` / `pnpm type-check` / `pnpm test --run` / `pnpm build` 통과
- [x] `MetadataRoute.Robots.allow` 가 `string | string[]` 둘 다 지원 (Next.js 16 타입 정의)
- [ ] (머지 후) production 배포 → `https://blog.fosworld.co.kr/robots.txt` 에 `Allow: /api/og/` + `Disallow: /api/` 공존 확인
- [ ] (24시간 후) Google Search Console 에서 "수정 확인" / "재크롤 요청" → 알람 9건 자연 해소 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)