### PR TITLE
fix(markdown): description 의 마크다운 이스케이프 backslash 제거

### DIFF
--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -159,6 +159,15 @@ description: 한 줄<br>다음 줄
 본문`;
     expect(extractDescription(content)).toBe("한 줄 다음 줄");
   });
+
+  it("frontmatter description 의 마크다운 이스케이프(\\~)를 평문으로 되돌린다", () => {
+    const content = `---
+description: 진행기간 2026-01 \\~ 2026-03
+---
+
+본문`;
+    expect(extractDescription(content)).toBe("진행기간 2026-01 ~ 2026-03");
+  });
 });
 
 // ===== getReadingTime =====

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -168,6 +168,15 @@ description: 진행기간 2026-01 \\~ 2026-03
 본문`;
     expect(extractDescription(content)).toBe("진행기간 2026-01 ~ 2026-03");
   });
+
+  it("본문(mainContent) 추출 경로에서도 마크다운 이스케이프의 backslash 를 제거한다", () => {
+    // frontmatter description 이 없어 본문에서 첫 문단을 뽑는 경로
+    const content = "진행기간 2026-01 \\~ 2026-03 \\*강조\\*";
+    const result = extractDescription(content);
+    expect(result).not.toContain("\\");
+    expect(result).toContain("진행기간 2026-01");
+    expect(result).toContain("강조");
+  });
 });
 
 // ===== getReadingTime =====

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -94,6 +94,13 @@ export function extractTitle(
   return null;
 }
 
+// Markdown 이스케이프(`\~`, `\*` 등) 를 평문으로 되돌린다.
+// 본문 소스는 `~` 를 취소선으로 오인하지 않도록 `\~` 로 escape 하는데,
+// 평문 description 에서는 backslash 가 그대로 노출되므로 제거한다.
+function unescapeMarkdown(text: string): string {
+  return text.replace(/\\([!-/:-@[-`{-~])/g, "$1");
+}
+
 // Extract description from markdown content
 export function extractDescription(
   content: string,
@@ -104,11 +111,13 @@ export function extractDescription(
     parsed ?? parseFrontMatter(content);
 
   if (frontMatter.description) {
-    return frontMatter.description.replace(HTML_TAG_RE, " ").replace(/\s+/g, " ").trim();
+    return unescapeMarkdown(
+      frontMatter.description.replace(HTML_TAG_RE, " ").replace(/\s+/g, " ").trim(),
+    );
   }
 
   // Remove markdown syntax and get first paragraph
-  const plainText = mainContent
+  const plainText = unescapeMarkdown(mainContent)
     .replace(HTML_TAG_RE, " ") // Remove HTML tags (<br>, <details> 등)
     .replace(/^#+\s+.+$/gm, "") // Remove headers
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Replace links with text


### PR DESCRIPTION
## 요약
- 홈 최근글 카드에서 진행기간 등 `~` 표기가 `\~` 로 escape 되어 backslash 가 그대로 노출되던 문제 수정
- 원인: 본문에서 `~` 취소선 오인 방지용 `\~` escape 를 `extractDescription` 이 평문으로 뽑을 때 제거하지 않음
- `unescapeMarkdown` 헬퍼 추가 (`\` + ASCII 문장부호 제거) 후 frontmatter/본문 추출 양쪽 브랜치에 적용
- 홈 카드·상세 메타·RSS·OG 가 모두 이 단일 함수를 통과 → 한 곳 수정으로 전 경로 커버 (별도 공통화 불필요)

## 검증
- [x] `pnpm test src/lib/markdown.test.ts` — 회귀 케이스 추가, 55개 통과
- [x] `pnpm lint` / `pnpm type-check` 통과
- [ ] 기존 DB 행은 sync 시점 저장값이라 즉시 반영 안 됨 — `POST /api/sync` 재실행 필요 (상세·RSS·OG 는 실시간 추출이라 즉시 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
