### PR TITLE
fix(category): 교차 카테고리 SQL ESCAPE 문법 수정

### DIFF
--- a/src/infra/db/repositories/PostRepository.test.ts
+++ b/src/infra/db/repositories/PostRepository.test.ts
@@ -137,7 +137,7 @@ describe("PostRepository.getCrossCategoryPosts", () => {
     expect(sqlCondition).toContain("path");
     expect(sqlCondition).toContain("NOT LIKE");
     expect(sqlCondition).toContain("AI/RAG/%");
-    expect(sqlCondition).toContain("ESCAPE");
+    expect(sqlCondition).toContain("ESCAPE '\\\\'");
     expect(result).toEqual([{ ...rows[0], folders: ["opensearch"] }]);
   });
 
@@ -155,7 +155,7 @@ describe("PostRepository.getCrossCategoryPosts", () => {
     const whereCondition = db.where.mock.calls[0]?.[0];
     const sqlCondition = flattenSqlTokens(whereCondition).join(" ");
     expect(sqlCondition).toContain("AI/R\\%\\_\\\\/%");
-    expect(sqlCondition).toContain("ESCAPE");
+    expect(sqlCondition).toContain("ESCAPE '\\\\'");
   });
 });
 

--- a/src/infra/db/repositories/PostRepository.ts
+++ b/src/infra/db/repositories/PostRepository.ts
@@ -426,7 +426,7 @@ export class PostRepository extends BaseRepository {
         and(
           eq(posts.isActive, true),
           sql`JSON_CONTAINS(${posts.categories}, JSON_QUOTE(${folderPath}))`,
-          sql`${posts.path} NOT LIKE ${escapedFolderPrefix} ESCAPE '\\'`,
+          sql`${posts.path} NOT LIKE ${escapedFolderPrefix} ESCAPE '\\\\'`,
         ),
       )
       .orderBy(asc(posts.title));


### PR DESCRIPTION
## 요약

- MySQL에 잘못 전달되던 `LIKE ... ESCAPE` 백슬래시 리터럴을 수정합니다.
- 테스트가 `ESCAPE` 키워드 존재뿐 아니라 정확한 SQL 리터럴까지 검증하도록 강화합니다.

## 검증

- [x] `pnpm test src/infra/db/repositories/PostRepository.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm build` — 396개 정적 페이지 생성, 기존 cross-category SQL 오류 미발생

🤖 Generated with [Claude Code](https://claude.com/claude-code)
