### PR TITLE
feat(sync): GitHub 폴더 기반 카테고리 검증

### DIFF
--- a/docs/adr/017-design-system.md
+++ b/docs/adr/017-design-system.md
@@ -10,7 +10,10 @@
 - **모션**: **motion-one** (~3KB, Framer Motion 경량 alt) — 미세 page transition + hover 디테일
 - **다크 우선**: default `dark` 유지 (Vercel/Linear 컨벤션, 현 동작과 일치)
 - **토큰 시스템**: Tailwind v4 `@theme` 블록 (`globals.css`) 으로 표준화 — 컬러/타이포/spacing/radii/shadows/motion primitives
-- **카테고리 9종 (canonical)**: `ai / algorithm / db / devops / java / js / react / next / system` — oklch chroma 0.09, lightness 0.74 (dark) / 0.50 (light). 데이터의 raw 카테고리 키 (architecture/network/interview/kafka/internet 등) 는 헬퍼 (`src/lib/category-meta.ts`, plan010) 에서 9종 중 하나로 정규화 (미매핑 → `system`)
+- **카테고리 9종** (canonical): `ai / algorithm / db / devops / java / js / react / next / system` — oklch chroma 0.09, lightness 0.74 (dark) / 0.50 (light).
+  알려진 raw 카테고리 키는 헬퍼(`src/lib/category-meta.ts`, plan010)에서 기존 canonical 색상으로 정규화한다.
+  정적 meta가 없는 카테고리는 원래 이름을 표시하고 이름의 안정적인 hash로 hue를 계산한다.
+  새 폴더를 추가할 때 canonical 목록을 수정할 필요가 없도록 등록과 시각적 설정을 분리한다.
 - **OG / Avatar 팔레트는 7색 부분집합** (plan021/022): `og-palette.ts` 의 `OG_CATEGORY_HEX` 는 9종 중 `next` / `system` 제외한 7개만 hex 매핑. 이유: hash % palette.length 라 색 다양성만 충분하면 되고 `system` 은 fallback (`OG_CATEGORY_DEFAULT_HEX` brand teal) 와 의미가 겹침. `next` 는 forward-compat 자리
 - **워크플로우**: Claude Design (Anthropic Labs Research Preview) 으로 mockup 생성 → 이 저장소에서 코드 구현. 단계별 프롬프트는 `docs/design-inspiration.md`
 

--- a/docs/adr/030-multi-category.md
+++ b/docs/adr/030-multi-category.md
@@ -25,9 +25,12 @@
   - json 배열은 `JSON_CONTAINS` 풀스캔이라 인덱스 활용이 어렵다. 글 수가 적어 허용하고, 커지면 multi-value index 또는 관계 테이블 이전을 별도 plan 으로 검토한다.
   - sync 저장은 full·incremental 두 경로가 있다. 두 경로 모두 frontmatter 를 파싱해 `categories` 를 저장해야 평상시(증분) 운영에서 누락이 없다. 공통 헬퍼로 두 경로의 정합을 보장한다.
   - frontmatter 카테고리명은 폴더 경로와 대소문자가 일치해야 매칭된다(`JSON_CONTAINS` 대소문자 민감).
-    불일치 시 글 저자가 매칭 누락을 겪을 수 있으므로 sync 단계에서 알려진 카테고리 prefix로 해석되지 않는 값을 `warn` 로그로 남긴다.
-    현재 경고 기준은 실제 폴더 트리가 아니라 `RAW_TO_CANONICAL`/아이콘/OG 색상 같은 정적 category meta 이다.
-    새 최상위 폴더를 category key로 사용하려면 해당 meta도 함께 갱신해야 하며, 실제 폴더 트리 기반 검증은 별도 후속 이슈로 추적한다.
+    불일치 시 글 저자가 매칭 누락을 겪을 수 있으므로 sync 단계에서 실제 폴더와 정적 meta 모두에 없는 값을 `warn` 로그로 남긴다.
+    경고 기준은 동기화 대상 GitHub HEAD의 실제 폴더 경로와 선택적 정적 category meta 이다.
+    둘 중 하나에 존재하면 허용하고, 모두 없을 때만 경고한다.
+    경고는 오타 확인을 돕는 진단이며 글 저장을 막지 않는다.
     작성 가이드(폴더명 그대로 쓸 것)는 fos-study `CLAUDE.md`("카테고리와 Frontmatter" 절)에 명시했다.
-  - 색상과 아이콘은 slash path 전체를 canonical 9종으로 늘리지 않고 첫 세그먼트 기준으로 fallback한다.
+  - 색상과 아이콘은 slash path 전체를 canonical 9종으로 늘리지 않고 첫 세그먼트 기준으로 대체값을 찾는다.
     예: `AI/RAG`는 `AI`와 같은 색상·아이콘을 사용한다.
+    정적 meta가 없는 새 최상위 폴더는 코드 수정 없이 카테고리로 등록한다.
+    화면에는 원래 폴더명을 표시하고 기본 아이콘과 카테고리명 기반의 안정적인 색상을 사용한다.

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -395,11 +395,17 @@ ADR-030의 `posts.categories`는 `AI` 같은 최상위 폴더뿐 아니라 `AI/R
 조회 결과는 경로상 해당 폴더 안에 있는 글을 제외하고, `getFolderContents(folderPath)` 결과와 path 기준으로 중복 제거해 합친다.
 
 색상과 아이콘은 slash path 전체를 canonical category로 늘리지 않는다.
-`src/lib/category-meta.ts`와 `src/infra/db/constants.ts`는 먼저 전체 key를 확인하고, 없으면 첫 path segment를 기준으로 fallback한다.
+`src/lib/category-meta.ts`와 `src/infra/db/constants.ts`는 먼저 전체 key를 확인하고, 없으면 첫 path segment를 기준으로 대체값을 찾는다.
 예: `AI/RAG`는 `AI`와 같은 색상·아이콘을 사용한다.
 
-sync 단계는 frontmatter `categories` 값이 전체 key 또는 첫 path segment 어느 쪽으로도 알려진 카테고리로 해석되지 않으면 `warn` 로그를 남긴다.
-이는 `categories: [AI/RAG]` 같은 정상 하위 경로는 허용하면서, 오타로 인한 매칭 누락은 운영 로그에서 드러내기 위한 가드다.
+sync 단계는 현재 GitHub HEAD의 tree에서 폴더 경로를 한 번 읽고 전체·증분 글 동기화가 같은 목록을 사용한다.
+frontmatter `categories` 값이 실제 폴더 또는 선택적 정적 category meta에 있으면 허용한다.
+둘 다 없으면 글은 그대로 저장하고 `warn` 로그만 남긴다.
+tree를 완전히 읽지 못하면 잘못된 개별 경고를 만들지 않도록 검증을 생략하고 원인을 한 번 기록한다.
+
+최상위 폴더에 글이 하나 이상 있으면 기존 category metadata 갱신 과정이 DB 카테고리를 자동 생성한다.
+정적 meta는 기존 별칭·색상·아이콘을 위한 선택적 설정이며 카테고리 등록 조건이 아니다.
+정적 meta가 없는 카테고리는 원래 폴더명을 표시하고 기본 아이콘과 이름 기반의 안정적인 색상을 사용한다.
 
 ## 용어집 동기화와 본문 툴팁 구조 (plan054)
 

--- a/docs/pages/categories.md
+++ b/docs/pages/categories.md
@@ -63,7 +63,7 @@
 - `src/components/CategoryCard.tsx`
 - `src/lib/subline.ts` — `SublinePart` 공유 타입
 - `src/lib/time.ts` — `formatRelativeKo`, `formatYYYYMMDD`
-- `src/lib/category-meta.ts` — `getCategoryColor`
+- `src/lib/category-meta.ts` — `getCategoryColor`, `getCategoryLabel`
 - `src/infra/db/repositories/CategoryRepository.ts` — `getCategoriesWithLatest()`
 - `src/infra/db/types.ts` — `CategoryData` 타입
 - `src/app/globals.css` — `.cat-card::after` radial blob

--- a/docs/pages/category-detail.md
+++ b/docs/pages/category-detail.md
@@ -96,7 +96,7 @@ README 섹션 (있을 때만, ReadmeFrame wrap)
 - `src/components/JsonLd.tsx`
 - `src/lib/subline.ts` — `SublinePart` 공유 타입
 - `src/lib/time.ts` — `formatYYYYMMDD`, `formatRelativeKo`
-- `src/lib/category-meta.ts` — `getCategoryColor`, `toCanonicalCategory`
+- `src/lib/category-meta.ts` — `getCategoryColor`, `getCategoryLabel`
 - `src/infra/db/repositories/FolderRepository.ts`
 - `src/infra/db/repositories/PostRepository.ts` — `getCrossCategoryPosts`
 - `src/infra/db/constants.ts` — `categoryIcons`, `DEFAULT_CATEGORY_ICON`

--- a/docs/pages/category-detail.md
+++ b/docs/pages/category-detail.md
@@ -96,7 +96,7 @@ README 섹션 (있을 때만, ReadmeFrame wrap)
 - `src/components/JsonLd.tsx`
 - `src/lib/subline.ts` — `SublinePart` 공유 타입
 - `src/lib/time.ts` — `formatYYYYMMDD`, `formatRelativeKo`
-- `src/lib/category-meta.ts` — `getCategoryColor`, `getCategoryLabel`
+- `src/lib/category-meta.ts` — `getCategoryColor`
 - `src/infra/db/repositories/FolderRepository.ts`
 - `src/infra/db/repositories/PostRepository.ts` — `getCrossCategoryPosts`
 - `src/infra/db/constants.ts` — `categoryIcons`, `DEFAULT_CATEGORY_ICON`

--- a/docs/pages/post-detail.md
+++ b/docs/pages/post-detail.md
@@ -163,7 +163,7 @@
 - `src/infra/db/repositories/PostRepository.ts`
 - `src/infra/db/repositories/VisitRepository.ts` — `getVisitCount(pagePath)`
 - `src/lib/markdown.ts` — 본문 처리 + plan012 hast 헬퍼 (`extractRawText` / `findChildText` / `findCodeProp`)
-- `src/lib/category-meta.ts` — `getCategoryColor` / `getCategoryHue` / `toCanonicalCategory` (plan010)
+- `src/lib/category-meta.ts` — `getCategoryColor` / `getCategoryHue` / `getCategoryLabel` (plan010, plan055)
 - `src/app/globals.css` — plan009 토큰 + plan011 prose 확장 (H2 counter / blockquote QUOTE / inline code / mermaid 격리) + plan012 코드 블록 frame (`.code-card` / shiki dual theme) + plan035 모바일 가독성 (inline code keep-all / code-card-body pre overflow-x)
 
 ---

--- a/src/components/ArticleHero.tsx
+++ b/src/components/ArticleHero.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from "react";
 import {
   getCategoryColor,
   getCategoryHue,
-  toCanonicalCategory,
+  getCategoryLabel,
 } from "@/lib/category-meta";
 
 interface ArticleHeroProps {
@@ -111,7 +111,7 @@ export function ArticleHero({
                 }}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
-                {toCanonicalCategory(cat)}
+                {getCategoryLabel(cat)}
               </Link>
             );
           })}

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 import { ArrowUpRight } from "lucide-react";
 import type { CategoryData } from "@/infra/db/types";
-import { getCategoryColor, toCanonicalCategory } from "@/lib/category-meta";
+import { getCategoryColor, getCategoryLabel } from "@/lib/category-meta";
 
 interface CategoryCardProps {
   category: CategoryData;
@@ -10,7 +10,7 @@ interface CategoryCardProps {
 
 export function CategoryCard({ category }: CategoryCardProps) {
   const catColor = getCategoryColor(category.slug);
-  const canonical = toCanonicalCategory(category.slug);
+  const label = getCategoryLabel(category.slug);
 
   return (
     <Link
@@ -38,7 +38,7 @@ export function CategoryCard({ category }: CategoryCardProps) {
           className="font-mono text-[10px] uppercase tracking-[0.1em]"
           style={{ color: "var(--cat-color)" }}
         >
-          {canonical}
+          {label}
         </span>
       </div>
 

--- a/src/components/CategoryFeatured.tsx
+++ b/src/components/CategoryFeatured.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { CSSProperties } from "react";
 import type { CategoryData } from "@/infra/db/types";
-import { getCategoryColor, toCanonicalCategory } from "@/lib/category-meta";
+import { getCategoryColor, getCategoryLabel } from "@/lib/category-meta";
 import { formatRelativeKo } from "@/lib/time";
 
 interface CategoryFeaturedProps {
@@ -12,7 +12,7 @@ interface CategoryFeaturedProps {
 
 export function CategoryFeatured({ category, rank, latestUpdatedAt }: CategoryFeaturedProps) {
   const catColor = getCategoryColor(category.slug);
-  const canonical = toCanonicalCategory(category.slug);
+  const label = getCategoryLabel(category.slug);
   const rankStr = `#${String(rank).padStart(2, "0")}`;
 
   const inlineStyle = {
@@ -49,7 +49,7 @@ export function CategoryFeatured({ category, rank, latestUpdatedAt }: CategoryFe
           className="font-mono text-[10px] uppercase tracking-[0.1em]"
           style={{ color: "var(--cat-color)" }}
         >
-          {canonical}
+          {label}
         </span>
       </div>
 

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 import { getCategoryIcon } from "@/infra/db/constants";
 import type { PostData } from "@/infra/db/types";
-import { getCategoryColor, toCanonicalCategory } from "@/lib/category-meta";
+import { getCategoryColor, getCategoryLabel } from "@/lib/category-meta";
 import { formatDate } from "@/lib/date-utils";
 import { Eye } from "lucide-react";
 
@@ -45,7 +45,7 @@ export function PostCard({
                   style={{ color: getCategoryColor(cat) }}
                 >
                   <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
-                  <span>{toCanonicalCategory(cat)}</span>
+                  <span>{getCategoryLabel(cat)}</span>
                 </span>
               ))}
             </div>
@@ -99,7 +99,7 @@ export function PostCard({
                 style={{ color: getCategoryColor(cat) }}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
-                {getCategoryIcon(cat)} {toCanonicalCategory(cat)}
+                {getCategoryIcon(cat)} {getCategoryLabel(cat)}
               </span>
             ))}
             {viewCount !== undefined && (
@@ -120,7 +120,7 @@ export function PostCard({
                 style={{ color: getCategoryColor(cat) }}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
-                <span>{toCanonicalCategory(cat)}</span>
+                <span>{getCategoryLabel(cat)}</span>
               </span>
             ))}
           </div>

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { CSSProperties } from "react";
 import type { SeriesInfo } from "@/infra/db/types";
-import { getCategoryColor, toCanonicalCategory } from "@/lib/category-meta";
+import { getCategoryColor, getCategoryLabel } from "@/lib/category-meta";
 import { formatDate } from "@/lib/date-utils";
 import { seriesHref } from "@/lib/path-utils";
 
@@ -11,7 +11,7 @@ interface SeriesCardProps {
 
 export function SeriesCard({ series }: SeriesCardProps) {
   const catColor = getCategoryColor(series.firstPost.category);
-  const canonical = toCanonicalCategory(series.firstPost.category);
+  const label = getCategoryLabel(series.firstPost.category);
   const inlineStyle = { "--cat-color": catColor } as CSSProperties;
 
   return (
@@ -24,7 +24,7 @@ export function SeriesCard({ series }: SeriesCardProps) {
         <div className="flex items-center justify-between gap-2 font-mono text-[11px] uppercase tracking-[0.06em]">
           <span className="flex items-center gap-2" style={{ color: "var(--cat-color)" }}>
             <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
-            <span>{canonical}</span>
+            <span>{label}</span>
           </span>
           <span className="text-[var(--color-fg-muted)]">{series.postCount} posts</span>
         </div>

--- a/src/infra/db/constants.test.ts
+++ b/src/infra/db/constants.test.ts
@@ -39,5 +39,6 @@ describe("categoryIcons", () => {
 
   it("알 수 없는 하위 폴더 경로는 기본 아이콘을 반환한다", () => {
     expect(getCategoryIcon("unknown/path")).toBe(DEFAULT_CATEGORY_ICON);
+    expect(getCategoryIcon("blockchain")).toBe(DEFAULT_CATEGORY_ICON);
   });
 });

--- a/src/infra/github/api.test.ts
+++ b/src/infra/github/api.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCommit: vi.fn(),
+  getTree: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  octokit: {
+    git: {
+      getCommit: mocks.getCommit,
+      getTree: mocks.getTree,
+    },
+  },
+  OWNER: "owner",
+  REPO: "repo",
+  BRANCH: "main",
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { child: () => ({ warn: mocks.warn }) },
+}));
+
+import { getRepositoryFolderPaths } from "./api";
+
+describe("getRepositoryFolderPaths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getCommit.mockResolvedValue({ data: { tree: { sha: "root-sha" } } });
+  });
+
+  it("recursive tree에서 최상위와 하위 폴더 경로를 수집한다", async () => {
+    mocks.getTree.mockResolvedValue({
+      data: {
+        truncated: false,
+        tree: [
+          { path: "AI", type: "tree", sha: "ai-sha" },
+          { path: "AI/RAG", type: "tree", sha: "rag-sha" },
+          { path: "AI/RAG/intro.md", type: "blob", sha: "file-sha" },
+        ],
+      },
+    });
+
+    const result = await getRepositoryFolderPaths("head-sha");
+
+    expect(result).toEqual(new Set(["AI", "AI/RAG"]));
+    expect(mocks.getTree).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      tree_sha: "root-sha",
+      recursive: "1",
+    });
+  });
+
+  it("빈 repository tree는 빈 Set을 반환한다", async () => {
+    mocks.getTree.mockResolvedValue({
+      data: { truncated: false, tree: [] },
+    });
+
+    await expect(getRepositoryFolderPaths("head-sha")).resolves.toEqual(
+      new Set(),
+    );
+  });
+
+  it("recursive tree가 잘리면 하위 tree를 비재귀 순회해 경로를 완성한다", async () => {
+    mocks.getTree
+      .mockResolvedValueOnce({ data: { truncated: true, tree: [] } })
+      .mockResolvedValueOnce({
+        data: {
+          truncated: false,
+          tree: [{ path: "AI", type: "tree", sha: "ai-sha" }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          truncated: false,
+          tree: [{ path: "RAG", type: "tree", sha: "rag-sha" }],
+        },
+      })
+      .mockResolvedValueOnce({ data: { truncated: false, tree: [] } });
+
+    const result = await getRepositoryFolderPaths("head-sha");
+
+    expect(result).toEqual(new Set(["AI", "AI/RAG"]));
+    expect(mocks.getTree).toHaveBeenCalledTimes(4);
+  });
+
+  it("비재귀 tree도 잘리면 불완전 상태를 한 번 경고하고 null을 반환한다", async () => {
+    mocks.getTree
+      .mockResolvedValueOnce({ data: { truncated: true, tree: [] } })
+      .mockResolvedValueOnce({ data: { truncated: true, tree: [] } });
+
+    await expect(getRepositoryFolderPaths("head-sha")).resolves.toBeNull();
+    expect(mocks.warn).toHaveBeenCalledOnce();
+  });
+
+  it("필수 tree 정보가 없으면 null을 반환한다", async () => {
+    mocks.getTree
+      .mockResolvedValueOnce({ data: { truncated: true, tree: [] } })
+      .mockResolvedValueOnce({
+        data: {
+          truncated: false,
+          tree: [{ path: "AI", type: "tree", sha: null }],
+        },
+      });
+
+    await expect(getRepositoryFolderPaths("head-sha")).resolves.toBeNull();
+    expect(mocks.warn).toHaveBeenCalledOnce();
+  });
+
+  it("GitHub API 오류는 한 번 경고하고 null을 반환한다", async () => {
+    mocks.getCommit.mockRejectedValue(new Error("GitHub 오류"));
+
+    await expect(getRepositoryFolderPaths("head-sha")).resolves.toBeNull();
+    expect(mocks.warn).toHaveBeenCalledOnce();
+  });
+});

--- a/src/infra/github/api.ts
+++ b/src/infra/github/api.ts
@@ -91,10 +91,10 @@ export async function getRepositoryFolderPaths(
     }
 
     const folderPaths = new Set<string>();
-    const pendingTrees = [{ sha: rootTreeSha, path: "" }];
+    const pendingTreeStack = [{ sha: rootTreeSha, path: "" }];
 
-    while (pendingTrees.length > 0) {
-      const current = pendingTrees.pop();
+    while (pendingTreeStack.length > 0) {
+      const current = pendingTreeStack.pop();
       if (!current) break;
 
       const tree = await withRetry(() =>
@@ -118,7 +118,7 @@ export async function getRepositoryFolderPaths(
 
         const path = current.path ? `${current.path}/${item.path}` : item.path;
         folderPaths.add(path);
-        pendingTrees.push({ sha: item.sha, path });
+        pendingTreeStack.push({ sha: item.sha, path });
       }
     }
 

--- a/src/infra/github/api.ts
+++ b/src/infra/github/api.ts
@@ -55,6 +55,86 @@ export async function getCurrentHeadSha(): Promise<string> {
   return response.data.commit.sha;
 }
 
+export async function getRepositoryFolderPaths(
+  commitSha: string,
+): Promise<ReadonlySet<string> | null> {
+  try {
+    const commit = await withRetry(() =>
+      octokit.git.getCommit({ owner: OWNER, repo: REPO, commit_sha: commitSha }),
+    );
+    const rootTreeSha = commit.data.tree.sha;
+    if (!rootTreeSha) {
+      log.warn({ commitSha }, "GitHub tree SHA 누락 -> category 검증 생략");
+      return null;
+    }
+
+    const recursiveTree = await withRetry(() =>
+      octokit.git.getTree({
+        owner: OWNER,
+        repo: REPO,
+        tree_sha: rootTreeSha,
+        recursive: "1",
+      }),
+    );
+
+    if (!recursiveTree.data.truncated) {
+      const folderPaths = new Set<string>();
+      for (const item of recursiveTree.data.tree) {
+        if (item.type !== "tree") continue;
+        if (!item.path) {
+          log.warn({ commitSha }, "GitHub tree 경로 누락 -> category 검증 생략");
+          return null;
+        }
+        folderPaths.add(item.path);
+      }
+      return folderPaths;
+    }
+
+    const folderPaths = new Set<string>();
+    const pendingTrees = [{ sha: rootTreeSha, path: "" }];
+
+    while (pendingTrees.length > 0) {
+      const current = pendingTrees.pop();
+      if (!current) break;
+
+      const tree = await withRetry(() =>
+        octokit.git.getTree({
+          owner: OWNER,
+          repo: REPO,
+          tree_sha: current.sha,
+        }),
+      );
+      if (tree.data.truncated) {
+        log.warn({ commitSha }, "GitHub tree 응답 잘림 -> category 검증 생략");
+        return null;
+      }
+
+      for (const item of tree.data.tree) {
+        if (item.type !== "tree") continue;
+        if (!item.path || !item.sha) {
+          log.warn({ commitSha }, "GitHub tree 정보 누락 -> category 검증 생략");
+          return null;
+        }
+
+        const path = current.path ? `${current.path}/${item.path}` : item.path;
+        folderPaths.add(path);
+        pendingTrees.push({ sha: item.sha, path });
+      }
+    }
+
+    return folderPaths;
+  } catch (error) {
+    log.warn(
+      {
+        err: error instanceof Error ? error : new Error(String(error)),
+        commitSha,
+      },
+      "GitHub repository 폴더 조회 실패 -> category 검증 생략",
+    );
+    return null;
+  }
+}
+
 /**
  * baseSha..headSha 사이의 변경 파일 목록 반환.
  * 변경 파일이 300개 이상이면 null을 반환 → full sync 폴백.

--- a/src/lib/category-meta.test.ts
+++ b/src/lib/category-meta.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   isKnownCategoryKey,
   toCanonicalCategory,
+  getCategoryLabel,
   getCategoryHue,
   getCategoryColor,
 } from "./category-meta";
@@ -60,6 +61,12 @@ describe("isKnownCategoryKey", () => {
 });
 
 describe("getCategoryHue", () => {
+  it("기존 category의 hue를 유지한다", () => {
+    expect(getCategoryHue("AI")).toBe(285);
+    expect(getCategoryHue("database")).toBe(55);
+    expect(getCategoryHue("javascript")).toBe(90);
+  });
+
   it('returns 220 for "react"', () => {
     expect(getCategoryHue("react")).toBe(220);
   });
@@ -70,6 +77,37 @@ describe("getCategoryHue", () => {
 
   it('returns 285 for "AI/RAG" (AI hue)', () => {
     expect(getCategoryHue("AI/RAG")).toBe(285);
+  });
+
+  it("미등록 category와 하위 path는 같은 안정적 hue를 사용한다", () => {
+    const blockchainHue = getCategoryHue("blockchain");
+    const quantumHue = getCategoryHue("quantum");
+
+    expect(blockchainHue).toBeGreaterThanOrEqual(0);
+    expect(blockchainHue).toBeLessThan(360);
+    expect(getCategoryHue("blockchain")).toBe(blockchainHue);
+    expect(getCategoryHue("blockchain/evm")).toBe(blockchainHue);
+    expect(quantumHue).toBeGreaterThanOrEqual(0);
+    expect(quantumHue).toBeLessThan(360);
+    expect(getCategoryHue("quantum")).toBe(quantumHue);
+  });
+});
+
+describe("getCategoryLabel", () => {
+  it("기존 category의 canonical label을 유지한다", () => {
+    expect(getCategoryLabel("AI")).toBe("ai");
+    expect(getCategoryLabel("database")).toBe("db");
+    expect(getCategoryLabel("javascript")).toBe("js");
+  });
+
+  it("미등록 category는 trim한 원래 key를 표시한다", () => {
+    expect(getCategoryLabel(" blockchain ")).toBe("blockchain");
+    expect(getCategoryLabel("blockchain/evm")).toBe("blockchain/evm");
+  });
+
+  it("빈 key는 기존 안전 대체값을 사용한다", () => {
+    expect(getCategoryLabel("   ")).toBe("system");
+    expect(getCategoryHue("   ")).toBe(250);
   });
 });
 

--- a/src/lib/category-meta.ts
+++ b/src/lib/category-meta.ts
@@ -45,14 +45,24 @@ function getTopLevelCategory(raw: string): string {
   return normalizeCategoryKey(raw).split("/")[0] ?? "";
 }
 
+function getKnownCanonicalCategory(raw: string): CanonicalCategory | undefined {
+  const key = normalizeCategoryKey(raw);
+  return RAW_TO_CANONICAL[key] ?? RAW_TO_CANONICAL[getTopLevelCategory(key)];
+}
+
 export function isKnownCategoryKey(raw: string): boolean {
   const key = normalizeCategoryKey(raw);
   return key in RAW_TO_CANONICAL || getTopLevelCategory(key) in RAW_TO_CANONICAL;
 }
 
 export function toCanonicalCategory(raw: string): CanonicalCategory {
+  return getKnownCanonicalCategory(raw) ?? "system";
+}
+
+export function getCategoryLabel(raw: string): string {
   const key = normalizeCategoryKey(raw);
-  return RAW_TO_CANONICAL[key] ?? RAW_TO_CANONICAL[getTopLevelCategory(key)] ?? "system";
+  if (!key) return "system";
+  return getKnownCanonicalCategory(key) ?? key;
 }
 
 /**
@@ -72,7 +82,18 @@ const CANONICAL_TO_HUE: Record<CanonicalCategory, number> = {
 };
 
 export function getCategoryHue(raw: string): number {
-  return CANONICAL_TO_HUE[toCanonicalCategory(raw)];
+  const knownCategory = getKnownCanonicalCategory(raw);
+  if (knownCategory) return CANONICAL_TO_HUE[knownCategory];
+
+  const topLevel = getTopLevelCategory(raw);
+  if (!topLevel) return CANONICAL_TO_HUE.system;
+
+  let hash = 2166136261;
+  for (const character of topLevel) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) % 360;
 }
 
 /**

--- a/src/lib/category-meta.ts
+++ b/src/lib/category-meta.ts
@@ -1,8 +1,8 @@
 /**
- * 카테고리 정규화 헬퍼.
- * - canonical 9개: ai / algorithm / db / devops / java / js / react / next / system
- * - 데이터 raw key (categoryIcons 의 keys + 미정의 키) 를 canonical 로 흡수
- * - 누락/미매핑 키는 모두 'system' 으로 default
+ * 카테고리 meta 헬퍼.
+ * 알려진 raw key는 기존 canonical 9종으로 연결한다.
+ * `toCanonicalCategory()`는 미등록 key를 `system`으로 처리하는 호환 계약을 유지한다.
+ * 화면 표시와 색상은 `getCategoryLabel()`과 `getCategoryHue()`가 동적 대체값을 제공한다.
  */
 
 export type CanonicalCategory =

--- a/src/services/MetadataSyncService.test.ts
+++ b/src/services/MetadataSyncService.test.ts
@@ -64,6 +64,24 @@ describe("MetadataSyncService.refresh", () => {
     ]);
   });
 
+  it("미등록 최상위 category를 기본 아이콘과 함께 자동 등록한다", async () => {
+    const mocks = makeMocks();
+    vi.mocked(mocks.postRepo.getCategoryStats).mockResolvedValue([
+      { category: "blockchain", count: 1 },
+    ]);
+
+    await createService(mocks).refresh();
+
+    expect(mocks.categoryRepo.syncAll).toHaveBeenCalledWith([
+      {
+        name: "blockchain",
+        slug: "blockchain",
+        icon: "📁",
+        postCount: 1,
+      },
+    ]);
+  });
+
   it("원본 README가 사라지면 DB readme를 지우고 delete change를 반환한다", async () => {
     const mocks = makeMocks();
     vi.mocked(mocks.postRepo.getAllPostPaths).mockResolvedValue([

--- a/src/services/PostSyncService.test.ts
+++ b/src/services/PostSyncService.test.ts
@@ -27,6 +27,7 @@ function makeMocks() {
     update: vi.fn().mockResolvedValue(undefined),
   };
   const githubApi: ConstructorParameters<typeof PostSyncService>[1] = {
+    getRepositoryFolderPaths: vi.fn().mockResolvedValue(new Set()),
     getDirectoryContents: vi.fn().mockResolvedValue([]),
     getFileContent: vi.fn().mockResolvedValue(null),
     getFileCommitDates: vi.fn().mockResolvedValue(null),
@@ -53,8 +54,12 @@ describe("PostSyncService", () => {
       sha: "new-sha",
     });
 
-    const result = await new PostSyncService(postRepo, githubApi).syncAll();
+    const result = await new PostSyncService(postRepo, githubApi).syncAll(
+      "head-sha",
+    );
 
+    expect(githubApi.getRepositoryFolderPaths).toHaveBeenCalledOnce();
+    expect(githubApi.getRepositoryFolderPaths).toHaveBeenCalledWith("head-sha");
     expect(postRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({ path: "AI/intro.md", title: "새 제목" }),
     );
@@ -78,7 +83,9 @@ describe("PostSyncService", () => {
     ]);
     vi.mocked(postRepo.deactivateByIds).mockResolvedValue(1);
 
-    const result = await new PostSyncService(postRepo, githubApi).syncAll();
+    const result = await new PostSyncService(postRepo, githubApi).syncAll(
+      "head-sha",
+    );
 
     expect(githubApi.getFileContent).not.toHaveBeenCalled();
     expect(postRepo.deactivateByIds).toHaveBeenCalledWith([2]);
@@ -95,14 +102,18 @@ describe("PostSyncService", () => {
       sha: "rename-sha",
     });
 
-    const result = await new PostSyncService(postRepo, githubApi).syncChanged([
-      {
-        status: "renamed",
-        filename: "AI/new.md",
-        previous_filename: "AI/old.md",
-      },
-    ]);
+    const result = await new PostSyncService(postRepo, githubApi).syncChanged(
+      [
+        {
+          status: "renamed",
+          filename: "AI/new.md",
+          previous_filename: "AI/old.md",
+        },
+      ],
+      "head-sha",
+    );
 
+    expect(githubApi.getRepositoryFolderPaths).toHaveBeenCalledOnce();
     expect(result).toMatchObject({ added: 1, updated: 0, deleted: 1 });
     expect(result.changedPosts).toEqual([
       { path: "AI/old.md", operation: "delete" },
@@ -114,14 +125,96 @@ describe("PostSyncService", () => {
     const { postRepo, githubApi } = makeMocks();
     vi.mocked(postRepo.deactive).mockResolvedValue(true);
 
-    const result = await new PostSyncService(postRepo, githubApi).syncChanged([
-      { status: "removed", filename: "AI/README.md" },
-    ]);
+    const result = await new PostSyncService(postRepo, githubApi).syncChanged(
+      [{ status: "removed", filename: "AI/README.md" }],
+      "head-sha",
+    );
 
     expect(postRepo.deactive).toHaveBeenCalledWith("AI/README.md");
     expect(result.changedPosts).toEqual([
       { path: "AI/README.md", operation: "delete" },
     ]);
+  });
+
+  it("실제 폴더와 정적 meta category는 경고 없이 저장한다", async () => {
+    const { postRepo, githubApi } = makeMocks();
+    vi.mocked(githubApi.getRepositoryFolderPaths).mockResolvedValue(
+      new Set(["AI", "AI/RAG"]),
+    );
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({
+      content: "---\ncategories: [AI/RAG, database/legacy]\n---\n# 제목",
+      sha: "sha",
+    });
+
+    await new PostSyncService(postRepo, githubApi).syncChanged(
+      [{ status: "added", filename: "AI/intro.md" }],
+      "head-sha",
+    );
+
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+    expect(postRepo.create).toHaveBeenCalledOnce();
+  });
+
+  it("없는 category는 한 번 경고하지만 새 글을 저장한다", async () => {
+    const { postRepo, githubApi } = makeMocks();
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({
+      content: "---\ncategories: [unknown/path, unknown/path]\n---\n# 제목",
+      sha: "sha",
+    });
+
+    await new PostSyncService(postRepo, githubApi).syncChanged(
+      [{ status: "added", filename: "AI/intro.md" }],
+      "head-sha",
+    );
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      { path: "AI/intro.md", categories: ["unknown/path"] },
+      "frontmatter categories 에 알려지지 않은 category key 포함",
+    );
+    expect(postRepo.create).toHaveBeenCalledOnce();
+  });
+
+  it("대소문자가 다른 실제 폴더는 경고하지만 기존 글을 갱신한다", async () => {
+    const { postRepo, githubApi } = makeMocks();
+    vi.mocked(githubApi.getRepositoryFolderPaths).mockResolvedValue(
+      new Set(["Study/RAG"]),
+    );
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({
+      content: "---\ncategories: [study/RAG]\n---\n# 제목",
+      sha: "sha",
+    });
+    vi.mocked(postRepo.getPostId).mockResolvedValue(7);
+
+    await new PostSyncService(postRepo, githubApi).syncChanged(
+      [{ status: "modified", filename: "AI/intro.md" }],
+      "head-sha",
+    );
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      { path: "AI/intro.md", categories: ["study/RAG"] },
+      "frontmatter categories 에 알려지지 않은 category key 포함",
+    );
+    expect(postRepo.update).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ categories: ["AI", "study/RAG"] }),
+    );
+  });
+
+  it("폴더 조회 실패는 category 경고 없이 글을 저장한다", async () => {
+    const { postRepo, githubApi } = makeMocks();
+    vi.mocked(githubApi.getRepositoryFolderPaths).mockResolvedValue(null);
+    vi.mocked(githubApi.getFileContent).mockResolvedValue({
+      content: "---\ncategories: [unknown/path]\n---\n# 제목",
+      sha: "sha",
+    });
+
+    await new PostSyncService(postRepo, githubApi).syncChanged(
+      [{ status: "added", filename: "AI/intro.md" }],
+      "head-sha",
+    );
+
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+    expect(postRepo.create).toHaveBeenCalledOnce();
   });
 
   it("retitleAll은 content 제목이 다른 글만 보정한다", async () => {
@@ -167,7 +260,12 @@ describe("PostSyncService helpers", () => {
   });
 
   it("알려지지 않은 category key를 경고한다", () => {
-    warnUnknownFrontMatterCategories("AI/rag.md", "AI", ["unknown/path"]);
+    warnUnknownFrontMatterCategories(
+      "AI/rag.md",
+      "AI",
+      ["unknown/path"],
+      new Set(),
+    );
 
     expect(loggerMock.warn).toHaveBeenCalledWith(
       { path: "AI/rag.md", categories: ["unknown/path"] },

--- a/src/services/PostSyncService.ts
+++ b/src/services/PostSyncService.ts
@@ -10,6 +10,9 @@ import { shouldSyncFile } from "@/infra/github/file-filter";
 const log = logger.child({ module: "PostSyncService" });
 
 type GithubApi = {
+  getRepositoryFolderPaths: (
+    commitSha: string,
+  ) => Promise<ReadonlySet<string> | null>;
   getDirectoryContents: (path?: string) => Promise<
     Array<{ name: string; path: string; sha: string; type: string }>
   >;
@@ -80,18 +83,24 @@ export function mergeCategories(pathCategory: string, fmCategories?: string[]): 
 export function warnUnknownFrontMatterCategories(
   path: string,
   pathCategory: string,
-  fmCategories?: string[],
+  fmCategories: string[] | undefined,
+  repositoryFolderPaths: ReadonlySet<string> | null,
 ): void {
+  if (repositoryFolderPaths == null) return;
+
   const unknownCategories = (fmCategories ?? [])
     .map((category) => category.trim())
     .filter((category) => category.length > 0)
     .filter((category) => category !== pathCategory)
+    .filter((category) => !repositoryFolderPaths.has(category))
     .filter((category) => !isKnownCategoryKey(category));
 
-  if (unknownCategories.length === 0) return;
+  const uniqueUnknownCategories = Array.from(new Set(unknownCategories));
+
+  if (uniqueUnknownCategories.length === 0) return;
 
   log.warn(
-    { path, categories: unknownCategories },
+    { path, categories: uniqueUnknownCategories },
     "frontmatter categories 에 알려지지 않은 category key 포함",
   );
 }
@@ -140,10 +149,12 @@ export class PostSyncService {
     private githubApi: GithubApi,
   ) {}
 
-  async syncAll(): Promise<PostSyncResult> {
+  async syncAll(headSha: string): Promise<PostSyncResult> {
     let added = 0;
     let updated = 0;
 
+    const repositoryFolderPaths =
+      await this.githubApi.getRepositoryFolderPaths(headSha);
     const githubFiles = await this.collectMarkdownFiles();
     log.info(
       { count: githubFiles.length },
@@ -160,7 +171,11 @@ export class PostSyncService {
       const existing = existingPathMap.get(file.path);
       if (existing?.sha === file.sha) continue;
 
-      const result = await this.upsert(file.path, existing?.id);
+      const result = await this.upsert(
+        file.path,
+        repositoryFolderPaths,
+        existing?.id,
+      );
       if (result === "added") added++;
       if (result === "updated") updated++;
       if (result !== "skipped") {
@@ -194,11 +209,16 @@ export class PostSyncService {
     };
   }
 
-  async syncChanged(changedFiles: ChangedFile[]): Promise<PostSyncResult> {
+  async syncChanged(
+    changedFiles: ChangedFile[],
+    headSha: string,
+  ): Promise<PostSyncResult> {
     let added = 0;
     let updated = 0;
     let deleted = 0;
     const changedPosts: SyncedPageChange[] = [];
+    const repositoryFolderPaths =
+      await this.githubApi.getRepositoryFolderPaths(headSha);
 
     for (const file of changedFiles) {
       if (file.status === "removed") {
@@ -226,7 +246,7 @@ export class PostSyncService {
 
       if (!shouldSyncFile(file.filename)) continue;
 
-      const result = await this.upsert(file.filename);
+      const result = await this.upsert(file.filename, repositoryFolderPaths);
       if (result === "added") added++;
       if (result === "updated") updated++;
       if (result !== "skipped") {
@@ -271,6 +291,7 @@ export class PostSyncService {
 
   private async upsert(
     filePath: string,
+    repositoryFolderPaths: ReadonlySet<string> | null,
     knownPostId?: number,
   ): Promise<"added" | "updated" | "skipped"> {
     const [fileData, commitDates] = await Promise.all([
@@ -290,7 +311,12 @@ export class PostSyncService {
     const description = extractDescription(content, 200);
     const { frontMatter } = parseFrontMatter(content);
     const { tags, series, seriesOrder } = resolveFrontMatterMeta(frontMatter, filePath);
-    warnUnknownFrontMatterCategories(filePath, category, frontMatter.categories);
+    warnUnknownFrontMatterCategories(
+      filePath,
+      category,
+      frontMatter.categories,
+      repositoryFolderPaths,
+    );
     const categories = mergeCategories(category, frontMatter.categories);
 
     const existingPostId = knownPostId ?? await this.postRepo.getPostId(filePath);

--- a/src/services/PostSyncService.ts
+++ b/src/services/PostSyncService.ts
@@ -217,8 +217,12 @@ export class PostSyncService {
     let updated = 0;
     let deleted = 0;
     const changedPosts: SyncedPageChange[] = [];
-    const repositoryFolderPaths =
-      await this.githubApi.getRepositoryFolderPaths(headSha);
+    const needsFolderPaths = changedFiles.some(
+      (file) => file.status !== "removed",
+    );
+    const repositoryFolderPaths = needsFolderPaths
+      ? await this.githubApi.getRepositoryFolderPaths(headSha)
+      : null;
 
     for (const file of changedFiles) {
       if (file.status === "removed") {

--- a/src/services/SyncService.test.ts
+++ b/src/services/SyncService.test.ts
@@ -76,7 +76,7 @@ describe("SyncService.sync", () => {
 
     const result = await createService(mocks).sync();
 
-    expect(mocks.postSyncService.syncAll).toHaveBeenCalledOnce();
+    expect(mocks.postSyncService.syncAll).toHaveBeenCalledWith("head-sha");
     expect(mocks.postSyncService.syncChanged).not.toHaveBeenCalled();
     expect(mocks.glossarySyncService.syncDefinitions).toHaveBeenCalledWith(
       "full",
@@ -104,7 +104,7 @@ describe("SyncService.sync", () => {
 
     await createService(mocks).sync();
 
-    expect(mocks.postSyncService.syncAll).toHaveBeenCalledOnce();
+    expect(mocks.postSyncService.syncAll).toHaveBeenCalledWith("head-sha");
     expect(mocks.postSyncService.syncChanged).not.toHaveBeenCalled();
   });
 
@@ -121,7 +121,10 @@ describe("SyncService.sync", () => {
 
     await createService(mocks).sync();
 
-    expect(mocks.postSyncService.syncChanged).toHaveBeenCalledWith(changedFiles);
+    expect(mocks.postSyncService.syncChanged).toHaveBeenCalledWith(
+      changedFiles,
+      "head-sha",
+    );
     expect(mocks.glossarySyncService.syncDefinitions).toHaveBeenCalledWith(
       "incremental",
       changedFiles,

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -102,7 +102,7 @@ export class SyncService {
           syncPlan.mode,
           syncPlan.changedFiles,
         );
-      const postResult = await this.syncPosts(syncPlan);
+      const postResult = await this.syncPosts(syncPlan, headSha);
       const metadataResult = await this.metadataSyncService.refresh();
       const glossaryMentions = await this.glossarySyncService.syncMentions({
         definitionsChanged: glossaryDefinitions.definitionsChanged,
@@ -188,10 +188,10 @@ export class SyncService {
     return { mode: "incremental", changedFiles };
   }
 
-  private syncPosts(plan: SyncPlan): Promise<PostSyncResult> {
+  private syncPosts(plan: SyncPlan, headSha: string): Promise<PostSyncResult> {
     return plan.mode === "full"
-      ? this.postSyncService.syncAll()
-      : this.postSyncService.syncChanged(plan.changedFiles);
+      ? this.postSyncService.syncAll(headSha)
+      : this.postSyncService.syncChanged(plan.changedFiles, headSha);
   }
 
 }

--- a/tasks/plan055-github-folder-categories/index.json
+++ b/tasks/plan055-github-folder-categories/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan055-github-folder-categories",
   "description": "GitHub HEAD의 실제 폴더를 카테고리 기준으로 사용하고 새 카테고리를 코드 수정 없이 표시한다.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-07-20",
   "total_phases": 3,
   "related_docs": [
@@ -20,21 +20,21 @@
       "file": "phase-01.md",
       "title": "GitHub HEAD 폴더 기반 category 검증",
       "execution_profile": "standard",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "동적 category 표시와 자동 등록",
       "execution_profile": "standard",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "통합 검증과 완료 상태 반영",
       "execution_profile": "fast",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan055-github-folder-categories/index.json
+++ b/tasks/plan055-github-folder-categories/index.json
@@ -1,0 +1,40 @@
+{
+  "name": "plan055-github-folder-categories",
+  "description": "GitHub HEAD의 실제 폴더를 카테고리 기준으로 사용하고 새 카테고리를 코드 수정 없이 표시한다.",
+  "status": "pending",
+  "created_at": "2026-07-20",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/adr/017-design-system.md",
+    "docs/adr/030-multi-category.md",
+    "docs/code-architecture.md",
+    "docs/pages/categories.md",
+    "docs/pages/category-detail.md",
+    "docs/pages/post-detail.md"
+  ],
+  "depends_on": [],
+  "issue": "#182",
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "GitHub HEAD 폴더 기반 category 검증",
+      "execution_profile": "standard",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "동적 category 표시와 자동 등록",
+      "execution_profile": "standard",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "통합 검증과 완료 상태 반영",
+      "execution_profile": "fast",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan055-github-folder-categories/phase-01.md
+++ b/tasks/plan055-github-folder-categories/phase-01.md
@@ -1,0 +1,112 @@
+# Phase 01 — GitHub HEAD 폴더 기반 category 검증
+
+**Execution profile**: standard
+**Status**: pending
+
+---
+
+## 목표
+
+frontmatter `categories`를 동기화 대상 GitHub HEAD의 실제 폴더와 대조한다.
+전체·증분 동기화가 같은 폴더 스냅샷을 사용하며, 검증할 수 없거나 값이 잘못되어도 글 저장은 중단하지 않는다.
+
+**범위 외**: 신규 카테고리 표시명·색상·아이콘, DB schema, `/api/sync` 응답 변경, 동시 동기화 잠금.
+
+---
+
+## 작업 항목 (4)
+
+### 1. `src/infra/github/api.ts` — commit 기준 폴더 스냅샷
+
+다음 함수를 추가하고 기존 `withRetry()`와 Octokit client를 재사용한다.
+
+```ts
+export async function getRepositoryFolderPaths(
+  commitSha: string,
+): Promise<ReadonlySet<string> | null>
+```
+
+`octokit.git.getCommit()`으로 commit의 root tree SHA를 얻고 `octokit.git.getTree({ recursive: "1" })`에서 `type === "tree"`인 저장소 상대 경로를 수집한다.
+경로는 선행·후행 slash 없이 GitHub가 반환한 대소문자를 보존한다.
+
+recursive 응답의 `truncated`가 `true`이면 root tree부터 비재귀 조회하며 각 하위 tree SHA를 순회해 완전한 경로 집합을 만든다.
+비재귀 응답도 잘렸거나 필수 SHA·path가 없어 완전성을 보장할 수 없으면 `null`을 반환한다.
+빈 repository tree는 빈 `Set`이며, API 오류와 불완전한 tree는 검증 생략 원인을 한 번 기록한 뒤 `null`로 구분한다.
+
+### 2. `PostSyncService` — 요청 단위 검증 문맥
+
+`GithubApi` 구조적 타입에 `getRepositoryFolderPaths`를 추가하고 공개 계약을 다음처럼 확장한다.
+
+```ts
+syncAll(headSha: string): Promise<PostSyncResult>
+syncChanged(changedFiles: ChangedFile[], headSha: string): Promise<PostSyncResult>
+```
+
+각 호출은 폴더 스냅샷을 한 번만 읽어 모든 upsert에 전달한다.
+`upsert()`와 parsing 경로를 full·incremental에서 계속 공유하며 별도 category 저장 경로를 만들지 않는다.
+
+### 3. frontmatter category 경고 계약
+
+`warnUnknownFrontMatterCategories()`에 `ReadonlySet<string> | null` 폴더 인자를 추가한다.
+trim과 빈 문자열 제거 후 현재 글의 path category를 제외하고 다음 중 하나면 허용한다.
+
+- 폴더 집합의 경로와 대소문자까지 정확히 일치한다.
+- `isKnownCategoryKey()`가 선택적 정적 meta로 인정한다.
+
+둘 다 아니면 중복을 제거한 category 목록을 한 번의 `warn`에 기록한다.
+폴더 인자가 `null`이면 잘못된 개별 경고를 피하기 위해 검증을 생략한다.
+경고 유무와 관계없이 `mergeCategories()`와 repository create·update를 실행한다.
+
+### 4. `SyncService` wiring과 회귀 테스트
+
+`SyncService.syncPosts()`가 full·incremental 양쪽에서 현재 `headSha`를 `PostSyncService`에 전달하게 한다.
+`SyncService`가 GitHub tree를 직접 조회하거나 category 판정을 맡지 않게 한다.
+`src/services/index.ts`의 구조적 Github API wiring과 테스트 mock을 새 함수에 맞춘다.
+
+다음을 자동 테스트한다.
+
+- full·incremental 모두 현재 HEAD를 전달한다.
+- 실제 최상위·하위 폴더는 경고하지 않는다.
+- 정적 meta만 있는 legacy key도 경고하지 않는다.
+- 둘 다 없는 key는 경고하지만 create·update된다.
+- 대소문자가 다른 실제 경로는 경고한다.
+- 폴더 조회 실패는 개별 category 경고 없이 저장한다.
+- recursive tree 잘림은 하위 조회로 완성하고, 완성할 수 없으면 `null`을 반환한다.
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/infra/github/api.ts` | commit 기준 폴더 tree 조회 |
+| `src/infra/github/api.test.ts` | tree 정상·잘림·실패 테스트 |
+| `src/services/PostSyncService.ts` | 폴더 스냅샷과 경고 기준 |
+| `src/services/PostSyncService.test.ts` | full·incremental 저장·경고 회귀 |
+| `src/services/SyncService.ts` | `headSha` 전달 |
+| `src/services/SyncService.test.ts` | 전체·증분 전달 계약 |
+| `src/services/index.ts` | Github API wiring |
+
+## 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-blog/.claude/worktrees/plan055-github-folder-categories
+# branch: feat/plan055-github-folder-categories
+pnpm test src/infra/github/api.test.ts src/services/PostSyncService.test.ts src/services/SyncService.test.ts
+pnpm type-check
+rg -n "getRepositoryFolderPaths" src/infra/github/api.ts src/services/PostSyncService.ts
+rg -n "new PostSyncService\(postRepo, githubApi\)" src/services/index.ts
+```
+
+기대값:
+
+- 테스트와 type-check exit code가 0이다.
+- 두 `rg`가 함수 정의와 `PostSyncService` 참조, 기존 `githubApi` 구조적 주입을 출력한다.
+- `/api/sync` 응답 타입과 DB schema에는 diff가 없다.
+
+## 의도 메모 (왜)
+
+- 증분 변경 파일만으로는 변경되지 않은 폴더를 알 수 없으므로 해당 HEAD의 완전한 tree를 기준으로 삼는다.
+- `SyncService`는 HEAD와 실행 순서만 조정하고 category 검증은 글 parsing을 소유한 `PostSyncService`에 둔다.
+- plan054의 `refactor(sync): split post and metadata responsibilities`가 최종 구조다.
+  이번 phase는 분리된 책임을 되돌리지 않고 `PostSyncService`의 기존 full·incremental 공통 upsert 경로를 확장한다.
+- category 검증은 저자에게 오타를 알려주는 진단이며 콘텐츠 가용성을 차단하는 제약이 아니다.
+- full sync의 Markdown 파일 탐색은 기존 Contents API 경로를 유지해 issue #182 밖의 변경을 만들지 않는다.

--- a/tasks/plan055-github-folder-categories/phase-01.md
+++ b/tasks/plan055-github-folder-categories/phase-01.md
@@ -1,7 +1,7 @@
 # Phase 01 — GitHub HEAD 폴더 기반 category 검증
 
 **Execution profile**: standard
-**Status**: pending
+**Status**: completed
 
 ---
 

--- a/tasks/plan055-github-folder-categories/phase-02.md
+++ b/tasks/plan055-github-folder-categories/phase-02.md
@@ -1,0 +1,102 @@
+# Phase 02 — 동적 category 표시와 자동 등록
+
+**Execution profile**: standard
+**Status**: pending
+
+---
+
+## 목표
+
+정적 category meta가 없는 새 최상위 폴더도 코드 수정 없이 고유 이름과 안정적인 시각 표현으로 노출한다.
+기존 category의 별칭·색상·아이콘은 유지한다.
+
+**범위 외**: 사용자 지정 category 설정 파일, 빈 폴더 category, DB schema, OG 이미지 팔레트 변경.
+
+---
+
+## 작업 항목 (4)
+
+### 1. `src/lib/category-meta.ts` — 표시명과 색상 판정 분리
+
+다음 표시 함수를 추가한다.
+
+```ts
+export function getCategoryLabel(raw: string): string
+```
+
+trim한 전체 key 또는 첫 path segment가 `RAW_TO_CANONICAL`에 있으면 기존 canonical label을 반환한다.
+둘 다 없으면 trim한 원래 key를 반환하고, 빈 값만 `system`을 사용한다.
+
+`getCategoryHue()`는 알려진 key의 기존 hue를 그대로 유지한다.
+미등록 key는 첫 path segment의 안정적인 문자열 hash로 `0 <= hue < 360` 값을 계산한다.
+같은 최상위 폴더의 slash path는 같은 hue를 사용하며 프로세스·호출 순서에 의존하지 않아야 한다.
+`toCanonicalCategory()`와 `getCategoryTokenVar()`의 기존 공개 계약은 제거하지 않는다.
+
+### 2. category label 소비자 전환
+
+category 이름을 사용자에게 표시하는 다음 컴포넌트가 `toCanonicalCategory()` 대신 `getCategoryLabel()`을 사용하게 한다.
+
+- `src/components/PostCard.tsx`
+- `src/components/CategoryCard.tsx`
+- `src/components/CategoryFeatured.tsx`
+- `src/components/SeriesCard.tsx`
+- `src/components/ArticleHero.tsx`
+
+링크 slug, 저장 category key, CSS custom property에는 원본 key를 계속 사용한다.
+스타일 계산은 기존 `getCategoryColor()`를 재사용한다.
+
+### 3. 기본 아이콘과 category 자동 등록 보존
+
+`getCategoryIcon()`이 정적 아이콘이 없는 key에 `DEFAULT_CATEGORY_ICON`인 `📁`을 반환하는 기존 동작을 유지한다.
+`MetadataSyncService.updateCategories()`가 `PostRepository.getCategoryStats()`의 미등록 최상위 category도 `CategoryRepository.syncAll()`에 전달하는지 테스트로 고정한다.
+
+새 category 설정 테이블이나 `.category.yml`을 추가하지 않는다.
+활성 글이 하나 이상 있는 최상위 폴더만 기존 metadata 갱신 과정에서 category row를 생성한다.
+
+### 4. 표시 회귀 테스트
+
+`src/lib/category-meta.test.ts`에 다음 동작을 추가한다.
+
+- 기존 `AI`, `database`, `javascript`의 label과 hue는 유지된다.
+- `blockchain` label은 `system`이 아니라 `blockchain`이다.
+- `blockchain`과 `blockchain/evm`은 같은 안정적 hue를 사용한다.
+- 서로 다른 미등록 key의 hash 충돌 여부를 테스트 조건으로 삼지 않고 유효 범위와 반복 호출 안정성을 검증한다.
+- 빈 key는 안전한 기존 대체값을 사용한다.
+
+아이콘과 metadata 테스트에는 미등록 `blockchain`이 기본 아이콘과 category sync 입력으로 전달되는 사례를 추가한다.
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/lib/category-meta.ts` | 동적 label과 hash hue |
+| `src/lib/category-meta.test.ts` | 기존 meta와 동적 대체값 회귀 |
+| `src/components/PostCard.tsx` | 동적 label 표시 |
+| `src/components/CategoryCard.tsx` | 동적 label 표시 |
+| `src/components/CategoryFeatured.tsx` | 동적 label 표시 |
+| `src/components/SeriesCard.tsx` | 동적 label 표시 |
+| `src/components/ArticleHero.tsx` | 글 상세 category chip의 동적 label 표시 |
+| `src/infra/db/constants.test.ts` | 기본 아이콘 회귀 |
+| `src/services/MetadataSyncService.test.ts` | 신규 category 자동 등록 회귀 |
+
+## 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-blog/.claude/worktrees/plan055-github-folder-categories
+# branch: feat/plan055-github-folder-categories
+pnpm test src/lib/category-meta.test.ts src/infra/db/constants.test.ts src/services/MetadataSyncService.test.ts
+pnpm type-check
+! rg -n "toCanonicalCategory" src/components/PostCard.tsx src/components/CategoryCard.tsx src/components/CategoryFeatured.tsx src/components/SeriesCard.tsx src/components/ArticleHero.tsx
+```
+
+기대값:
+
+- 테스트와 type-check exit code가 0이다.
+- category 표시 컴포넌트에서 `toCanonicalCategory` 사용이 0건이다.
+- 기존 정적 category의 기대 색상과 아이콘 테스트가 계속 통과한다.
+
+## 의도 메모 (왜)
+
+- category 존재 여부와 디자인 재정의 여부를 분리해야 새 콘텐츠 폴더가 애플리케이션 배포에 종속되지 않는다.
+- 알려진 category의 기존 디자인을 보존해 화면 회귀를 피하고, 미등록 category만 결정적인 대체값을 사용한다.
+- 사용자 지정 meta 파일은 schema·검증·동기화 책임을 추가하므로 이번 자동 등록 범위에 포함하지 않는다.

--- a/tasks/plan055-github-folder-categories/phase-02.md
+++ b/tasks/plan055-github-folder-categories/phase-02.md
@@ -1,7 +1,7 @@
 # Phase 02 — 동적 category 표시와 자동 등록
 
 **Execution profile**: standard
-**Status**: pending
+**Status**: completed
 
 ---
 

--- a/tasks/plan055-github-folder-categories/phase-03.md
+++ b/tasks/plan055-github-folder-categories/phase-03.md
@@ -1,7 +1,7 @@
 # Phase 03 — 통합 검증과 완료 상태 반영
 
 **Execution profile**: fast
-**Status**: pending
+**Status**: completed
 
 ---
 

--- a/tasks/plan055-github-folder-categories/phase-03.md
+++ b/tasks/plan055-github-folder-categories/phase-03.md
@@ -1,0 +1,76 @@
+# Phase 03 — 통합 검증과 완료 상태 반영
+
+**Execution profile**: fast
+**Status**: pending
+
+---
+
+## 목표
+
+issue #182의 폴더 검증과 동적 category 표시가 전체 품질 검사에서 함께 통과하는지 확인하고 task를 완료 상태로 전환한다.
+
+**범위 외**: 기능 확장, 새 dependency, DB migration, docs 내용 변경.
+
+---
+
+## 작업 항목 (4)
+
+### 1. category 동기화 집중 회귀
+
+GitHub tree, 전체·증분 post sync, metadata sync, category meta와 아이콘 테스트를 한 번에 실행한다.
+실제 폴더 허용, 미등록 오타 경고, 저장 유지, 자동 category 등록, 동적 label·색상을 모두 증명해야 한다.
+
+### 2. 저장소 품질 검사
+
+`pnpm lint`, `pnpm type-check`, 전체 `pnpm test`, `pnpm build`를 실행한다.
+실패하면 원인을 고치고 관련 집중 테스트부터 다시 실행한 뒤 전체 검증을 반복한다.
+
+### 3. 범위와 잔재 검사
+
+다음을 확인한다.
+
+- `SyncService`가 tree 순회나 category 판정을 직접 소유하지 않는다.
+- category 표시 컴포넌트에 `toCanonicalCategory` 호출이 남지 않는다.
+- 새 dependency, DB schema, migration, `/api/sync` 응답 변경이 없다.
+- `RAW_TO_CANONICAL`은 선택적 legacy alias와 디자인 설정으로 남아 있으며 등록 필수 조건으로 쓰이지 않는다.
+
+### 4. task 완료 상태 반영
+
+모든 검증이 통과한 뒤 `tasks/plan055-github-folder-categories/index.json`의 최상위 `status`와 세 phase의 `status`를 `completed`로 변경한다.
+각 phase 파일의 `Status`도 `completed`로 맞춘다.
+이 상태 변경은 phase 03의 검증 관련 수정과 같은 단일 commit에 포함한다.
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `tasks/plan055-github-folder-categories/index.json` | 전체·phase 완료 상태 |
+| `tasks/plan055-github-folder-categories/phase-01.md` | 완료 상태 |
+| `tasks/plan055-github-folder-categories/phase-02.md` | 완료 상태 |
+| `tasks/plan055-github-folder-categories/phase-03.md` | 완료 상태 |
+
+## 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-blog/.claude/worktrees/plan055-github-folder-categories
+# branch: feat/plan055-github-folder-categories
+pnpm test src/infra/github/api.test.ts src/services/PostSyncService.test.ts src/services/SyncService.test.ts src/services/MetadataSyncService.test.ts src/lib/category-meta.test.ts src/infra/db/constants.test.ts
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm build
+git diff --check
+! rg -n "toCanonicalCategory" src/components/PostCard.tsx src/components/CategoryCard.tsx src/components/CategoryFeatured.tsx src/components/SeriesCard.tsx src/components/ArticleHero.tsx
+git diff --quiet origin/main...HEAD -- package.json pnpm-lock.yaml 'src/infra/db/schema/**' 'drizzle/**'
+```
+
+기대값:
+
+- 모든 명령의 exit code가 0이다.
+- 잔재 검사 출력이 0줄이다.
+- `index.json`과 세 phase 파일의 상태가 모두 `completed`다.
+
+## 의도 메모 (왜)
+
+- GitHub API 경계, 서비스 orchestration, category 표시를 함께 바꾸므로 집중 테스트와 전체 build를 모두 통과해야 완료로 본다.
+- task 상태는 구현·검증 완료 뒤에만 갱신해 계획과 실제 상태가 어긋나지 않게 한다.


### PR DESCRIPTION
## 요약
- GitHub HEAD의 실제 폴더 tree와 선택적 정적 meta를 기준으로 frontmatter category를 검증합니다.
- 알 수 없는 category는 저장을 막지 않고 경고하며, tree 조회 실패 시 잘못된 개별 경고를 생략합니다.
- 새 최상위 폴더 category를 원래 이름, 기본 아이콘, 안정적인 hash 색상으로 자동 표시합니다.

## 주요 커밋
- `feat(sync): validate categories against GitHub tree`
- `feat(category): add dynamic category presentation`
- `docs(task): complete plan055 implementation`
- `docs(category): align dynamic metadata references`

## 검증
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test` — 39 files, 388 tests
- [x] `pnpm build` — 396 static pages
- [x] code-reviewer `PASS`
- [x] docs-verifier `PASS`

## 특이사항 및 후속
- 기존 `getCrossCategoryPosts` SQL fallback 경고와 `/about` GitHub 401 fallback이 build 중 출력됐지만 이번 변경과 무관하며 build는 성공했습니다.
- `fos-study/CLAUDE.md` 작성 지침 갱신은 별도 저장소 후속 작업입니다.

Closes #182

🤖 Generated with Codex
