### PR TITLE
feat(ui): mermaid 다이어그램 확대 보기

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -268,6 +268,15 @@ code, kbd, samp, pre {
   padding: 0;
 }
 
+/* mermaid 확대 모달 — mermaid 가 svg 에 심는 인라인 max-width 를 풀어
+   컨테이너 크기까지 키우고, 넘치는 부분은 확대·이동 조작에 맡긴다. */
+.mermaid-zoom-stage svg {
+  max-width: 100% !important;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+}
+
 /* === 코드 블록 frame (plan012) === */
 /* CodeCard (figure.code-card) 가 grid/flex item 안에 있을 때 부모를 늘리지 않도록
  * min-width: 0 강제. fig 자체는 .code-card-body 의 overflow-x: auto 에 의존. */

--- a/src/components/Mermaid.test.tsx
+++ b/src/components/Mermaid.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const renderMock = vi.fn();
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: (...args: unknown[]) => renderMock(...args),
+  },
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "dark", systemTheme: "dark" }),
+}));
+
+const { Mermaid } = await import("./Mermaid");
+
+beforeEach(() => {
+  renderMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Mermaid", () => {
+  it("렌더에 성공하면 확대 버튼을 함께 보여준다", async () => {
+    renderMock.mockResolvedValue({ svg: "<svg><rect /></svg>" });
+
+    render(<Mermaid chart="flowchart LR\n A --> B" />);
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText("다이어그램 확대 보기")).not.toBeNull(),
+    );
+  });
+
+  it("확대 버튼을 누르면 확대 모달이 열린다", async () => {
+    renderMock.mockResolvedValue({ svg: "<svg><rect /></svg>" });
+
+    render(<Mermaid chart="flowchart LR\n A --> B" />);
+
+    const button = await waitFor(() =>
+      screen.getByLabelText("다이어그램 확대 보기"),
+    );
+    fireEvent.click(button);
+
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+  });
+
+  it("렌더에 실패하면 확대 버튼을 감춘다", async () => {
+    renderMock.mockRejectedValue(new Error("bad chart"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<Mermaid chart="not a chart" />);
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(screen.queryByLabelText("다이어그램 확대 보기")).toBeNull();
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -3,6 +3,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import mermaid from "mermaid";
 import { useTheme } from "next-themes";
+import { Maximize2 } from "lucide-react";
+import { MermaidZoomModal } from "./mermaid/MermaidZoomModal";
+
+const ICON_SIZE_ZOOM = 16;
 
 interface MermaidProps {
   chart: string;
@@ -10,6 +14,8 @@ interface MermaidProps {
 
 export function Mermaid({ chart }: MermaidProps) {
   const [svg, setSvg] = useState<string>("");
+  const [hasError, setHasError] = useState(false);
+  const [isZoomOpen, setIsZoomOpen] = useState(false);
   const { theme, systemTheme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -32,23 +38,52 @@ export function Mermaid({ chart }: MermaidProps) {
         const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
         const { svg } = await mermaid.render(id, chart);
         setSvg(svg);
+        setHasError(false);
       } catch (error) {
         console.error("Failed to render mermaid chart:", error);
         // 에러 발생 시 원본 코드 표시
         setSvg(
           `<pre class="text-red-500">${error instanceof Error ? error.message : "Mermaid rendering error"}</pre>`,
         );
+        setHasError(true);
       }
     };
 
     renderChart();
   }, [chart, theme, systemTheme]);
 
+  const canZoom = Boolean(svg) && !hasError;
+
   return (
-    <div
-      ref={containerRef}
-      className="mermaid flex justify-center my-8 overflow-x-auto"
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
+    <div className="my-8">
+      <div
+        ref={containerRef}
+        className="mermaid flex justify-center overflow-x-auto"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+
+      {/* 다이어그램과 겹치지 않게 아래 줄에 둔다. 다이어그램이 낮으면 위에 겹친다. */}
+      {canZoom && (
+        <div className="mt-2 flex justify-end">
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-brand-400)]"
+            onClick={() => setIsZoomOpen(true)}
+            aria-label="다이어그램 확대 보기"
+          >
+            <Maximize2 size={ICON_SIZE_ZOOM} />
+            <span>확대</span>
+          </button>
+        </div>
+      )}
+
+      {isZoomOpen && (
+        <MermaidZoomModal
+          svg={svg}
+          label="다이어그램 확대 보기"
+          onClose={() => setIsZoomOpen(false)}
+        />
+      )}
+    </div>
   );
 }

--- a/src/components/mermaid/MermaidZoomModal.test.tsx
+++ b/src/components/mermaid/MermaidZoomModal.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MermaidZoomModal } from "./MermaidZoomModal";
+
+afterEach(() => {
+  cleanup();
+});
+
+const SVG = `<svg role="img" aria-label="chart"><rect width="10" height="10" /></svg>`;
+
+function renderModal(onClose = vi.fn()) {
+  render(<MermaidZoomModal svg={SVG} label="다이어그램 확대 보기" onClose={onClose} />);
+  return onClose;
+}
+
+describe("MermaidZoomModal", () => {
+  it("전달받은 svg 를 dialog 안에 렌더한다", () => {
+    renderModal();
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.querySelector("svg")).not.toBeNull();
+  });
+
+  it("확대 버튼이 배율을 올린다", () => {
+    renderModal();
+
+    expect(screen.getByText("100%")).not.toBeNull();
+    fireEvent.click(screen.getByLabelText("확대"));
+    expect(screen.queryByText("100%")).toBeNull();
+    expect(screen.getByText("150%")).not.toBeNull();
+  });
+
+  it("원래 크기로 버튼이 배율을 되돌린다", () => {
+    renderModal();
+
+    fireEvent.click(screen.getByLabelText("확대"));
+    fireEvent.click(screen.getByLabelText("원래 크기로"));
+    expect(screen.getByText("100%")).not.toBeNull();
+  });
+
+  it("배율에 하한이 있다", () => {
+    renderModal();
+
+    for (let i = 0; i < 10; i += 1) {
+      fireEvent.click(screen.getByLabelText("축소"));
+    }
+    expect(screen.getByText("50%")).not.toBeNull();
+  });
+
+  it("ESC 키로 닫는다", () => {
+    const onClose = renderModal();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("닫기 버튼으로 닫는다", () => {
+    const onClose = renderModal();
+
+    fireEvent.click(screen.getByLabelText("닫기"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("열려 있는 동안 배경 스크롤을 잠그고 닫을 때 되돌린다", () => {
+    const { unmount } = render(
+      <MermaidZoomModal svg={SVG} label="다이어그램 확대 보기" onClose={vi.fn()} />,
+    );
+
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+});

--- a/src/components/mermaid/MermaidZoomModal.test.tsx
+++ b/src/components/mermaid/MermaidZoomModal.test.tsx
@@ -63,6 +63,56 @@ describe("MermaidZoomModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("다이어그램 밖을 탭하면 닫는다", () => {
+    const onClose = renderModal();
+    const stage = document.querySelector(".mermaid-zoom-stage") as HTMLElement;
+    stage.setPointerCapture = () => {};
+
+    fireEvent.pointerDown(stage, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(stage, { pointerId: 1, clientX: 11, clientY: 12 });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("끌어서 이동한 뒤에는 닫지 않는다", () => {
+    const onClose = renderModal();
+    const stage = document.querySelector(".mermaid-zoom-stage") as HTMLElement;
+    stage.setPointerCapture = () => {};
+
+    fireEvent.pointerDown(stage, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(stage, { pointerId: 1, clientX: 90, clientY: 60 });
+    fireEvent.pointerUp(stage, { pointerId: 1, clientX: 90, clientY: 60 });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("다이어그램을 탭하면 닫지 않는다", () => {
+    const onClose = renderModal();
+    const stage = document.querySelector(".mermaid-zoom-stage") as HTMLElement;
+    stage.setPointerCapture = () => {};
+    const svg = stage.querySelector("svg") as SVGSVGElement;
+
+    fireEvent.pointerDown(svg, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(svg, { pointerId: 1, clientX: 10, clientY: 10 });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("Tab 포커스를 모달 안에 묶는다", () => {
+    renderModal();
+    const buttons = screen.getAllByRole("button");
+    const first = buttons[0];
+    const last = buttons[buttons.length - 1];
+
+    last.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
   it("열려 있는 동안 배경 스크롤을 잠그고 닫을 때 되돌린다", () => {
     const { unmount } = render(
       <MermaidZoomModal svg={SVG} label="다이어그램 확대 보기" onClose={vi.fn()} />,

--- a/src/components/mermaid/MermaidZoomModal.tsx
+++ b/src/components/mermaid/MermaidZoomModal.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Minus, Plus, RotateCcw, X } from "lucide-react";
+
+const MIN_SCALE = 0.5;
+const MAX_SCALE = 12;
+const MAX_INITIAL_SCALE = 6;
+const SCALE_STEP = 1.5;
+const WHEEL_SENSITIVITY = 0.0015;
+const ICON_SIZE = 22;
+const ICON_SIZE_CLOSE = 26;
+
+type Transform = { scale: number; x: number; y: number };
+
+const IDENTITY: Transform = { scale: 1, x: 0, y: 0 };
+
+function clampScale(value: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
+}
+
+/**
+ * 확대 중심(p)을 화면에 고정한 채 scale 만 바꾼다.
+ * transform 은 `translate(x, y) scale(s)` 순서이므로 screen = x + s * c 이고,
+ * 같은 컨텐츠 좌표 c 를 같은 p 에 남기려면 x' = p - s' * (p - x) / s 다.
+ * p 는 스테이지 중심을 원점으로 하는 좌표다.
+ */
+function zoomAt(t: Transform, nextScale: number, px: number, py: number): Transform {
+  const scale = clampScale(nextScale);
+  return {
+    scale,
+    x: px - ((px - t.x) * scale) / t.scale,
+    y: py - ((py - t.y) * scale) / t.scale,
+  };
+}
+
+type MermaidZoomModalProps = {
+  svg: string;
+  label: string;
+  onClose: () => void;
+};
+
+/** 확대 transform 을 걷어낸 svg 배치 크기와 원본 크기. 모달을 여는 순간 한 번만 잰다. */
+type Metrics = { layoutWidth: number; layoutHeight: number; intrinsicWidth: number };
+
+function measure(node: SVGSVGElement, currentScale: number): Metrics | null {
+  const intrinsicWidth = node.viewBox?.baseVal?.width || 0;
+  const rect = node.getBoundingClientRect();
+  if (intrinsicWidth <= 0 || currentScale <= 0) return null;
+
+  const layoutWidth = rect.width / currentScale;
+  const layoutHeight = rect.height / currentScale;
+  if (layoutWidth <= 0 || layoutHeight <= 0) return null;
+
+  return { layoutWidth, layoutHeight, intrinsicWidth };
+}
+
+/**
+ * 모달을 열었을 때의 배율과 위치.
+ *
+ * CSS 가 svg 를 스테이지에 맞추며 줄인 만큼을 세 후보 중 가장 큰 것으로 되돌린다.
+ * 좁은 화면에서 잘게 줄어든 다이어그램은 원본 픽셀 크기까지 키우고,
+ * 스테이지보다 작은 다이어그램은 남은 여백까지 채운다.
+ * 확대한 결과가 스테이지를 넘치면 시작점(왼쪽 위)이 먼저 보이도록 밀어 둔다.
+ */
+function computeInitial(m: Metrics, stageRect: DOMRect): Transform {
+  const toOriginalSize = m.intrinsicWidth / m.layoutWidth;
+  const fillStage = Math.min(
+    stageRect.width / m.layoutWidth,
+    stageRect.height / m.layoutHeight,
+  );
+  const scale = clampScale(
+    Math.min(Math.max(toOriginalSize, fillStage, 1), MAX_INITIAL_SCALE),
+  );
+
+  return {
+    scale,
+    x: Math.max(0, (m.layoutWidth * scale - stageRect.width) / 2),
+    y: Math.max(0, (m.layoutHeight * scale - stageRect.height) / 2),
+  };
+}
+
+export function MermaidZoomModal({ svg, label, onClose }: MermaidZoomModalProps) {
+  const [transform, setTransform] = useState<Transform>(IDENTITY);
+  // 모달을 열었을 때의 배율. 배율 표시가 이 값을 100% 로 삼는다.
+  const [baseScale, setBaseScale] = useState(1);
+  const baseScaleRef = useRef(1);
+  const metricsRef = useRef<Metrics | null>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // 진행 중인 pointer 위치. 1개면 이동, 2개면 손가락 확대.
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const pinchRef = useRef<{ distance: number; scale: number } | null>(null);
+  const transformRef = useRef<Transform>(IDENTITY);
+  transformRef.current = transform;
+
+  // 스테이지 중심을 원점으로 하는 좌표로 변환
+  const toStagePoint = useCallback((clientX: number, clientY: number) => {
+    const rect = stageRef.current?.getBoundingClientRect();
+    if (!rect) return { x: 0, y: 0 };
+    return {
+      x: clientX - (rect.left + rect.width / 2),
+      y: clientY - (rect.top + rect.height / 2),
+    };
+  }, []);
+
+  const zoomByStep = useCallback((factor: number) => {
+    setTransform((t) => zoomAt(t, t.scale * factor, 0, 0));
+  }, []);
+
+  const applyInitial = useCallback(() => {
+    const stage = stageRef.current;
+    const node = stage?.querySelector("svg");
+    // 첫 측정값을 재사용한다. 확대한 뒤 다시 재면 transform 이 섞여 배율이 조금씩 어긋난다.
+    const metrics =
+      metricsRef.current ??
+      (node ? measure(node, transformRef.current.scale) : null);
+
+    if (!stage || !metrics) {
+      // 크기를 재지 못하면 배율만 처음 값으로 되돌린다.
+      setTransform({ ...IDENTITY, scale: baseScaleRef.current });
+      return;
+    }
+
+    metricsRef.current = metrics;
+    const initial = computeInitial(metrics, stage.getBoundingClientRect());
+    baseScaleRef.current = initial.scale;
+    setBaseScale(initial.scale);
+    setTransform(initial);
+  }, []);
+
+  const reset = useCallback(() => applyInitial(), [applyInitial]);
+
+  useEffect(() => {
+    metricsRef.current = null;
+    applyInitial();
+  }, [applyInitial, svg]);
+
+  // 이전 포커스 보존 + 배경 스크롤 잠금
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    closeButtonRef.current?.focus();
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = "";
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      } else if (e.key === "+" || e.key === "=") {
+        zoomByStep(SCALE_STEP);
+      } else if (e.key === "-" || e.key === "_") {
+        zoomByStep(1 / SCALE_STEP);
+      } else if (e.key === "0") {
+        reset();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, zoomByStep, reset]);
+
+  // React 의 onWheel 은 passive 로 등록되어 preventDefault 가 먹지 않는다.
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const p = toStagePoint(e.clientX, e.clientY);
+      const current = transformRef.current;
+      const next = current.scale * Math.exp(-e.deltaY * WHEEL_SENSITIVITY);
+      setTransform(zoomAt(current, next, p.x, p.y));
+    };
+
+    stage.addEventListener("wheel", handleWheel, { passive: false });
+    return () => stage.removeEventListener("wheel", handleWheel);
+  }, [toStagePoint]);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    pinchRef.current = null;
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const pointers = pointersRef.current;
+    const previous = pointers.get(e.pointerId);
+    if (!previous) return;
+
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pointers.size === 1) {
+      const dx = e.clientX - previous.x;
+      const dy = e.clientY - previous.y;
+      setTransform((t) => ({ ...t, x: t.x + dx, y: t.y + dy }));
+      return;
+    }
+
+    if (pointers.size >= 2) {
+      const [a, b] = Array.from(pointers.values());
+      const distance = Math.hypot(a.x - b.x, a.y - b.y);
+      if (distance === 0) return;
+
+      if (!pinchRef.current) {
+        pinchRef.current = { distance, scale: transformRef.current.scale };
+        return;
+      }
+
+      const center = toStagePoint((a.x + b.x) / 2, (a.y + b.y) / 2);
+      const ratio = distance / pinchRef.current.distance;
+      setTransform((t) =>
+        zoomAt(t, pinchRef.current!.scale * ratio, center.x, center.y),
+      );
+    }
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    pointersRef.current.delete(e.pointerId);
+    if (pointersRef.current.size < 2) pinchRef.current = null;
+  };
+
+  const modal = (
+    <div
+      className="fixed inset-0 z-[100] bg-[var(--color-bg-base)]/95 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-label={label}
+    >
+      {/* 컨트롤 */}
+      <div className="absolute top-4 right-4 z-10 flex items-center gap-1">
+        <button
+          type="button"
+          className="rounded-md p-2 text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-overlay)] hover:text-[var(--color-fg-primary)]"
+          onClick={() => zoomByStep(1 / SCALE_STEP)}
+          aria-label="축소"
+        >
+          <Minus size={ICON_SIZE} />
+        </button>
+        <button
+          type="button"
+          className="rounded-md p-2 text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-overlay)] hover:text-[var(--color-fg-primary)]"
+          onClick={() => zoomByStep(SCALE_STEP)}
+          aria-label="확대"
+        >
+          <Plus size={ICON_SIZE} />
+        </button>
+        <button
+          type="button"
+          className="rounded-md p-2 text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-overlay)] hover:text-[var(--color-fg-primary)]"
+          onClick={reset}
+          aria-label="원래 크기로"
+        >
+          <RotateCcw size={ICON_SIZE} />
+        </button>
+        <button
+          ref={closeButtonRef}
+          type="button"
+          className="rounded-md p-2 text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-overlay)] hover:text-[var(--color-fg-primary)]"
+          onClick={onClose}
+          aria-label="닫기"
+        >
+          <X size={ICON_SIZE_CLOSE} />
+        </button>
+      </div>
+
+      {/* 배율 표시 */}
+      <div className="absolute bottom-4 right-4 z-10 select-none text-sm text-[var(--color-fg-muted)]">
+        {Math.round((transform.scale / baseScale) * 100)}%
+      </div>
+
+      <div className="absolute bottom-4 left-4 z-10 hidden select-none text-sm text-[var(--color-fg-muted)] sm:block">
+        휠이나 두 손가락으로 확대하고 끌어서 이동한다. ESC 로 닫는다.
+      </div>
+
+      <div
+        ref={stageRef}
+        className="mermaid-zoom-stage h-full w-full touch-none overflow-hidden"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        style={{ cursor: transform.scale > 1 ? "grab" : "default" }}
+      >
+        <div
+          className="flex h-full w-full items-center justify-center p-6"
+          style={{
+            transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+            transformOrigin: "center center",
+          }}
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/src/components/mermaid/MermaidZoomModal.tsx
+++ b/src/components/mermaid/MermaidZoomModal.tsx
@@ -9,6 +9,8 @@ const MAX_SCALE = 12;
 const MAX_INITIAL_SCALE = 6;
 const SCALE_STEP = 1.5;
 const WHEEL_SENSITIVITY = 0.0015;
+/** 이 거리 안에서 누르고 놓으면 이동이 아니라 탭으로 본다. */
+const TAP_SLOP = 6;
 const ICON_SIZE = 22;
 const ICON_SIZE_CLOSE = 26;
 
@@ -33,6 +35,11 @@ function zoomAt(t: Transform, nextScale: number, px: number, py: number): Transf
     x: px - ((px - t.x) * scale) / t.scale,
     y: py - ((py - t.y) * scale) / t.scale,
   };
+}
+
+/** 누른 지점이 다이어그램 위인지. 스테이지는 화면을 다 덮어서 좌표만으로는 배경과 구분되지 않는다. */
+function isDiagramTarget(target: EventTarget): boolean {
+  return target instanceof Element && target.closest("svg") !== null;
 }
 
 type MermaidZoomModalProps = {
@@ -88,12 +95,15 @@ export function MermaidZoomModal({ svg, label, onClose }: MermaidZoomModalProps)
   const baseScaleRef = useRef(1);
   const metricsRef = useRef<Metrics | null>(null);
   const stageRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   // 진행 중인 pointer 위치. 1개면 이동, 2개면 손가락 확대.
   const pointersRef = useRef(new Map<number, { x: number; y: number }>());
   const pinchRef = useRef<{ distance: number; scale: number } | null>(null);
+  // 배경 탭 판정용 누름 지점
+  const pressRef = useRef<{ x: number; y: number; onDiagram: boolean } | null>(null);
   const transformRef = useRef<Transform>(IDENTITY);
   transformRef.current = transform;
 
@@ -139,6 +149,26 @@ export function MermaidZoomModal({ svg, label, onClose }: MermaidZoomModalProps)
     applyInitial();
   }, [applyInitial, svg]);
 
+  // 창 크기나 방향이 바뀌면 스테이지 크기가 달라져 배율과 위치가 어긋난다. 다시 재서 맞춘다.
+  useEffect(() => {
+    const stage = stageRef.current;
+    if (!stage || typeof ResizeObserver === "undefined") return;
+
+    let first = true;
+    const observer = new ResizeObserver(() => {
+      // 관찰을 시작할 때 한 번 즉시 발화하므로 그 호출은 흘린다.
+      if (first) {
+        first = false;
+        return;
+      }
+      metricsRef.current = null;
+      applyInitial();
+    });
+
+    observer.observe(stage);
+    return () => observer.disconnect();
+  }, [applyInitial]);
+
   // 이전 포커스 보존 + 배경 스크롤 잠금
   useEffect(() => {
     previousFocusRef.current = document.activeElement as HTMLElement | null;
@@ -153,7 +183,25 @@ export function MermaidZoomModal({ svg, label, onClose }: MermaidZoomModalProps)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key === "Tab") {
+        // aria-modal 은 스크린리더 인지만 바꾼다. 실제 포커스는 여기서 모달 안에 묶는다.
+        const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+          "button:not([disabled])",
+        );
+        if (!focusables?.length) return;
+
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const active = document.activeElement;
+
+        if (e.shiftKey && (active === first || !dialogRef.current?.contains(active))) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      } else if (e.key === "Escape") {
         onClose();
       } else if (e.key === "+" || e.key === "=") {
         zoomByStep(SCALE_STEP);
@@ -189,6 +237,10 @@ export function MermaidZoomModal({ svg, label, onClose }: MermaidZoomModalProps)
     e.currentTarget.setPointerCapture(e.pointerId);
     pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     pinchRef.current = null;
+    pressRef.current =
+      pointersRef.current.size === 1
+        ? { x: e.clientX, y: e.clientY, onDiagram: isDiagramTarget(e.target) }
+        : null;
   };
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -215,21 +267,29 @@ export function MermaidZoomModal({ svg, label, onClose }: MermaidZoomModalProps)
         return;
       }
 
+      // updater 클로저는 나중에 실행되므로 ref 를 지역 변수로 붙잡아 둔다.
+      const pinch = pinchRef.current;
       const center = toStagePoint((a.x + b.x) / 2, (a.y + b.y) / 2);
-      const ratio = distance / pinchRef.current.distance;
-      setTransform((t) =>
-        zoomAt(t, pinchRef.current!.scale * ratio, center.x, center.y),
-      );
+      const ratio = distance / pinch.distance;
+      setTransform((t) => zoomAt(t, pinch.scale * ratio, center.x, center.y));
     }
   };
 
   const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
     pointersRef.current.delete(e.pointerId);
     if (pointersRef.current.size < 2) pinchRef.current = null;
+
+    // 다이어그램 밖을 누르고 그 자리에서 놓았으면 배경 클릭으로 보고 닫는다.
+    const press = pressRef.current;
+    pressRef.current = null;
+    if (!press || press.onDiagram || pointersRef.current.size > 0) return;
+    if (Math.hypot(e.clientX - press.x, e.clientY - press.y) > TAP_SLOP) return;
+    onClose();
   };
 
   const modal = (
     <div
+      ref={dialogRef}
       className="fixed inset-0 z-[100] bg-[var(--color-bg-base)]/95 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"


### PR DESCRIPTION
## Summary
- Wide mermaid diagrams shrink to the article width on small screens, so their labels became unreadable.
- So this PR adds a zoom button per diagram and a full-screen modal with fit-aware scaling, pinch zoom, and panning.

## Changes
- Zoom modal
  - Initial scale picked from three candidates
    - Restores shrunken diagrams to their original pixel size
    - Fills the remaining space when the diagram is smaller than the stage
    - Starts at the top-left corner when the result overflows
  - Gestures and controls
    - Pinch zoom, drag panning, wheel zoom
    - Zoom in, zoom out, reset buttons, plus `+`, `-`, `0`, ESC keys
  - Overlay and controls use theme tokens
    - A black overlay hides mermaid's dark arrows under the light theme
- Diagram footer button
  - Placed on its own row below the diagram, since short diagrams overlapped an absolute button
  - Hidden when mermaid rendering fails
- Tests
  - 7 cases for the modal, 3 cases for button visibility

## Review Points
- The modal measures the svg once on open and reuses it. Re-measuring after a zoom mixes the active transform in and drifts the reset scale by about 2% per press.
- `MAX_SCALE` is 12 while the initial scale can reach 6, so a mobile diagram already opened at ~5x still has room to zoom in.
- Verified with `pnpm start` at 390px and 1280px in both themes. New Tailwind utilities in a fresh directory are not picked up by the dev server, so the overlay looks transparent under `pnpm dev`.

---
> Generated with AI
