### PR TITLE
feat(seo): plan050 — category 페이지 generateMetadata 가드 + React cache

### DIFF
--- a/src/app/category/[...path]/page.tsx
+++ b/src/app/category/[...path]/page.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { cache } from "react";
 import { getRepositories } from "@/infra/db/repositories";
 import { computeFolderPaths } from "@/lib/path-utils";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
@@ -28,12 +29,42 @@ interface FolderPageProps {
   }>;
 }
 
+type FolderContents = Awaited<
+  ReturnType<ReturnType<typeof getRepositories>["folder"]["getFolderContents"]>
+>;
+
+const getCachedFolderContents = cache(
+  async (folderPath: string): Promise<FolderContents> => {
+    try {
+      const { folder } = getRepositories();
+      return await folder.getFolderContents(folderPath);
+    } catch (error) {
+      log.warn(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        "Database not available",
+      );
+      return { folders: [], posts: [], readme: null };
+    }
+  },
+);
+
 export async function generateMetadata({
   params,
 }: FolderPageProps): Promise<Metadata> {
   const resolvedParams = await params;
   const pathSegments = resolvedParams.path.map(decodeURIComponent);
   const currentFolder = pathSegments[pathSegments.length - 1];
+  const folderPath = pathSegments.join("/");
+
+  const { folders, posts, readme } = await getCachedFolderContents(folderPath);
+
+  if (folders.length === 0 && posts.length === 0 && !readme) {
+    return {
+      title: "카테고리를 찾을 수 없습니다 | FOS Study",
+      robots: { index: false, follow: false },
+    };
+  }
+
   const canonicalUrl = `${siteUrl}/category/${pathSegments
     .map(encodeURIComponent)
     .join("/")}`;
@@ -77,18 +108,7 @@ export default async function FolderPage({ params }: FolderPageProps) {
   const category = pathSegments[0];
   const currentFolder = pathSegments[pathSegments.length - 1];
 
-  let folderContents = { folders: [], posts: [], readme: null } as Awaited<
-    ReturnType<ReturnType<typeof getRepositories>["folder"]["getFolderContents"]>
-  >;
-
-  try {
-    const { folder } = getRepositories();
-    folderContents = await folder.getFolderContents(folderPath);
-  } catch (error) {
-    log.warn({ err: error instanceof Error ? error : new Error(String(error)) }, "Database not available");
-  }
-
-  const { folders, posts, readme } = folderContents;
+  const { folders, posts, readme } = await getCachedFolderContents(folderPath);
 
   if (folders.length === 0 && posts.length === 0 && !readme) {
     notFound();

--- a/tasks/plan050-category-metadata-guard/index.json
+++ b/tasks/plan050-category-metadata-guard/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan050-category-metadata-guard",
   "description": "category 페이지가 임의 path 에 대해 200 응답하면서 canonical / og:image 메타를 자기 자신으로 노출하는 문제 방어. generateMetadata 에 getFolderContents 검증 추가 + React cache() 로 page() 와 쿼리 공유. 빈 결과면 canonical 미생성 + robots noindex. Search Console 의 /api/og/category/분산_계산_알고리즘.md 같은 잘못된 URL 인덱싱을 차단.",
-  "status": "in_progress",
+  "status": "completed",
   "created_at": "2026-05-21",
   "total_phases": 2,
   "related_docs": [
@@ -14,14 +14,14 @@
       "file": "phase-01.md",
       "title": "generateMetadata 가드 + React cache 도입",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "검증 + index.json 마킹 + production 모드 응답 확인",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- category 페이지가 임의 path 에 대해 200 응답하며 canonical / og:image 메타를 자기 자신으로 노출하던 문제 방어 — `generateMetadata` 에 `getFolderContents` 검증 추가
- 빈 결과면 canonical / openGraph 미생성 + `robots: { index: false, follow: false }` 반환 → Google 이 `/api/og/category/분산_계산_알고리즘.md` 같은 잘못된 URL 을 더 이상 인덱싱 못 함
- React `cache()` 로 `getCachedFolderContents` wrap → `generateMetadata` 와 `page()` 가 같은 request 안에서 DB 쿼리 1회만 수행 (중복 방지)
- try-catch 를 cached 함수 안으로 이동해 에러 처리 단일화. 빈 값 fallback 으로 metadata 단도 자연스럽게 noindex 분기로 흐름

## Test plan
- [x] `pnpm lint` / `pnpm type-check` / `pnpm test -- --run` / `pnpm build` 통과
- [x] code-reviewer PASS — 금지사항 / 타입 / 에러 처리 / logger / Next.js 16 컨벤션 모두 준수
- [x] docs-verifier PASS — docs/code-architecture.md 의 "카테고리 페이지 metadata 가드 (plan050)" 섹션과 정합, plan048/049 와 충돌 없음
- [ ] production 배포 후 잘못된 path (e.g. `/category/분산_계산_알고리즘.md`) 가 noindex 메타 반환하는지 확인
- [ ] 기존 정상 카테고리 (`/category/devops` 등) canonical 정상 노출 회귀 없는지 확인
- [ ] Search Console 의 `/api/og/category/분산_계산_알고리즘.md` 알람이 ISR 재크롤 (1분~) 후 자연 해소되는지 추적

🤖 Generated with [Claude Code](https://claude.com/claude-code)