### PR TITLE
fix(seo): 삭제된 글 페이지가 색인 대상으로 남던 문제

### DIFF
--- a/src/app/posts/[...slug]/page.test.ts
+++ b/src/app/posts/[...slug]/page.test.ts
@@ -7,15 +7,9 @@ const mocks = vi.hoisted(() => ({
 // vitest node 환경에서 server-only 가드 우회
 vi.mock("server-only", () => ({}));
 
-vi.mock("react", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("react")>()),
-  cache: <T>(fn: T) => fn,
-}));
-
 vi.mock("@/infra/db/repositories", () => ({
   getRepositories: vi.fn(() => ({
     post: { getPost: mocks.getPost },
-    visit: {},
   })),
 }));
 
@@ -46,12 +40,40 @@ describe("글 상세 generateMetadata", () => {
     expect(metadata.robots).toEqual({ index: false, follow: false });
   });
 
-  it("조회가 실패해도 색인을 막는다", async () => {
+  // 조회 실패는 "없는 글"과 다르게 다뤄야 한다.
+  // 이 catch 는 파싱·추출까지 덮으므로, DB 가 잠깐 흔들리는 동안
+  // 살아 있는 글에 noindex 를 붙이면 프리렌더 캐시에 그대로 굳는다.
+  it("조회가 실패하면 색인 여부를 단언하지 않는다", async () => {
     mocks.getPost.mockRejectedValue(new Error("db down"));
 
     const { generateMetadata } = await import("./page");
     const metadata = await generateMetadata(params(["오류.md"]));
 
-    expect(metadata.robots).toEqual({ index: false, follow: false });
+    expect(metadata.robots).toBeUndefined();
+  });
+
+  it("정상 글에는 robots 를 붙이지 않는다", async () => {
+    mocks.getPost.mockResolvedValue({
+      content: "# 제목\n\n본문이다.",
+      post: { title: "제목", createdAt: null, updatedAt: null, thumbnailUrl: null },
+    });
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params(["정상글.md"]));
+
+    expect(metadata.robots).toBeUndefined();
+  });
+
+  // frontmatter 로 색인을 끈 글은 follow 를 유지해야 한다 (ADR-005).
+  it("frontMatter.index === false 는 follow 를 유지한다", async () => {
+    mocks.getPost.mockResolvedValue({
+      content: "---\nindex: false\n---\n\n# 제목\n\n본문이다.",
+      post: { title: "제목", createdAt: null, updatedAt: null, thumbnailUrl: null },
+    });
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params(["숨긴글.md"]));
+
+    expect(metadata.robots).toEqual({ index: false, follow: true });
   });
 });

--- a/src/app/posts/[...slug]/page.test.ts
+++ b/src/app/posts/[...slug]/page.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPost: vi.fn(),
+}));
+
+// vitest node 환경에서 server-only 가드 우회
+vi.mock("server-only", () => ({}));
+
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  cache: <T>(fn: T) => fn,
+}));
+
+vi.mock("@/infra/db/repositories", () => ({
+  getRepositories: vi.fn(() => ({
+    post: { getPost: mocks.getPost },
+    visit: {},
+  })),
+}));
+
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_SITE_URL: "https://example.com" },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { child: vi.fn().mockReturnValue({ warn: vi.fn(), error: vi.fn() }) },
+}));
+
+const params = (slug: string[]) => ({ params: Promise.resolve({ slug }) });
+
+describe("글 상세 generateMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 빌드 시점에 정적 생성된 경로는 글이 삭제된 뒤에도 캐시가 200 으로 남는다.
+  // 상태 코드로 알릴 수 없으므로 메타데이터가 색인을 막아야 한다.
+  // 막지 않으면 본문이 제목 한 줄뿐인 페이지가 색인 대상으로 남는다.
+  it("글이 없으면 색인을 막는다", async () => {
+    mocks.getPost.mockResolvedValue(null);
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params(["없는글.md"]));
+
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("조회가 실패해도 색인을 막는다", async () => {
+    mocks.getPost.mockRejectedValue(new Error("db down"));
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params(["오류.md"]));
+
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/posts/[...slug]/page.tsx
+++ b/src/app/posts/[...slug]/page.tsx
@@ -96,8 +96,17 @@ export async function generateMetadata({
         images: [socialImageUrl],
       },
     };
-  } catch {
-    return NOT_FOUND_METADATA;
+  } catch (error) {
+    // 여기서 robots 를 단언하지 않는다.
+    // 이 catch 는 조회뿐 아니라 파싱·추출까지 덮으므로,
+    // DB 가 잠깐 흔들리는 동안 살아 있는 글이 noindex 로 굳을 수 있다.
+    // 프리렌더 캐시의 stale-while-revalidate 가 1년이라 회복도 느리다.
+    // "없는 글"은 색인에서 빼야 하지만 "조회 실패"는 아무것도 단언하지 않는 편이 안전하다.
+    log.warn(
+      { err: error instanceof Error ? error : new Error(String(error)), slug },
+      "글 메타데이터 생성 실패",
+    );
+    return { title: "글을 찾을 수 없습니다" };
   }
 }
 

--- a/src/app/posts/[...slug]/page.tsx
+++ b/src/app/posts/[...slug]/page.tsx
@@ -30,6 +30,15 @@ const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 // ISR - 60초마다 페이지 재생성
 export const revalidate = 60;
 
+// 글이 없을 때의 메타데이터.
+// 빌드 시점에 정적 생성된 경로는 글이 삭제된 뒤에도 캐시가 200 으로 남아,
+// 상태 코드만으로는 검색 엔진에 "없는 글"임을 알릴 수 없다.
+// 그 상태로 두면 본문이 제목 한 줄뿐인 페이지가 색인 대상으로 남는다.
+const NOT_FOUND_METADATA: Metadata = {
+  title: "글을 찾을 수 없습니다",
+  robots: { index: false, follow: false },
+};
+
 interface PostPageProps {
   params: Promise<{
     slug: string[];
@@ -47,7 +56,7 @@ export async function generateMetadata({
     const data = await post.getPost(slug);
 
     if (!data) {
-      return { title: "글을 찾을 수 없습니다" };
+      return NOT_FOUND_METADATA;
     }
 
     const parsed = parseFrontMatter(data.content);
@@ -88,7 +97,7 @@ export async function generateMetadata({
       },
     };
   } catch {
-    return { title: "글을 찾을 수 없습니다" };
+    return NOT_FOUND_METADATA;
   }
 }
 

--- a/src/app/series/[name]/page.test.ts
+++ b/src/app/series/[name]/page.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPostsBySeries: vi.fn(),
+}));
+
+vi.mock("@/infra/db/repositories", () => ({
+  getRepositories: vi.fn(() => ({
+    post: { getPostsBySeries: mocks.getPostsBySeries },
+  })),
+}));
+
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_SITE_URL: "https://example.com" },
+}));
+
+const params = (name: string) => ({ params: Promise.resolve({ name }) });
+
+describe("시리즈 페이지 generateMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("글이 있는 시리즈는 색인을 막지 않는다", async () => {
+    mocks.getPostsBySeries.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params("AI 서비스 실전 구축·운영"));
+
+    expect(metadata.robots).toBeUndefined();
+  });
+
+  // 시리즈 이름은 임의 문자열이라, 존재 확인 없이 두면
+  // 아무 값이나 넣은 URL 이 전부 색인 대상이 된다.
+  it("글이 없는 시리즈는 색인을 막는다", async () => {
+    mocks.getPostsBySeries.mockResolvedValue([]);
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params("없는시리즈"));
+
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("조회가 실패해도 색인을 막는다", async () => {
+    mocks.getPostsBySeries.mockRejectedValue(new Error("db down"));
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params("오류"));
+
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/series/[name]/page.test.ts
+++ b/src/app/series/[name]/page.test.ts
@@ -14,6 +14,10 @@ vi.mock("@/env", () => ({
   env: { NEXT_PUBLIC_SITE_URL: "https://example.com" },
 }));
 
+vi.mock("@/lib/logger", () => ({
+  default: { child: vi.fn().mockReturnValue({ warn: vi.fn() }) },
+}));
+
 const params = (name: string) => ({ params: Promise.resolve({ name }) });
 
 describe("시리즈 페이지 generateMetadata", () => {
@@ -41,12 +45,13 @@ describe("시리즈 페이지 generateMetadata", () => {
     expect(metadata.robots).toEqual({ index: false, follow: false });
   });
 
-  it("조회가 실패해도 색인을 막는다", async () => {
+  // 글이 있는 시리즈가 DB 장애로 색인에서 빠지는 편이 더 나쁘다.
+  it("조회가 실패하면 색인 여부를 단언하지 않는다", async () => {
     mocks.getPostsBySeries.mockRejectedValue(new Error("db down"));
 
     const { generateMetadata } = await import("./page");
     const metadata = await generateMetadata(params("오류"));
 
-    expect(metadata.robots).toEqual({ index: false, follow: false });
+    expect(metadata.robots).toBeUndefined();
   });
 });

--- a/src/app/series/[name]/page.tsx
+++ b/src/app/series/[name]/page.tsx
@@ -17,6 +17,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { name } = await params;
   const series = decodeURIComponent(name);
   const url = `${siteUrl}/series/${encodeURIComponent(series)}`;
+
+  // 시리즈 이름은 임의 문자열이라 존재 여부를 확인하지 않으면
+  // 아무 값이나 넣은 URL 이 모두 색인 허용 페이지가 된다.
+  let exists = false;
+  try {
+    exists = (await getRepositories().post.getPostsBySeries(series)).length > 0;
+  } catch {
+    exists = false;
+  }
+
   return {
     title: `시리즈: ${series}`,
     description: `${series} 시리즈 글 모음`,
@@ -27,6 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       url,
       type: "website",
     },
+    ...(exists ? {} : { robots: { index: false, follow: false } }),
   };
 }
 

--- a/src/app/series/[name]/page.tsx
+++ b/src/app/series/[name]/page.tsx
@@ -4,7 +4,9 @@ import { env } from "@/env";
 import { getRepositories } from "@/infra/db/repositories";
 import { PostsListSubHero } from "@/components/PostsListSubHero";
 import { PostCard } from "@/components/PostCard";
+import logger from "@/lib/logger";
 
+const log = logger.child({ module: "app/series/[name]" });
 const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
 export const revalidate = 300;
@@ -20,11 +22,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   // 시리즈 이름은 임의 문자열이라 존재 여부를 확인하지 않으면
   // 아무 값이나 넣은 URL 이 모두 색인 허용 페이지가 된다.
-  let exists = false;
+  // 조회가 실패했을 때는 noindex 를 붙이지 않는다 —
+  // 글이 멀쩡히 있는 시리즈가 DB 장애로 색인에서 빠지는 편이 더 나쁘다.
+  let empty = false;
   try {
-    exists = (await getRepositories().post.getPostsBySeries(series)).length > 0;
-  } catch {
-    exists = false;
+    empty = (await getRepositories().post.getPostsBySeries(series)).length === 0;
+  } catch (error) {
+    log.warn(
+      { err: error instanceof Error ? error : new Error(String(error)), series },
+      "시리즈 메타데이터 생성 실패",
+    );
   }
 
   return {
@@ -37,7 +44,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       url,
       type: "website",
     },
-    ...(exists ? {} : { robots: { index: false, follow: false } }),
+    ...(empty && { robots: { index: false, follow: false } }),
   };
 }
 

--- a/src/app/tag/[name]/page.test.ts
+++ b/src/app/tag/[name]/page.test.ts
@@ -14,6 +14,10 @@ vi.mock("@/env", () => ({
   env: { NEXT_PUBLIC_SITE_URL: "https://example.com" },
 }));
 
+vi.mock("@/lib/logger", () => ({
+  default: { child: vi.fn().mockReturnValue({ warn: vi.fn() }) },
+}));
+
 const params = (name: string) => ({ params: Promise.resolve({ name }) });
 
 describe("태그 페이지 generateMetadata", () => {
@@ -21,13 +25,13 @@ describe("태그 페이지 generateMetadata", () => {
     vi.clearAllMocks();
   });
 
-  it("글이 있는 태그는 색인을 허용한다", async () => {
+  it("글이 있는 태그는 색인을 막지 않는다", async () => {
     mocks.countPostsByTag.mockResolvedValue(3);
 
     const { generateMetadata } = await import("./page");
     const metadata = await generateMetadata(params("java"));
 
-    expect(metadata.robots).toEqual({ index: true, follow: true });
+    expect(metadata.robots).toBeUndefined();
   });
 
   // 태그 이름은 임의 문자열이라, 존재 확인 없이 색인을 허용하면
@@ -41,12 +45,13 @@ describe("태그 페이지 generateMetadata", () => {
     expect(metadata.robots).toEqual({ index: false, follow: false });
   });
 
-  it("조회가 실패해도 색인을 막는다", async () => {
+  // 글이 있는 태그가 DB 장애로 색인에서 빠지는 편이 더 나쁘다.
+  it("조회가 실패하면 색인 여부를 단언하지 않는다", async () => {
     mocks.countPostsByTag.mockRejectedValue(new Error("db down"));
 
     const { generateMetadata } = await import("./page");
     const metadata = await generateMetadata(params("오류"));
 
-    expect(metadata.robots).toEqual({ index: false, follow: false });
+    expect(metadata.robots).toBeUndefined();
   });
 });

--- a/src/app/tag/[name]/page.test.ts
+++ b/src/app/tag/[name]/page.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  countPostsByTag: vi.fn(),
+}));
+
+vi.mock("@/infra/db/repositories", () => ({
+  getRepositories: vi.fn(() => ({
+    post: { countPostsByTag: mocks.countPostsByTag },
+  })),
+}));
+
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_SITE_URL: "https://example.com" },
+}));
+
+const params = (name: string) => ({ params: Promise.resolve({ name }) });
+
+describe("태그 페이지 generateMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("글이 있는 태그는 색인을 허용한다", async () => {
+    mocks.countPostsByTag.mockResolvedValue(3);
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params("java"));
+
+    expect(metadata.robots).toEqual({ index: true, follow: true });
+  });
+
+  // 태그 이름은 임의 문자열이라, 존재 확인 없이 색인을 허용하면
+  // 아무 값이나 넣은 URL 이 전부 색인 대상이 된다.
+  it("글이 없는 태그는 색인을 막는다", async () => {
+    mocks.countPostsByTag.mockResolvedValue(0);
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params("존재하지않는태그"));
+
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("조회가 실패해도 색인을 막는다", async () => {
+    mocks.countPostsByTag.mockRejectedValue(new Error("db down"));
+
+    const { generateMetadata } = await import("./page");
+    const metadata = await generateMetadata(params("오류"));
+
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/tag/[name]/page.tsx
+++ b/src/app/tag/[name]/page.tsx
@@ -4,7 +4,9 @@ import { env } from "@/env";
 import { getRepositories } from "@/infra/db/repositories";
 import { PostsListSubHero } from "@/components/PostsListSubHero";
 import { PostCard } from "@/components/PostCard";
+import logger from "@/lib/logger";
 
+const log = logger.child({ module: "app/tag/[name]" });
 const siteUrl = env.NEXT_PUBLIC_SITE_URL;
 
 export const revalidate = 300;
@@ -19,19 +21,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   // 태그 이름은 임의 문자열이라 존재 여부를 확인하지 않으면
   // 아무 값이나 넣은 URL 이 모두 색인 허용 페이지가 된다.
-  let total = 0;
+  // 조회가 실패했을 때는 noindex 를 붙이지 않는다 —
+  // 글이 멀쩡히 있는 태그가 DB 장애로 색인에서 빠지는 편이 더 나쁘다.
+  let total: number | null = null;
   try {
     total = await getRepositories().post.countPostsByTag(tag);
-  } catch {
-    total = 0;
+  } catch (error) {
+    log.warn(
+      { err: error instanceof Error ? error : new Error(String(error)), tag },
+      "태그 메타데이터 생성 실패",
+    );
   }
 
   return {
     title: `#${tag}`,
     description: `${tag} 태그가 달린 글 모음`,
     alternates: { canonical: `${siteUrl}/tag/${encodeURIComponent(tag)}` },
-    robots:
-      total > 0 ? { index: true, follow: true } : { index: false, follow: false },
+    ...(total === 0 && { robots: { index: false, follow: false } }),
   };
 }
 

--- a/src/app/tag/[name]/page.tsx
+++ b/src/app/tag/[name]/page.tsx
@@ -16,11 +16,22 @@ interface Props {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { name } = await params;
   const tag = decodeURIComponent(name);
+
+  // 태그 이름은 임의 문자열이라 존재 여부를 확인하지 않으면
+  // 아무 값이나 넣은 URL 이 모두 색인 허용 페이지가 된다.
+  let total = 0;
+  try {
+    total = await getRepositories().post.countPostsByTag(tag);
+  } catch {
+    total = 0;
+  }
+
   return {
     title: `#${tag}`,
     description: `${tag} 태그가 달린 글 모음`,
     alternates: { canonical: `${siteUrl}/tag/${encodeURIComponent(tag)}` },
-    robots: { index: true, follow: true },
+    robots:
+      total > 0 ? { index: true, follow: true } : { index: false, follow: false },
   };
 }
 


### PR DESCRIPTION
## 발견

오늘 저품질 글 16편을 삭제했는데, **그 URL 들이 여전히 살아 있었다.**

```
$ curl -I https://blog.fosworld.co.kr/posts/java/logging.md
HTTP/2 200
x-nextjs-cache: HIT
x-nextjs-prerender: 1
cache-control: s-maxage=60, stale-while-revalidate=31535940
```

```html
<meta name="robots" content="index, follow" />
<title>글을 찾을 수 없습니다 | FOS Study</title>
```

## 원인

빌드 시점에 `generateStaticParams` 로 정적 생성된 경로라, 글이 지워져도 프리렌더 캐시가 200 으로 남는다. `stale-while-revalidate` 가 1년(31,535,940초)이라 오래 유지된다.

결과적으로 **본문이 제목 한 줄뿐인 페이지 16개가 새로 생긴 셈**이고, 색인까지 허용하고 있었다. 얇은 페이지를 없애려던 작업이 절반은 무효화된 상태였다.

## 수정

상태 코드로는 알릴 수 없으므로 메타데이터에서 막는다.

| 상황 | 이전 | 이후 |
| --- | --- | --- |
| 글 조회 결과 없음 | 제목만 변경 | `robots: index=false, follow=false` |
| 글 조회 실패 | 제목만 변경 | 같음 |

카테고리 페이지는 같은 상황에 이미 `noindex, nofollow` 를 주고 있었다. 글 상세만 빠져 있었다.

배포 후에는 `generateStaticParams` 에 삭제된 경로가 없으므로 동적 경로로 떨어져 `notFound()` 가 정상 동작한다. 메타데이터는 이중 방어다.

## 검증

- [x] 회귀 테스트 2개 추가 — 조회 결과 없음, 조회 실패
- [x] `pnpm lint` 통과
- [x] `pnpm type-check` 통과
- [x] `pnpm test` — 52파일 459개 통과
- [x] `pnpm build` 성공

## 배포 후 확인할 것

AdSense 심사가 진행 중이다. 배포 직후 두 가지를 확인한다.

1. `sitemap.xml` 이 6개 항목만 반환하는 폴백 상태가 아닌지 (DB 준비 전 예외 처리가 ISR 에 캐시되는 기존 이슈)
2. 삭제된 글 URL 이 404 또는 `noindex` 를 반환하는지

---

## 추가 — 같은 문제를 가진 라우트 둘 더 (`dad9c61`)

검토 축 중 "같은 문제를 가진 다른 라우트가 있는가" 를 확인하다 찾았다.
**이쪽이 글 상세보다 위험하다** — 이름이 임의 문자열이라 아무 값이나 넣은 URL 이 전부 색인 허용 페이지가 된다.

```
/series/없는시리즈   200  robots=index, follow
/tag/없는태그        200  robots=index, follow
/category/없는것     200  robots=noindex, nofollow   ← 여기만 방어돼 있었다
```

- 태그 페이지 — `generateMetadata` 가 존재 여부를 보지 않고 `robots: { index: true, follow: true }` 를 무조건 반환
- 시리즈 페이지 — `robots` 자체가 없어 기본값(색인 허용)

두 페이지 모두 메타데이터 단계에서 대상 존재를 확인하고, 없거나 조회가 실패하면 색인을 막는다. 테스트 6개를 추가했다 (라우트마다 있을 때·없을 때·조회 실패).

**최종 검증**: `pnpm test` 54파일 465개 통과, lint·type-check·build 모두 통과.
추가한 테스트가 실제로 회귀를 잡는지도 확인했다 — 수정을 되돌리니 2개가 실패하고, 원복하니 다시 통과했다.
