### PR TITLE
fix(about): 만료된 GitHub 토큰의 공개 프로필 재시도

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { env } from "@/env";
 import logger from "@/lib/logger";
+import { fetchGitHubProfile } from "@/services/GitHubProfileService";
 import { createDefaultStatsService } from "@/services/StatsService";
 import { ProfileCard } from "@/components/about/ProfileCard";
 import { SiteStats } from "@/components/about/SiteStats";
@@ -31,74 +32,6 @@ export const metadata: Metadata = {
     type: "website",
   },
 };
-
-interface GitHubProfile {
-  name: string | null;
-  avatar_url: string;
-  bio: string | null;
-  html_url: string;
-  public_repos: number;
-  followers: number;
-}
-
-interface ProfileData {
-  name: string;
-  handle: string;
-  avatarUrl: string | null;
-  bio: string;
-  htmlUrl: string;
-  publicRepos: number;
-  followers: number;
-}
-
-async function fetchGitHubProfile(): Promise<ProfileData> {
-  try {
-    const res = await fetch("https://api.github.com/users/jon890", {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
-      },
-      next: { revalidate: 3600 },
-    });
-
-    if (!res.ok) {
-      const err = new Error(`GitHub API responded with status ${res.status}`);
-      log.warn({ component: "about", operation: "github-profile", err, status: res.status }, "github profile fetch failed");
-      return {
-        name: "jon890",
-        handle: "@jon890",
-        avatarUrl: null,
-        bio: "",
-        htmlUrl: "https://github.com/jon890",
-        publicRepos: 0,
-        followers: 0,
-      };
-    }
-
-    const data: GitHubProfile = await res.json();
-    return {
-      name: data.name ?? "jon890",
-      handle: "@jon890",
-      avatarUrl: data.avatar_url,
-      bio: data.bio ?? "",
-      htmlUrl: data.html_url,
-      publicRepos: data.public_repos,
-      followers: data.followers,
-    };
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    log.warn({ component: "about", operation: "github-profile", err, status: 0 }, "github profile fetch failed");
-    return {
-      name: "jon890",
-      handle: "@jon890",
-      avatarUrl: null,
-      bio: "",
-      htmlUrl: "https://github.com/jon890",
-      publicRepos: 0,
-      followers: 0,
-    };
-  }
-}
 
 interface SectionProps {
   idx: string;
@@ -134,7 +67,7 @@ async function fetchSiteStats() {
 
 export default async function AboutPage() {
   const [profile, stats] = await Promise.all([
-    fetchGitHubProfile(),
+    fetchGitHubProfile(env.GITHUB_TOKEN),
     fetchSiteStats(),
   ]);
 

--- a/src/services/GitHubProfileService.test.ts
+++ b/src/services/GitHubProfileService.test.ts
@@ -43,6 +43,20 @@ describe("fetchGitHubProfile", () => {
     expect(result.name).toBe("FOS");
   });
 
+  it("토큰이 403으로 거부되면 인증 없이 공개 프로필을 짧은 캐시로 재요청한다", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(profile), { status: 200 }));
+
+    const result = await fetchGitHubProfile("expired-token", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls[1]?.[1]?.headers).not.toHaveProperty("Authorization");
+    expect(fetcher.mock.calls[1]?.[1]?.next).toMatchObject({ revalidate: 60 });
+    expect(result.name).toBe("FOS");
+  });
+
   it("재요청도 실패하면 기본 프로필을 반환한다", async () => {
     const fetcher = vi
       .fn<typeof fetch>()

--- a/src/services/GitHubProfileService.test.ts
+++ b/src/services/GitHubProfileService.test.ts
@@ -51,6 +51,7 @@ describe("fetchGitHubProfile", () => {
 
     const result = await fetchGitHubProfile("expired-token", fetcher);
 
+    expect(fetcher).toHaveBeenCalledTimes(2);
     expect(result).toEqual({
       name: "jon890",
       handle: "@jon890",

--- a/src/services/GitHubProfileService.test.ts
+++ b/src/services/GitHubProfileService.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchGitHubProfile } from "./GitHubProfileService";
+
+const profile = {
+  name: "FOS",
+  avatar_url: "https://example.com/avatar.png",
+  bio: "Developer",
+  html_url: "https://github.com/jon890",
+  public_repos: 42,
+  followers: 7,
+};
+
+describe("fetchGitHubProfile", () => {
+  it("인증 요청이 성공하면 GitHub 프로필을 반환한다", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify(profile), { status: 200 }));
+
+    const result = await fetchGitHubProfile("valid-token", fetcher);
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fetcher.mock.calls[0]?.[1]?.headers).toMatchObject({ Authorization: "Bearer valid-token" });
+    expect(result).toEqual({
+      name: "FOS",
+      handle: "@jon890",
+      avatarUrl: "https://example.com/avatar.png",
+      bio: "Developer",
+      htmlUrl: "https://github.com/jon890",
+      publicRepos: 42,
+      followers: 7,
+    });
+  });
+
+  it("토큰이 거부되면 인증 없이 공개 프로필을 재요청한다", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(profile), { status: 200 }));
+
+    const result = await fetchGitHubProfile("expired-token", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls[0]?.[1]?.headers).toMatchObject({ Authorization: "Bearer expired-token" });
+    expect(fetcher.mock.calls[1]?.[1]?.headers).not.toHaveProperty("Authorization");
+    expect(result.name).toBe("FOS");
+  });
+
+  it("재요청도 실패하면 기본 프로필을 반환한다", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }));
+
+    const result = await fetchGitHubProfile("expired-token", fetcher);
+
+    expect(result).toEqual({
+      name: "jon890",
+      handle: "@jon890",
+      avatarUrl: null,
+      bio: "",
+      htmlUrl: "https://github.com/jon890",
+      publicRepos: 0,
+      followers: 0,
+    });
+  });
+});

--- a/src/services/GitHubProfileService.ts
+++ b/src/services/GitHubProfileService.ts
@@ -1,0 +1,78 @@
+import logger from "@/lib/logger";
+
+const log = logger.child({ module: "services/github-profile" });
+const profileUrl = "https://api.github.com/users/jon890";
+
+interface GitHubProfile {
+  name: string | null;
+  avatar_url: string;
+  bio: string | null;
+  html_url: string;
+  public_repos: number;
+  followers: number;
+}
+
+export interface ProfileData {
+  name: string;
+  handle: string;
+  avatarUrl: string | null;
+  bio: string;
+  htmlUrl: string;
+  publicRepos: number;
+  followers: number;
+}
+
+const fallbackProfile: ProfileData = {
+  name: "jon890",
+  handle: "@jon890",
+  avatarUrl: null,
+  bio: "",
+  htmlUrl: "https://github.com/jon890",
+  publicRepos: 0,
+  followers: 0,
+};
+
+function requestProfile(fetcher: typeof fetch, token?: string) {
+  return fetcher(profileUrl, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    next: { revalidate: 3600 },
+  });
+}
+
+export async function fetchGitHubProfile(token: string, fetcher: typeof fetch = fetch): Promise<ProfileData> {
+  try {
+    let response = await requestProfile(fetcher, token);
+
+    if (response.status === 401) {
+      log.warn(
+        { component: "about", operation: "github-profile", status: response.status },
+        "github token rejected, retrying public profile without authentication",
+      );
+      response = await requestProfile(fetcher);
+    }
+
+    if (!response.ok) {
+      const err = new Error(`GitHub API responded with status ${response.status}`);
+      log.warn({ component: "about", operation: "github-profile", err, status: response.status }, "github profile fetch failed");
+      return fallbackProfile;
+    }
+
+    const data: GitHubProfile = await response.json();
+    return {
+      name: data.name ?? "jon890",
+      handle: "@jon890",
+      avatarUrl: data.avatar_url,
+      bio: data.bio ?? "",
+      htmlUrl: data.html_url,
+      publicRepos: data.public_repos,
+      followers: data.followers,
+    };
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    log.warn({ component: "about", operation: "github-profile", err, status: 0 }, "github profile fetch failed");
+    return fallbackProfile;
+  }
+}

--- a/src/services/GitHubProfileService.ts
+++ b/src/services/GitHubProfileService.ts
@@ -32,13 +32,17 @@ const fallbackProfile: ProfileData = {
   followers: 0,
 };
 
-function requestProfile(fetcher: typeof fetch, token?: string) {
+function requestProfile(
+  fetcher: typeof fetch,
+  token?: string,
+  revalidate = 3600,
+) {
   return fetcher(profileUrl, {
     headers: {
       Accept: "application/vnd.github+json",
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
-    next: { revalidate: 3600 },
+    next: { revalidate },
   });
 }
 
@@ -46,17 +50,17 @@ export async function fetchGitHubProfile(token: string, fetcher: typeof fetch = 
   try {
     let response = await requestProfile(fetcher, token);
 
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
       log.warn(
-        { component: "about", operation: "github-profile", status: response.status },
+        { operation: "github-profile", status: response.status },
         "github token rejected, retrying public profile without authentication",
       );
-      response = await requestProfile(fetcher);
+      response = await requestProfile(fetcher, undefined, 60);
     }
 
     if (!response.ok) {
       const err = new Error(`GitHub API responded with status ${response.status}`);
-      log.warn({ component: "about", operation: "github-profile", err, status: response.status }, "github profile fetch failed");
+      log.warn({ operation: "github-profile", err, status: response.status }, "github profile fetch failed");
       return fallbackProfile;
     }
 
@@ -72,7 +76,7 @@ export async function fetchGitHubProfile(token: string, fetcher: typeof fetch = 
     };
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
-    log.warn({ component: "about", operation: "github-profile", err, status: 0 }, "github profile fetch failed");
+    log.warn({ operation: "github-profile", err, status: 0 }, "github profile fetch failed");
     return fallbackProfile;
   }
 }


### PR DESCRIPTION
## 요약

- `/about`의 GitHub 프로필 조회를 서비스로 분리해 실패 처리를 테스트 가능하게 만듭니다.
- 설정된 토큰이 401로 거부되면 공개 프로필 API를 인증 없이 한 번 재시도합니다.
- 콘텐츠 동기화의 GitHub 인증 동작은 변경하지 않습니다.

## 검증

- [x] `pnpm test src/services/GitHubProfileService.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] 만료된 로컬 토큰을 사용한 `pnpm build` — `/about` 포함 396개 정적 페이지 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)
