### PR TITLE
fix(home): 문자열 날짜로 홈 글 목록 렌더링 실패 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,12 @@ type(scope): description
 
 예시: `feat(sync): add retry with exponential backoff`, `fix(db): prevent duplicate post insertion`, `docs(task): add layered architecture ADR`
 
+이 repo의 PR 제목과 본문은 기본적으로 한국어로 작성한다.
+단 `type(scope):` prefix, command, file path, symbol, error message 같은 기술 식별자는 원문을 유지한다.
+
+PR은 기본적으로 ready-for-review 상태로 생성한다.
+Draft PR은 사용자가 명시적으로 요청했거나, 검증이 아직 끝나지 않아 reviewer가 머지 판단을 할 수 없는 경우에만 사용한다.
+
 **브랜치 네이밍 규칙** — 작업 성격에 따라 prefix 분리:
 
 | PR 종류 | 브랜치 prefix | 예시 |
@@ -352,19 +358,19 @@ git status --short | grep -E "^(M|A) pnpm-lock\.yaml" && \
 `gh pr create --body` HEREDOC 으로 다음 포맷:
 
 ```markdown
-## Summary
+## 요약
 - {핵심 변경 한 줄}
 - {핵심 변경 한 줄}
 
-## Test plan
+## 검증
 - [ ] {검증 방법 — 자동 또는 수동}
 - [ ] {검증 방법}
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
-`Summary` 는 변경의 *왜* 와 *무엇*.
-`Test plan` 은 reviewer 가 머지 전 확인할 항목.
+`요약` 은 변경의 *왜* 와 *무엇*.
+`검증` 은 reviewer 가 머지 전 확인할 항목.
 항목 0 개면 PR 본문 생략 (단발 docs PR 등 예외 명시).
 
 #### 의미 단위 atomic 커밋

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -27,6 +27,7 @@ export class PostRepository extends BaseRepository {
         subcategory: posts.subcategory,
         folders: posts.folders,
         description: posts.description,
+        createdAt: posts.createdAt,
       })
       .from(posts)
       .where(and(eq(posts.category, category), eq(posts.isActive, true)))
@@ -49,6 +50,7 @@ export class PostRepository extends BaseRepository {
         subcategory: posts.subcategory,
         folders: posts.folders,
         description: posts.description,
+        createdAt: posts.createdAt,
       })
       .from(posts)
       .where(eq(posts.isActive, true))
@@ -248,6 +250,7 @@ export class PostRepository extends BaseRepository {
         subcategory: posts.subcategory,
         folders: posts.folders,
         description: posts.description,
+        createdAt: posts.createdAt,
       })
       .from(posts)
       .where(and(inArray(posts.path, paths), eq(posts.isActive, true)));

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -7,6 +7,10 @@ describe("formatDate", () => {
     expect(formatDate(new Date(2026, 11, 31))).toBe("2026.12.31");
   });
 
+  it("accepts date strings returned by MySQL drivers", () => {
+    expect(formatDate("2026-01-05 12:34:56")).toBe("2026.01.05");
+  });
+
   it("returns empty string for null / undefined", () => {
     expect(formatDate(null)).toBe("");
     expect(formatDate(undefined)).toBe("");
@@ -14,5 +18,6 @@ describe("formatDate", () => {
 
   it("returns empty string for Invalid Date", () => {
     expect(formatDate(new Date("not-a-date"))).toBe("");
+    expect(formatDate("not-a-date")).toBe("");
   });
 });

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,4 +1,6 @@
-export function formatDate(date: Date | null | undefined): string {
-  if (!date || Number.isNaN(date.getTime())) return "";
-  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+export function formatDate(date: Date | string | null | undefined): string {
+  if (!date) return "";
+  const normalized = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(normalized.getTime())) return "";
+  return `${normalized.getFullYear()}.${String(normalized.getMonth() + 1).padStart(2, "0")}.${String(normalized.getDate()).padStart(2, "0")}`;
 }


### PR DESCRIPTION
## 요약
- 운영 환경에서 MySQL/Drizzle timestamp 값이 문자열로 들어와도 홈 글 목록이 렌더링되도록 수정했습니다.
- `PostCard`가 날짜를 표시할 수 있도록 홈, 카테고리, 인기 글 목록 쿼리에 `createdAt`을 포함했습니다.
- PR 작성 규칙에 한국어 제목/본문과 ready-for-review 기본값을 명시했습니다.

## 원인
- 운영 로그에서 SSR 중 `TypeError: a.getTime is not a function` 오류가 반복 확인됐습니다.
- 운영 DB에는 글과 카테고리 데이터가 있었지만, 홈 페이지가 렌더링 실패 후 빈 목록 fallback을 캐시하면서 글이 없는 것처럼 보였습니다.

## 검증
- [x] `pnpm test src/lib/date-utils.test.ts src/infra/db/repositories/PostRepository.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 운영 DB 직접 확인: posts=303, categories=21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
